### PR TITLE
#115 patch group alias - resolves issue where wildcard aliases were b…

### DIFF
--- a/src/alias/AliasList.java
+++ b/src/alias/AliasList.java
@@ -579,8 +579,12 @@ public class AliasList implements Listener<AliasEvent>
 
     /**
      * Lookup alias by talkgroup
+     *
+     * @param tgid to use when searching for an alias
+     * @param includeWildcards true if you want to additionally search for a matching alias that contains wildcard(s)
+     * when there is not a direct match to the TGID.
      */
-    public Alias getTalkgroupAlias(String tgid)
+    public Alias getTalkgroupAlias(String tgid, boolean includeWildcards)
     {
         Alias alias = null;
 
@@ -588,7 +592,7 @@ public class AliasList implements Listener<AliasEvent>
         {
             alias = mTalkgroup.get(tgid);
 
-            if (alias == null)
+            if (alias == null && includeWildcards)
             {
                 String wildcard = getWildcardMatch(tgid, mTalkgroupWildcards);
 
@@ -603,8 +607,16 @@ public class AliasList implements Listener<AliasEvent>
     }
 
     /**
-     * Alias list name
+     * Lookup alias by talkgroup.  Defaults to matching to wildcard talkgroups.
      */
+    public Alias getTalkgroupAlias(String tgid)
+    {
+        return getTalkgroupAlias(tgid, true);
+    }
+
+        /**
+         * Alias list name
+         */
     public String toString()
     {
         return mName;

--- a/src/alias/PatchGroupAlias.java
+++ b/src/alias/PatchGroupAlias.java
@@ -133,19 +133,16 @@ public class PatchGroupAlias extends Alias
         }
         else
         {
-            if(getId().size() > 0)
+            for(AliasID id: getId())
             {
-                for(AliasID id: getId())
+                if(id.getType() == AliasIDType.TALKGROUP)
                 {
-                    if(id.getType() == AliasIDType.TALKGROUP)
-                    {
-                        return "PATCH:" + ((TalkgroupID)id).getTalkgroup();
-                    }
+                    return "PATCH:" + ((TalkgroupID)id).getTalkgroup();
                 }
             }
         }
 
-        return "PATCH";
+        return "PATCH:****";
     }
 
     @Override
@@ -153,14 +150,20 @@ public class PatchGroupAlias extends Alias
     {
         List<AliasAction> aliasActions = new ArrayList<>();
 
-        for(Alias alias: mPatchedAliases)
-        {
-            aliasActions.addAll(alias.getAction());
-        }
-
         if(hasPatchGroupAlias())
         {
             aliasActions.addAll(getPatchGroupAlias().getAction());
+        }
+
+        for(Alias alias: mPatchedAliases)
+        {
+            for(AliasAction action: alias.getAction())
+            {
+                if(!aliasActions.contains(action))
+                {
+                    aliasActions.add(action);
+                }
+            }
         }
 
         return aliasActions;
@@ -187,7 +190,7 @@ public class PatchGroupAlias extends Alias
 
         for(Alias alias: mPatchedAliases)
         {
-            if(alias.getCallPriority() < highestPriority)
+            if(alias.hasCallPriority() && alias.getCallPriority() < highestPriority)
             {
                 highestPriority = alias.getCallPriority();
             }

--- a/src/module/decode/p25/P25DecoderState.java
+++ b/src/module/decode/p25/P25DecoderState.java
@@ -2924,8 +2924,8 @@ public class P25DecoderState extends DecoderState
     {
         PatchGroupAlias patchGroupAlias = null;
 
-        //Check for an existing alias for the patch talkgroup
-        Alias existingAlias = getAliasList().getTalkgroupAlias(patchGroupID);
+        //Check for an existing alias for the patch talkgroup - do not include wildcard aliases
+        Alias existingAlias = getAliasList().getTalkgroupAlias(patchGroupID, false);
 
         if(existingAlias instanceof PatchGroupAlias)
         {
@@ -2935,14 +2935,14 @@ public class P25DecoderState extends DecoderState
         {
             patchGroupAlias = new PatchGroupAlias();
 
+            patchGroupAlias.addAliasID(new TalkgroupID(patchGroupID));
+
             if(existingAlias != null)
             {
                 getAliasList().removeAlias(existingAlias);
 
                 patchGroupAlias.setPatchGroupAlias(existingAlias);
             }
-
-            patchGroupAlias.addAliasID(new TalkgroupID(patchGroupID));
 
             getAliasList().addAlias(patchGroupAlias);
         }


### PR DESCRIPTION
…eing matched against a temporary patch group id and removed from the alias list for the lifespan of the patch group.  General cleanup of the rollup methods for the patch group alias.  Adds  a new method to alias list that allows alias lookup from a tgid while excluding wildcard talkgroups.