### PR TITLE
#130 MPT-1327 Decoder Filter issue resolved.  

### DIFF
--- a/src/dsp/filter/design/FilterViewer.java
+++ b/src/dsp/filter/design/FilterViewer.java
@@ -43,33 +43,33 @@ public class FilterViewer extends Application
 //		FIRFilterSpecification specification = FIRFilterSpecification.lowPassBuilder()
 //		        .sampleRate( 48000 )
 //		        .gridDensity( 16 )
-//                .passBandCutoff( 3000 )
+//                .passBandCutoff( 3200 )
 //		        .passBandAmplitude( 1.0 )
-//		        .passBandRipple( 0.01 )
+//		        .passBandRipple( 0.02 )
 //		        .stopBandStart( 4000 )
 //		        .stopBandAmplitude( 0.0 )
-//		        .stopBandRipple( 0.027 )
+//		        .stopBandRipple( 0.03 )
 //		        .build();
 		
-//		FIRFilterSpecification specification = FIRFilterSpecification.highPassBuilder()
-//		        .sampleRate( 8000 )
-//		        .stopBandCutoff( 250 )
-//		        .stopBandAmplitude( 0.0 )
-//		        .stopBandRipple( 0.01 )
-//		        .passBandStart( 300 )
-//		        .passBandAmplitude( 1.0 )
-//		        .passBandRipple( 0.01 )
-//		        .build();
+		FIRFilterSpecification specification = FIRFilterSpecification.highPassBuilder()
+		        .sampleRate( 24000 )
+		        .stopBandCutoff( 800 )
+		        .stopBandAmplitude( 0.0 )
+		        .stopBandRipple( 0.03 )
+		        .passBandStart( 1000 )
+		        .passBandAmplitude( 1.0 )
+		        .passBandRipple( 0.08 )
+		        .build();
 
-		FIRFilterSpecification specification = FIRFilterSpecification.bandPassBuilder()
-	        .sampleRate( 48000 )
-	        .stopFrequency1( 200 )
-	        .passFrequencyBegin( 400 )
-	        .passFrequencyEnd( 3200 )
-	        .stopFrequency2( 3400 )
-	        .stopRipple( 0.0003 )
-	        .passRipple( 0.008)
-	        .build();
+//		FIRFilterSpecification specification = FIRFilterSpecification.bandPassBuilder()
+//	        .sampleRate( 48000 )
+//	        .stopFrequency1( 200 )
+//	        .passFrequencyBegin( 400 )
+//	        .passFrequencyEnd( 3200 )
+//	        .stopFrequency2( 3400 )
+//	        .stopRipple( 0.0003 )
+//	        .passRipple( 0.008)
+//	        .build();
 
 		float[] taps = null;
 

--- a/src/module/decode/DecoderFactory.java
+++ b/src/module/decode/DecoderFactory.java
@@ -101,17 +101,25 @@ public class DecoderFactory
 {
     private final static Logger mLog = LoggerFactory.getLogger(DecoderFactory.class);
 
-    private static final FIRFilterSpecification MPT1327_FILTER_SPECIFICATION = FIRFilterSpecification.bandPassBuilder()
-        .sampleRate(48000).stopFrequency1(200).passFrequencyBegin(400).passFrequencyEnd(3200)
-        .stopFrequency2(3400).stopRipple(0.0003).passRipple(0.008).build();
+    //Low-pass filter with ~60 dB attenuation and 89 taps
+    private static final FIRFilterSpecification MPT1327_FILTER_SPECIFICATION = FIRFilterSpecification.lowPassBuilder()
+        .sampleRate( 48000 )
+        .gridDensity( 16 )
+        .passBandCutoff( 3200 )
+        .passBandAmplitude( 1.0 )
+        .passBandRipple( 0.02 )
+        .stopBandStart( 4000 )
+        .stopBandAmplitude( 0.0 )
+        .stopBandRipple( 0.03 )
+        .build();
 
-    private static float[] MPT1327_BANDPASS_FILTER;
+    private static float[] MPT1327_LOWPASS_FILTER;
 
     static
     {
         try
         {
-            MPT1327_BANDPASS_FILTER = FilterFactory.getTaps(MPT1327_FILTER_SPECIFICATION);
+            MPT1327_LOWPASS_FILTER = FilterFactory.getTaps(MPT1327_FILTER_SPECIFICATION);
         }
         catch(Exception e)
         {
@@ -221,7 +229,7 @@ public class DecoderFactory
                 }
 
                 modules.add(new FMDemodulatorModule(iqPass, iqStop));
-                modules.add(new DemodulatedAudioFilterModule(MPT1327_BANDPASS_FILTER, 2.0f));
+                modules.add(new DemodulatedAudioFilterModule(MPT1327_LOWPASS_FILTER, 1.0f));
                 modules.add(new AudioModule(metadata));
                 break;
             case PASSPORT:


### PR DESCRIPTION
Converts the post-demodulation filter from a band pass filter to a low-pass filter with 60 dB attenuation and a cutoff of 3200 Hz.  This is then followed by a high-pass filter at the decimated channel rate, internal to the decoder that performs DC removal and removes any CTCSS tones prior to the FSK decoder.