### PR TITLE
#100 patch group alias enhancement

### DIFF
--- a/src/alias/AliasList.java
+++ b/src/alias/AliasList.java
@@ -218,7 +218,7 @@ public class AliasList implements Listener<AliasEvent>
                         //We don't maintain lookups for these items
                         break;
                     default:
-                        mLog.warn("Unrecognized Alias ID Type:" + id.getType().name());
+                        mLog.warn("Unrecognized Alias ID Type:" + id.getType().name() + " - can't ADD to lookup table");
                         break;
                 }
             }
@@ -358,10 +358,11 @@ public class AliasList implements Listener<AliasEvent>
                     break;
                 case NON_RECORDABLE:
                 case PRIORITY:
+                case BROADCAST_CHANNEL:
                     //We don't maintain lookups for these items
                     break;
                 default:
-                    mLog.warn("Unrecognized Alias ID Type:" + id.getType().name());
+                    mLog.warn("Unrecognized Alias ID Type:" + id.getType().name() + " - can't REMOVE from lookup table");
                     break;
             }
         }


### PR DESCRIPTION
enhances patch group alias to include any existing alias for the patch talkgroup ID in the rolled-up alias.  Streaming channels for the alias now includes any channels designated for the existing alias as well as the highest audio priority.  Alias name for the patch group alias is either the existing alias name, or the label "Patch:" and the patch group ID.