### PR TITLE
126 - Tuner processing refactor and significant improvement in processor and memory utilization.  R…

### DIFF
--- a/src/sample/OverflowableTransferQueue.java
+++ b/src/sample/OverflowableTransferQueue.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package sample;
+
+import java.util.Collection;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class OverflowableTransferQueue<E>
+{
+    public enum State {NORMAL, OVERFLOW};
+    private Listener<State> mStateListener;
+
+    private LinkedTransferQueue<E> mQueue = new LinkedTransferQueue<E>();
+    private AtomicInteger mCounter = new AtomicInteger();
+    private int mMaximumSize;
+    private int mResetThreshold;
+    private boolean mOverflow = false;
+
+    /**
+     * Concurrent transfer queue that couples a higher-throughput linked transfer queue with an atomic integer for
+     * monitoring queue size.  When the queue size exceeds maximum size (overflow), all inbound elements are ignored
+     * until the queue size is reduced to or below the reset threshold.
+     *
+     * @param maximumSize of the queue.  Overflow state will occur once queue size exceeds this value.
+     * @param resetThreshold for resetting overflow state to normal, once queue size is at or below this value.
+     */
+    public OverflowableTransferQueue(int maximumSize, int resetThreshold)
+    {
+        mMaximumSize = maximumSize;
+        mResetThreshold = resetThreshold;
+    }
+
+    /**
+     * Adds the element to the queue if able to do so without exceeding maximum queue size.  Otherwise, ignores
+     * the element.
+     */
+    public void offer(E e)
+    {
+        if(!mOverflow)
+        {
+            if(mCounter.get() > mMaximumSize)
+            {
+                setOverflow(true);
+            }
+            else
+            {
+                mQueue.offer(e);
+                mCounter.incrementAndGet();
+            }
+        }
+    }
+
+    /**
+     * Retrieves elements from the queue into the collection up to the maximum number of elements specified
+     */
+    public int drainTo(Collection<? super E> collection, int maxElements)
+    {
+        int drainCount = mQueue.drainTo(collection, maxElements);
+
+        if(drainCount > 0)
+        {
+            mCounter.addAndGet(-drainCount);
+        }
+
+        return drainCount;
+    }
+
+    /**
+     * Sets a listener to receive state change events
+     */
+    public void setStateListener(Listener<State> listener)
+    {
+        mStateListener = listener;
+    }
+
+
+    /**
+     * Current state of the queue, normal or overflow
+     */
+    public State getState()
+    {
+        return mOverflow ? State.OVERFLOW : State.NORMAL;
+    }
+
+    /**
+     * Toggles the overflow state
+     */
+    private void setOverflow(boolean overflow)
+    {
+        mOverflow = overflow;
+
+        if(mStateListener != null)
+        {
+            mStateListener.receive(getState());
+        }
+    }
+
+    /**
+     * Clears all elements from the queue and resets the internal counter to 0
+     */
+    public void clear()
+    {
+        synchronized(mQueue)
+        {
+            mQueue.clear();
+            mCounter.set(0);
+            mOverflow = false;
+        }
+    }
+}

--- a/src/source/tuner/LibUSBTransferProcessor.java
+++ b/src/source/tuner/LibUSBTransferProcessor.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package source.tuner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.usb4java.LibUsb;
+import source.tuner.usb.USBTransferProcessor;
+import util.ThreadPool;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Runnable for executing LibUsb processing of bulk transfer buffers
+ */
+public class LibUSBTransferProcessor
+{
+    private final static Logger mLog = LoggerFactory.getLogger(LibUSBTransferProcessor.class);
+
+    private static final long USB_TIMEOUT_MS = 2000l; //milliseconds
+
+    private List<USBTransferProcessor> mRegisteredProcessors = new CopyOnWriteArrayList<>();
+    private ByteBuffer mStatusBuffer = ByteBuffer.allocateDirect(4);
+    private AtomicBoolean mRunning = new AtomicBoolean();
+    private Processor mProcessor = new Processor();
+    private ScheduledFuture mProcessorFuture;
+
+    /**
+     * Registers the transfer processor so that LibUSB timeout processing will auto-start.
+     * @param processor to register
+     */
+    public void registerTransferProcessor(USBTransferProcessor processor)
+    {
+        if(!mRegisteredProcessors.contains(processor))
+        {
+            mRegisteredProcessors.add(processor);
+        }
+
+        start();
+    }
+
+    /**
+     * Unregisters the transfer processor so that LibUSB timeout processing will auto-stop once all processors have
+     * been unregistered.
+     *
+     * @param processor to unregister
+     */
+    public void unregisterTransferProcessor(USBTransferProcessor processor)
+    {
+        mRegisteredProcessors.remove(processor);
+
+        if(mRegisteredProcessors.isEmpty())
+        {
+            stop();
+        }
+    }
+
+    /**
+     * Starts processing of LibUSB timeout events
+     */
+    private void start()
+    {
+        if(mRunning.compareAndSet(false, true))
+        {
+            //Set periodicity to an odd multiple to avoid contention with transfer buffer receivers
+            mProcessorFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(mProcessor, 0L, 9L, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Stops processing of LibUSB timeout events
+     */
+    private void stop()
+    {
+        if(mRunning.compareAndSet(true, false))
+        {
+            if(mProcessorFuture != null)
+            {
+                mProcessorFuture.cancel(true);
+                mProcessorFuture = null;
+            }
+        }
+    }
+
+    /**
+     * Runnable to invoke LibUSB timeout handler.  All downstream completed transfer processing will occur on this
+     * thread instance.
+     */
+    class Processor implements Runnable
+    {
+        @Override
+        public void run()
+        {
+            int result = LibUsb.handleEventsTimeoutCompleted(null, USB_TIMEOUT_MS, mStatusBuffer.asIntBuffer());
+
+            if(result != LibUsb.SUCCESS)
+            {
+                mLog.error("Error processing timeout events for LibUSB - error code:" + result);
+            }
+
+            mStatusBuffer.rewind();
+        }
+    }
+}

--- a/src/source/tuner/TunerManager.java
+++ b/src/source/tuner/TunerManager.java
@@ -42,11 +42,23 @@ import java.util.Collection;
 
 public class TunerManager
 {
-    private final static Logger mLog =
-        LoggerFactory.getLogger(TunerManager.class);
+    private final static Logger mLog = LoggerFactory.getLogger(TunerManager.class);
 
     private MixerManager mMixerManager;
     private TunerModel mTunerModel;
+
+
+    /**
+     * Application-wide LibUSB timeout processor for transfer buffers.  All classes that need to use USB transfer
+     * buffers can register with this processor and the processor will auto-start and auto-stop while USB transfer
+     * processors are registered.
+     */
+    public static final LibUSBTransferProcessor LIBUSB_TRANSFER_PROCESSOR;
+
+    static
+    {
+        LIBUSB_TRANSFER_PROCESSOR = new LibUSBTransferProcessor();
+    }
 
     public TunerManager(MixerManager mixerManager, TunerModel tunerModel)
     {

--- a/src/source/tuner/airspy/AirspySampleAdapter.java
+++ b/src/source/tuner/airspy/AirspySampleAdapter.java
@@ -1,144 +1,155 @@
+/*******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
 package source.tuner.airspy;
 
-/*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2015 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
- ******************************************************************************/
-
+import dsp.filter.dc.DCRemovalFilter_RB;
+import dsp.filter.hilbert.HilbertTransform;
 import sample.adapter.ISampleAdapter;
 
 public class AirspySampleAdapter implements ISampleAdapter
 {
-	private static final float SCALE_SIGNED_12_BIT_TO_FLOAT = 1.0f / 2048.0f;
-	
-	private boolean mSamplePacking = false;
+    private static final float SCALE_SIGNED_12_BIT_TO_FLOAT = 1.0f / 2048.0f;
 
-	/**
-	 * Adapter to translate byte buffers received from the airspy tuner into 
-	 * float buffers for processing.
-	 */
-	public AirspySampleAdapter()
-	{
-	}
+    private DCRemovalFilter_RB mDCFilter = new DCRemovalFilter_RB(0.01f);
+    private HilbertTransform mHilbertTransform = new HilbertTransform();
+    private boolean mSamplePacking = false;
 
-	/**
-	 * Sample packing places two 12-bit samples into 3 bytes when enabled or 
-	 * places two 12-bit samples into 4 bytes when disabled.
-	 * 
-	 * @param enabled 
-	 */
-	public void setSamplePacking( boolean enabled )
-	{
-		mSamplePacking = enabled;
-	}
-	
-	@Override
-	public float[] convert( byte[] samples )
-	{
-		if( mSamplePacking )
-		{
-			return convertPacked( samples );
-		}
-		else
-		{
-			return convertUnpacked( samples );
-		}
-	}
 
-	/**
-	 * Converts the byte array containing unsigned 12-bit short values into
-	 * signed float values in the range -1 to 1;
-	 * 
-	 * @param data - byte array of unsigned 16-bit values
-	 * @return converted float values
-	 */
-	private float[] convertUnpacked( byte[] data )
-	{
-		float[] samples = new float[ data.length / 2 ];
+    /**
+     * Adapter to translate byte buffers received from the airspy tuner into
+     * float buffers for processing.
+     */
+    public AirspySampleAdapter()
+    {
+    }
 
-		int pointer = 0;
-		
-		for( int x = 0; x < data.length; x += 2 )
-		{
-			samples[ pointer++ ] = scale( ( data[ x ] & 0xFF ) | 
-										  ( data[ x + 1 ] << 8 ) );
-		}
-		
-		return samples;
-	}
-	
-	/**
-	 * Converts every 3 bytes containing a pair of 12-bit unsigned values into
-	 * a pair of float values in the range -1 to 1;
-	 * 
-	 * @param data - byte array of unsigned 12-bit values
-	 * @return converted float values
-	 */
-	private float[] convertPacked( byte[] data1 )
-	{
-		byte[] data = new byte[ data1.length ];
+    /**
+     * Sample packing places two 12-bit samples into 3 bytes when enabled or
+     * places two 12-bit samples into 4 bytes when disabled.
+     *
+     * @param enabled
+     */
+    public void setSamplePacking(boolean enabled)
+    {
+        mSamplePacking = enabled;
+    }
 
-		//Convert big-endian to little-endian
-		for( int x = 0; x < data1.length; x += 4 )
-		{
-			data[ x ] = data1[ x + 3 ];
-			data[ x + 1 ] = data1[ x + 2 ];
-			data[ x + 2 ] = data1[ x + 1 ];
-			data[ x + 3 ] = data1[ x ];
-		}
-		
-		int count = (int)( (float)data.length / 1.5f );
+    @Override
+    public float[] convert(byte[] samples)
+    {
+        float[] realSamples;
+
+        if(mSamplePacking)
+        {
+            realSamples = convertPacked(samples);
+        }
+        else
+        {
+            realSamples = convertUnpacked(samples);
+        }
+
+        mDCFilter.filter(realSamples);
+
+        return mHilbertTransform.filter(realSamples);
+    }
+
+    /**
+     * Converts the byte array containing unsigned 12-bit short values into
+     * signed float values in the range -1 to 1;
+     *
+     * @param data - byte array of unsigned 16-bit values
+     * @return converted float values
+     */
+    private float[] convertUnpacked(byte[] data)
+    {
+        float[] samples = new float[data.length / 2];
+
+        int pointer = 0;
+
+        for(int x = 0; x < data.length; x += 2)
+        {
+            samples[pointer++] = scale((data[x] & 0xFF) |
+                (data[x + 1] << 8));
+        }
+
+        return samples;
+    }
+
+    /**
+     * Converts every 3 bytes containing a pair of 12-bit unsigned values into
+     * a pair of float values in the range -1 to 1;
+     *
+     * @param data1 - byte array of unsigned 12-bit values
+     * @return converted float values
+     */
+    private float[] convertPacked(byte[] data1)
+    {
+        byte[] data = new byte[data1.length];
+
+        //Convert big-endian to little-endian
+        for(int x = 0; x < data1.length; x += 4)
+        {
+            data[x] = data1[x + 3];
+            data[x + 1] = data1[x + 2];
+            data[x + 2] = data1[x + 1];
+            data[x + 3] = data1[x];
+        }
+
+        int count = (int) ((float) data.length / 1.5f);
 
 		/* Ensure we have an even number of samples */
-		if( count % 2 == 1 )
-		{
-			count--;
-		}
+        if(count % 2 == 1)
+        {
+            count--;
+        }
 
-		int bytes = (int)((float)count * 1.5f);
+        int bytes = (int) ((float) count * 1.5f);
 
-		float[] samples = new float[ count ];
-		
-		int pointer = 0;
-		
-		int first;
-		int second;
-		
-		for( int x = 0; x < bytes; x += 3 )
-		{
-			first = ( ( data[ x ] << 4 ) & 0xFF0 ) | 
-					( ( data[ x + 1 ] >> 4 ) & 0xF );
+        float[] samples = new float[count];
 
-			samples[ pointer++ ] = scale( first );
+        int pointer = 0;
 
-			second = ( ( data[ x + 1 ] << 8 ) & 0xF00 ) |
-					   ( data[ x + 2 ] & 0xFF );
-			
-			samples[ pointer++ ] = scale( second );
-		}
-		
-		return samples;
-	}
+        int first;
+        int second;
 
-	/**
-	 * Converts unsigned 12-bit values to signed 12-bit values and then scales
-	 * the signed value to a signed float value in range: -1.0 : +1.0
-	 */
-	public static float scale( int value )
-	{
-		return (float)(( value & 0xFFF ) - 2048 ) * SCALE_SIGNED_12_BIT_TO_FLOAT;
-	}
+        for(int x = 0; x < bytes; x += 3)
+        {
+            first = ((data[x] << 4) & 0xFF0) |
+                ((data[x + 1] >> 4) & 0xF);
+
+            samples[pointer++] = scale(first);
+
+            second = ((data[x + 1] << 8) & 0xF00) |
+                (data[x + 2] & 0xFF);
+
+            samples[pointer++] = scale(second);
+        }
+
+        return samples;
+    }
+
+    /**
+     * Converts unsigned 12-bit values to signed 12-bit values and then scales
+     * the signed value to a signed float value in range: -1.0 : +1.0
+     */
+    public static float scale(int value)
+    {
+        return (float) ((value & 0xFFF) - 2048) * SCALE_SIGNED_12_BIT_TO_FLOAT;
+    }
 }

--- a/src/source/tuner/fcd/FCDTunerController.java
+++ b/src/source/tuner/fcd/FCDTunerController.java
@@ -1,28 +1,22 @@
 /*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
  ******************************************************************************/
 package source.tuner.fcd;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.IntBuffer;
-
-import javax.usb.UsbClaimException;
-import javax.usb.UsbException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +25,6 @@ import org.usb4java.DeviceDescriptor;
 import org.usb4java.DeviceHandle;
 import org.usb4java.LibUsb;
 import org.usb4java.LibUsbException;
-
 import source.SourceException;
 import source.tuner.TunerClass;
 import source.tuner.TunerController;
@@ -39,610 +32,587 @@ import source.tuner.TunerType;
 import source.tuner.configuration.TunerConfiguration;
 import source.tuner.fcd.proV1.FCD1TunerController.Block;
 
+import javax.usb.UsbClaimException;
+import javax.usb.UsbException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+
 public abstract class FCDTunerController extends TunerController
 {
-	private final static Logger mLog = 
-			LoggerFactory.getLogger( FCDTunerController.class );
+    private final static Logger mLog = LoggerFactory.getLogger(FCDTunerController.class);
 
-	public static final double USABLE_BANDWIDTH_PERCENT = 1.0;
-	public static final int DC_SPIKE_AVOID_BUFFER = 5000;
-	
-	public final static byte FCD_INTERFACE = (byte)0x2;
-	public final static byte FCD_ENDPOINT_IN = (byte)0x82;
-	public final static byte FCD_ENDPOINT_OUT = (byte)0x2;
-	
-	private Device mDevice;
-	private DeviceDescriptor mDeviceDescriptor;
-	private DeviceHandle mDeviceHandle;
-	
-	private FCDConfiguration mConfiguration = new FCDConfiguration();
-	
-	/**
-	 * Generic FCD tuner controller - contains functionality common across both
-	 * funcube dongle tuners 
-	 * 
-	 * @param device
-	 * @param descriptor
-	 * @param minTunableFrequency
-	 * @param maxTunableFrequency
-	 */
-	public FCDTunerController( Device device, 
-							   DeviceDescriptor descriptor,
-							   int sampleRate,
-							   int minTunableFrequency,
-							   int maxTunableFrequency )
-	{
-		super( minTunableFrequency, 
-			   maxTunableFrequency, 
-			   DC_SPIKE_AVOID_BUFFER, 
-			   USABLE_BANDWIDTH_PERCENT );
-		mDevice = device;
-		mDeviceDescriptor = descriptor;
+    public static final double USABLE_BANDWIDTH_PERCENT = 1.0;
+    public static final int DC_SPIKE_AVOID_BUFFER = 5000;
 
-		try
-		{
-			mFrequencyController.setSampleRate( sampleRate );
-		}
-		catch( SourceException se )
-		{
-			mLog.error("Error setting sample rate to [" + sampleRate + "]", se );
-		}
-	}
+    public final static byte FCD_INTERFACE = (byte)0x2;
+    public final static byte FCD_ENDPOINT_IN = (byte)0x82;
+    public final static byte FCD_ENDPOINT_OUT = (byte)0x2;
 
-	/**
-	 * Initializes the controller by opening the USB device and claiming the
-	 * HID interface.
-	 * 
-	 * Invoke this method after constructing this class to setup the
-	 * controller.
-	 * 
-	 * @throws SourceException if cannot open and claim the USB device
-	 */
-	public void init() throws SourceException
-	{
-		mDeviceHandle = new DeviceHandle();
-		
-		int result = LibUsb.open( mDevice, mDeviceHandle );
+    private Device mDevice;
+    private DeviceDescriptor mDeviceDescriptor;
+    private DeviceHandle mDeviceHandle;
 
-		if( result != LibUsb.SUCCESS )
-		{
-			mDeviceHandle = null;
-			
-			throw new SourceException( "libusb couldn't open funcube usb "
-					+ "device [" + LibUsb.errorName( result ) + "]" );
-		}
-		
-		claimInterface();
-	}
+    private FCDConfiguration mConfiguration = new FCDConfiguration();
 
-	/**
-	 * Disposes of resources.  Closes the USB device and interface.
-	 */
-	public void dispose()
-	{
-		if( mDeviceHandle != null )
-		{
-			try
-			{
-				LibUsb.close( mDeviceHandle );
-			}
-			catch( Exception e )
-			{
-				mLog.error( "error while closing device handle", e );
-			}
-			
-			mDeviceHandle = null;
-		}
-		
-		mDeviceDescriptor = null;
-		mDevice = null;
-	}
+    /**
+     * Generic FCD tuner controller - contains functionality common across both
+     * funcube dongle tuners
+     *
+     * @param device
+     * @param descriptor
+     * @param minTunableFrequency
+     * @param maxTunableFrequency
+     */
+    public FCDTunerController(Device device,
+                              DeviceDescriptor descriptor,
+                              int sampleRate,
+                              int minTunableFrequency,
+                              int maxTunableFrequency)
+    {
+        super(minTunableFrequency, maxTunableFrequency, DC_SPIKE_AVOID_BUFFER, USABLE_BANDWIDTH_PERCENT);
+        mDevice = device;
+        mDeviceDescriptor = descriptor;
 
-	/**
-	 * Sample rate of the tuner
-	 */
-	public abstract int getCurrentSampleRate() throws SourceException;
-	
-	/**
-	 * Tuner class
-	 */
-	public abstract TunerClass getTunerClass();
+        try
+        {
+            mFrequencyController.setSampleRate(sampleRate);
+        }
+        catch(SourceException se)
+        {
+            mLog.error("Error setting sample rate to [" + sampleRate + "]", se);
+        }
+    }
 
-	/**
-	 * Tuner type
-	 */
-	public abstract TunerType getTunerType();
+    /**
+     * Initializes the controller by opening the USB device and claiming the
+     * HID interface.
+     *
+     * Invoke this method after constructing this class to setup the
+     * controller.
+     *
+     * @throws SourceException if cannot open and claim the USB device
+     */
+    public void init() throws SourceException
+    {
+        mDeviceHandle = new DeviceHandle();
 
-	/**
-	 * Applies the settings in the tuner configuration
-	 */
-	public abstract void apply( TunerConfiguration config ) throws SourceException;
+        int result = LibUsb.open(mDevice, mDeviceHandle);
 
-	/**
-	 * USB address (bus/port)
-	 */
-	public String getUSBAddress()
-	{
-		if( mDevice != null )
-		{
-			StringBuilder sb = new StringBuilder();
-			
-			sb.append( "Bus:" );
-			int bus = LibUsb.getBusNumber( mDevice );
-			sb.append( bus );
-			
-			sb.append( " Port:" );
-			int port = LibUsb.getPortNumber( mDevice );
-			sb.append( port );
-			
-			return sb.toString();
-		}
+        if(result != LibUsb.SUCCESS)
+        {
+            mDeviceHandle = null;
 
-		return "UNKNOWN";
-	}
+            throw new SourceException("libusb couldn't open funcube usb device [" + LibUsb.errorName(result) + "]");
+        }
 
-	/**
-	 * USB Vendor and Product ID 
-	 */
-	public String getUSBID()
-	{
-		if( mDeviceDescriptor != null )
-		{
-			StringBuilder sb = new StringBuilder();
-			
-			sb.append( String.format( "%04X", 
-					(int)( mDeviceDescriptor.idVendor() & 0xFFFF ) ) );
+        claimInterface();
+    }
 
-			sb.append( ":" );
-			
-			sb.append( String.format( "%04X", 
-					(int)( mDeviceDescriptor.idProduct() & 0xFFFF ) ) );
+    /**
+     * Disposes of resources.  Closes the USB device and interface.
+     */
+    public void dispose()
+    {
+        if(mDeviceHandle != null)
+        {
+            try
+            {
+                LibUsb.close(mDeviceHandle);
+            }
+            catch(Exception e)
+            {
+                mLog.error("error while closing device handle", e);
+            }
 
-			return sb.toString();
-		}
+            mDeviceHandle = null;
+        }
 
-		return "UNKNOWN";
-	}
+        mDeviceDescriptor = null;
+        mDevice = null;
+    }
 
-	/**
-	 * USB Port Speed.  Should be 2.0 for both types of funcube dongles
-	 */
-	public String getUSBSpeed()
-	{
-		if( mDevice != null )
-		{
-			int speed = LibUsb.getDeviceSpeed( mDevice );
+    /**
+     * Sample rate of the tuner
+     */
+    public abstract int getCurrentSampleRate() throws SourceException;
 
-			switch( speed )
-			{
-				case 0:
-					return "1.1 LOW";
-				case 1:
-					return "1.1 FULL";
-				case 2:
-					return "2.0 HIGH";
-				case 3:
-					return "3.0 SUPER";
-				default:
-			}
-		}
-		
-		return "UNKNOWN";
-	}
-	
-	/**
-	 * Set fcd interface mode
-	 */
-	public void setFCDMode( Mode mode ) throws UsbException, UsbClaimException
-	{
-		ByteBuffer response = null;
-		
-		switch( mode )
-		{
-			case APPLICATION:
-				response = send( FCDCommand.BL_QUERY );
-				break;
-			case BOOTLOADER:
-				response = send( FCDCommand.APP_RESET );
-				break;
-			default:
-				break;
-		}
-		
-		if( response != null )
-		{
-			mConfiguration.set( response );
-		}
-		else
-		{
-			mConfiguration.setModeUnknown();
-		}
-	}
+    /**
+     * Tuner class
+     */
+    public abstract TunerClass getTunerClass();
 
-	/**
-	 * Sets the actual (uncorrected) device frequency
-	 */
-	public void setTunedFrequency( long frequency ) throws SourceException
-	{
-		try
-		{
-			send( FCDCommand.APP_SET_FREQUENCY_HZ, frequency );
-		}
-		catch( Exception e )
-		{
-			throw new SourceException( "Couldn't set FCD Local " +
-					"Oscillator Frequency [" + frequency + "]", e );
-		}
-	}
+    /**
+     * Tuner type
+     */
+    public abstract TunerType getTunerType();
 
-	/**
-	 * Gets the actual (uncorrected) device frequency
-	 */
-	public long getTunedFrequency() throws SourceException
-	{
-		try
-		{
-			ByteBuffer buffer = send( FCDCommand.APP_GET_FREQUENCY_HZ );
-			
-			buffer.order( ByteOrder.LITTLE_ENDIAN );
-			
-			return (int)( buffer.getInt( 2 ) & 0xFFFFFFFF );
-		}
-		catch( Exception e )
-		{
-			throw new SourceException( "FCDTunerController - "
-					+ "couldn't get LO frequency", e );
-		}
-	}
-	
-	/**
-	 * Returns the FCD device configuration
-	 */
-	public FCDConfiguration getConfiguration()
-	{
-		return mConfiguration;
-	}
+    /**
+     * Applies the settings in the tuner configuration
+     */
+    public abstract void apply(TunerConfiguration config) throws SourceException;
 
-	/**
-	 * Claims the USB interface.  Attempts to detach the active kernel driver if
-	 * one is currently attached.
-	 */
-	private void claimInterface() throws SourceException
-	{
-		if( mDeviceHandle != null )
-		{
-			int result = LibUsb.kernelDriverActive( mDeviceHandle, FCD_INTERFACE );
-			
-			if( result == 1 )
-			{
-				result = LibUsb.detachKernelDriver( mDeviceHandle, 
-						FCD_INTERFACE );
+    /**
+     * USB address (bus/port)
+     */
+    public String getUSBAddress()
+    {
+        if(mDevice != null)
+        {
+            StringBuilder sb = new StringBuilder();
 
-				if( result != LibUsb.SUCCESS )
-				{
-					mLog.error( "failed attempt to detach kernel driver [" + 
-					LibUsb.errorName( result ) + "]" );
-				}
-			}
-			
-			result = LibUsb.claimInterface( mDeviceHandle, FCD_INTERFACE );
-			
-			if( result != LibUsb.SUCCESS )
-			{
-				throw new SourceException( "couldn't claim usb interface [" + 
-					LibUsb.errorName( result ) + "]" );
-			}
-		}
-		else
-		{
-			throw new SourceException( "couldn't claim usb hid interface - no "
-					+ "device handle" );
-		}
-	}
+            sb.append("Bus:");
+            int bus = LibUsb.getBusNumber(mDevice);
+            sb.append(bus);
 
-	/**
-	 * Performs an interrupt write to the OUT endpoint.
-	 * @param buffer - direct allocated buffer.  Must be 64 bytes in length.
-	 * 
-	 * @throws LibUsbException on error
-	 */
-	private void write( ByteBuffer buffer ) throws LibUsbException
-	{
-		if( mDeviceHandle != null )
-		{
-			IntBuffer transferred = IntBuffer.allocate( 1 );
-			
-			int result = LibUsb.interruptTransfer( mDeviceHandle,
-												   FCD_ENDPOINT_OUT,
-												   buffer, 
-												   transferred,
-												   500l );
-			
-			if( result != LibUsb.SUCCESS )
-			{
-				throw new LibUsbException( "error writing byte buffer", 
-								result );
-			}
-//			else if( transferred.get() != buffer.capacity() )
-//			{
-//				throw new LibUsbException( "transferred bytes [" + 
-//						transferred.get( 0 ) + "] is not what was expected [" + 
-//						buffer.capacity() + "]", result );
-//			}
-		}
-		else
-		{
-			throw new LibUsbException( "device handle is null", 
-							LibUsb.ERROR_NO_DEVICE );
-		}
-	}
-	
-	/**
-	 * Performs an interrupt write to the OUT endpoint for the FCD command.
-	 * @param command - no-argument command to write
-	 * @throws LibUsbException - on error
-	 */
-	private void write( FCDCommand command ) throws LibUsbException
-	{
-		ByteBuffer buffer = ByteBuffer.allocateDirect( 64 );
+            sb.append(" Port:");
+            int port = LibUsb.getPortNumber(mDevice);
+            sb.append(port);
 
-		buffer.put( 0, command.getCommand() );
-		buffer.put( 1, (byte)0x00 );
+            return sb.toString();
+        }
 
-		write( buffer );
-	}
+        return "UNKNOWN";
+    }
 
-	/**
-	 * Convenience logger for debugging read/write operations
-	 */
-	@SuppressWarnings( "unused" )
-    private void log( String label, ByteBuffer buffer )
-	{
-		StringBuilder sb = new StringBuilder();
+    /**
+     * USB Vendor and Product ID
+     */
+    public String getUSBID()
+    {
+        if(mDeviceDescriptor != null)
+        {
+            StringBuilder sb = new StringBuilder();
 
-		sb.append( label );
-		
-		sb.append( " " );
+            sb.append(String.format("%04X", (int)(mDeviceDescriptor.idVendor() & 0xFFFF)));
+            sb.append(":");
+            sb.append(String.format("%04X", (int)(mDeviceDescriptor.idProduct() & 0xFFFF)));
 
-		sb.append( buffer.get( 0 ) );
-		sb.append( " | " );
-		
-		for( int x = 0; x < 64; x++ )
-		{
-			sb.append( String.format( "%02X", (int)( buffer.get( x ) & 0xFF ) ) );
-			sb.append( " " );
-		}
-		
-		mLog.debug( sb.toString() );
-	}
-	
-	/**
-	 * Performs an interrupt write to the OUT endpoint for the FCD command.
-	 * @param command - command to write
-	 * @param argument - value to write with the command
-	 * @throws LibUsbException - on error
-	 */
-	private void write( FCDCommand command, long argument ) throws LibUsbException
-	{
-		ByteBuffer buffer = ByteBuffer.allocateDirect( 64 );
+            return sb.toString();
+        }
+
+        return "UNKNOWN";
+    }
+
+    /**
+     * USB Port Speed.  Should be 2.0 for both types of funcube dongles
+     */
+    public String getUSBSpeed()
+    {
+        if(mDevice != null)
+        {
+            int speed = LibUsb.getDeviceSpeed(mDevice);
+
+            switch(speed)
+            {
+                case 0:
+                    return "1.1 LOW";
+                case 1:
+                    return "1.1 FULL";
+                case 2:
+                    return "2.0 HIGH";
+                case 3:
+                    return "3.0 SUPER";
+                default:
+            }
+        }
+
+        return "UNKNOWN";
+    }
+
+    /**
+     * Set fcd interface mode
+     */
+    public void setFCDMode(Mode mode) throws UsbException, UsbClaimException
+    {
+        ByteBuffer response = null;
+
+        switch(mode)
+        {
+            case APPLICATION:
+                response = send(FCDCommand.BL_QUERY);
+                break;
+            case BOOTLOADER:
+                response = send(FCDCommand.APP_RESET);
+                break;
+            default:
+                break;
+        }
+
+        if(response != null)
+        {
+            mConfiguration.set(response);
+        }
+        else
+        {
+            mConfiguration.setModeUnknown();
+        }
+    }
+
+    /**
+     * Sets the actual (uncorrected) device frequency
+     */
+    public void setTunedFrequency(long frequency) throws SourceException
+    {
+        try
+        {
+            send(FCDCommand.APP_SET_FREQUENCY_HZ, frequency);
+        }
+        catch(Exception e)
+        {
+            throw new SourceException("Couldn't set FCD Local " +
+                "Oscillator Frequency [" + frequency + "]", e);
+        }
+    }
+
+    /**
+     * Gets the actual (uncorrected) device frequency
+     */
+    public long getTunedFrequency() throws SourceException
+    {
+        try
+        {
+            ByteBuffer buffer = send(FCDCommand.APP_GET_FREQUENCY_HZ);
+
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+            return (int)(buffer.getInt(2) & 0xFFFFFFFF);
+        }
+        catch(Exception e)
+        {
+            throw new SourceException("FCDTunerController - "
+                + "couldn't get LO frequency", e);
+        }
+    }
+
+    /**
+     * Returns the FCD device configuration
+     */
+    public FCDConfiguration getConfiguration()
+    {
+        return mConfiguration;
+    }
+
+    /**
+     * Claims the USB interface.  Attempts to detach the active kernel driver if
+     * one is currently attached.
+     */
+    private void claimInterface() throws SourceException
+    {
+        if(mDeviceHandle != null)
+        {
+            int result = LibUsb.kernelDriverActive(mDeviceHandle, FCD_INTERFACE);
+
+            if(result == 1)
+            {
+                result = LibUsb.detachKernelDriver(mDeviceHandle, FCD_INTERFACE);
+
+                if(result != LibUsb.SUCCESS)
+                {
+                    mLog.error("failed attempt to detach kernel driver [" + LibUsb.errorName(result) + "]");
+                }
+            }
+
+            result = LibUsb.claimInterface(mDeviceHandle, FCD_INTERFACE);
+
+            if(result != LibUsb.SUCCESS)
+            {
+                throw new SourceException("couldn't claim usb interface [" + LibUsb.errorName(result) + "]");
+            }
+        }
+        else
+        {
+            throw new SourceException("couldn't claim usb hid interface - no device handle");
+        }
+    }
+
+    /**
+     * Performs an interrupt write to the OUT endpoint.
+     *
+     * @param buffer - direct allocated buffer.  Must be 64 bytes in length.
+     * @throws LibUsbException on error
+     */
+    private void write(ByteBuffer buffer) throws LibUsbException
+    {
+        if(mDeviceHandle != null)
+        {
+            IntBuffer transferred = IntBuffer.allocate(1);
+
+            int result = LibUsb.interruptTransfer(mDeviceHandle, FCD_ENDPOINT_OUT, buffer, transferred, 500l);
+
+            if(result != LibUsb.SUCCESS)
+            {
+                throw new LibUsbException("error writing byte buffer", result);
+            }
+        }
+        else
+        {
+            throw new LibUsbException("device handle is null", LibUsb.ERROR_NO_DEVICE);
+        }
+    }
+
+    /**
+     * Performs an interrupt write to the OUT endpoint for the FCD command.
+     *
+     * @param command - no-argument command to write
+     * @throws LibUsbException - on error
+     */
+    private void write(FCDCommand command) throws LibUsbException
+    {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(64);
+
+        buffer.put(0, command.getCommand());
+        buffer.put(1, (byte)0x00);
+
+        write(buffer);
+    }
+
+    /**
+     * Convenience logger for debugging read/write operations
+     */
+    @SuppressWarnings("unused")
+    private void log(String label, ByteBuffer buffer)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(label);
+
+        sb.append(" ");
+
+        sb.append(buffer.get(0));
+        sb.append(" | ");
+
+        for(int x = 0; x < 64; x++)
+        {
+            sb.append(String.format("%02X", (int)(buffer.get(x) & 0xFF)));
+            sb.append(" ");
+        }
+
+        mLog.debug(sb.toString());
+    }
+
+    /**
+     * Performs an interrupt write to the OUT endpoint for the FCD command.
+     *
+     * @param command - command to write
+     * @param argument - value to write with the command
+     * @throws LibUsbException - on error
+     */
+    private void write(FCDCommand command, long argument) throws LibUsbException
+    {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(64);
 
 		/* The FCD expects little-endian formatted values */
-		buffer.order( ByteOrder.LITTLE_ENDIAN );
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
 
-		buffer.put( 0, command.getCommand() );
-		buffer.putLong( 1, argument );
+        buffer.put(0, command.getCommand());
+        buffer.putLong(1, argument);
 
-		write( buffer );
-	}
-	
-	/**
-	 * Performs an interrupt read against the endpoint
-	 * @return buffer read from FCD
-	 * @throws LibUsbException on error
-	 */
-	private ByteBuffer read() throws LibUsbException
-	{
-		if( mDeviceHandle != null )
-		{
-			ByteBuffer buffer = ByteBuffer.allocateDirect( 64 );
+        write(buffer);
+    }
 
-			IntBuffer transferred = IntBuffer.allocate( 1 );
-			
+    /**
+     * Performs an interrupt read against the endpoint
+     *
+     * @return buffer read from FCD
+     * @throws LibUsbException on error
+     */
+    private ByteBuffer read() throws LibUsbException
+    {
+        if(mDeviceHandle != null)
+        {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(64);
 
-			int result = LibUsb.interruptTransfer( mDeviceHandle,
-												   FCD_ENDPOINT_IN,
-												   buffer, 
-												   transferred,
-												   500l );
-			
-			if( result != LibUsb.SUCCESS )
-			{
-				throw new LibUsbException( "error reading byte buffer", 
-								result );
-			}
-			else if( transferred.get( 0 ) != buffer.capacity() )
-			{
-				throw new LibUsbException( "received bytes [" + 
-						transferred.get( 0 ) + "] didn't match expected "
-						+ "length [" + buffer.capacity() + "]", result );
-			}
+            IntBuffer transferred = IntBuffer.allocate(1);
 
-			return buffer;
-		}
-		
-		throw new LibUsbException( "device handle is null", 
-				LibUsb.ERROR_NO_DEVICE );
-	}
-	
-	/**
-	 * Sends the FCD command and argument.  Performs a read to complete the
-	 * command.
-	 * 
-	 * @param command - command to send
-	 * @param argument - command argument to send
-	 * @throws LibUsbException - on error
-	 */
-	protected void send( FCDCommand command, long argument ) throws LibUsbException
-	{
-		write( command, argument );
-		read();
-	}
-		
-	/**
-	 * Sends the no-argument FCD command.  Performs a read to complete the
-	 * command.
-	 * 
-	 * @param command - command to send
-	 * @throws LibUsbException - on error
-	 */
-	protected ByteBuffer send( FCDCommand command ) throws LibUsbException
-	{
-		write( command );
-		return read();
-	}
 
-	/**
-	 * FCD configuration string parsing  class
-	 */
-	public class FCDConfiguration
-	{
-		private String mConfig;
-		private Mode mMode;
+            int result = LibUsb.interruptTransfer(mDeviceHandle, FCD_ENDPOINT_IN, buffer, transferred, 500l);
 
-		public FCDConfiguration()
-		{
-			mConfig = null;
-			mMode = Mode.UNKNOWN;
-		}
-		
-		private void setModeUnknown()
-		{
-			mConfig = null;
-			mMode = Mode.UNKNOWN;
-		}
-		
-		/**
-		 * Extracts the configuration string from the buffer
-		 */
-		public void set( ByteBuffer buffer )
-		{
-			if( buffer.capacity() == 64 )
-			{
-				byte[] data = new byte[ 64 ];
-				
-				for( int x = 0; x < 64; x++ )
-				{
-					data[ x ] = buffer.get( x );
-				}
+            if(result != LibUsb.SUCCESS)
+            {
+                throw new LibUsbException("error reading byte buffer", result);
+            }
+            else if(transferred.get(0) != buffer.capacity())
+            {
+                throw new LibUsbException("received bytes [" + transferred.get(0) +
+                    "] didn't match expected length [" + buffer.capacity() + "]", result);
+            }
 
-				mConfig = new String( data );
-				mMode = Mode.getMode( mConfig );
-			}
-			else
-			{
-				mConfig = null;
-				mMode = Mode.ERROR;
-			}
-		}
-		
-		public Mode getMode()
-		{
-			return mMode;
-		}
-		
+            return buffer;
+        }
+
+        throw new LibUsbException("device handle is null", LibUsb.ERROR_NO_DEVICE);
+    }
+
+    /**
+     * Sends the FCD command and argument.  Performs a read to complete the
+     * command.
+     *
+     * @param command - command to send
+     * @param argument - command argument to send
+     * @throws LibUsbException - on error
+     */
+    protected void send(FCDCommand command, long argument) throws LibUsbException
+    {
+        write(command, argument);
+        read();
+    }
+
+    /**
+     * Sends the no-argument FCD command.  Performs a read to complete the
+     * command.
+     *
+     * @param command - command to send
+     * @throws LibUsbException - on error
+     */
+    protected ByteBuffer send(FCDCommand command) throws LibUsbException
+    {
+        write(command);
+        return read();
+    }
+
+    /**
+     * FCD configuration string parsing  class
+     */
+    public class FCDConfiguration
+    {
+        private String mConfig;
+        private Mode mMode;
+
+        public FCDConfiguration()
+        {
+            mConfig = null;
+            mMode = Mode.UNKNOWN;
+        }
+
+        private void setModeUnknown()
+        {
+            mConfig = null;
+            mMode = Mode.UNKNOWN;
+        }
+
+        /**
+         * Extracts the configuration string from the buffer
+         */
+        public void set(ByteBuffer buffer)
+        {
+            if(buffer.capacity() == 64)
+            {
+                byte[] data = new byte[64];
+
+                for(int x = 0; x < 64; x++)
+                {
+                    data[x] = buffer.get(x);
+                }
+
+                mConfig = new String(data);
+                mMode = Mode.getMode(mConfig);
+            }
+            else
+            {
+                mConfig = null;
+                mMode = Mode.ERROR;
+            }
+        }
+
+        public Mode getMode()
+        {
+            return mMode;
+        }
+
         public FCDModel getModel()
-		{
-			FCDModel retVal = FCDModel.FUNCUBE_UNKNOWN;
-			
-			switch( mMode )
-			{
-				case APPLICATION:
-					retVal = FCDModel.getFCD( mConfig.substring( 15, 22 ) );
-					break;
-				case BOOTLOADER:
-				case UNKNOWN:
-				case ERROR:
-					break;
-			}
-			
-			return retVal;
-		}
-		
-		public Block getBandBlocking()
-		{
-			Block retVal = Block.UNKNOWN;
-			
-			switch( mMode )
-			{
-				case APPLICATION:
-					retVal = Block.getBlock( mConfig.substring( 23, 33 ).trim() );
-					break;
-				case BOOTLOADER:
-				case UNKNOWN:
-				case ERROR:
-				break;
-			}
-			
-			return retVal;
-		}
+        {
+            FCDModel retVal = FCDModel.FUNCUBE_UNKNOWN;
 
-		public String getFirmware()
-		{
-			String retVal = null;
-			
-			switch( mMode )
-			{
-				case APPLICATION:
-					retVal = mConfig.substring( 9, 14 );
-					break;
-				case BOOTLOADER:
-				case UNKNOWN:
-				case ERROR:
-					break;
-			}
+            switch(mMode)
+            {
+                case APPLICATION:
+                    retVal = FCDModel.getFCD(mConfig.substring(15, 22));
+                    break;
+                case BOOTLOADER:
+                case UNKNOWN:
+                case ERROR:
+                    break;
+            }
 
-			return retVal;
-		}
+            return retVal;
+        }
 
-		public String toString()
-		{
-			return getModel().getLabel();
-		}
-	}
-	
-	public enum Mode 
-	{ 
-		APPLICATION,
-		BOOTLOADER,
-		ERROR,
-		UNKNOWN;
+        public Block getBandBlocking()
+        {
+            Block retVal = Block.UNKNOWN;
 
-		public static Mode getMode( String config )
-		{
-			Mode retVal = UNKNOWN;
+            switch(mMode)
+            {
+                case APPLICATION:
+                    retVal = Block.getBlock(mConfig.substring(23, 33).trim());
+                    break;
+                case BOOTLOADER:
+                case UNKNOWN:
+                case ERROR:
+                    break;
+            }
 
-			if( config == null )
-			{
-				retVal = ERROR;
-			}
-			else
-			{
-				if( config.length() >= 8 )
-				{
-					String mode = config.substring( 2, 8 ).trim();
+            return retVal;
+        }
 
-					if( mode.equalsIgnoreCase( "FCDAPP" ) )
-					{
-						retVal = APPLICATION;
-					}
-					else if( mode.equalsIgnoreCase( "FCDBL" ) )
-					{
-						retVal = BOOTLOADER;
-					}
-				}
-			}
-			
-			return retVal;
-		}
-	}
+        public String getFirmware()
+        {
+            String retVal = null;
+
+            switch(mMode)
+            {
+                case APPLICATION:
+                    retVal = mConfig.substring(9, 14);
+                    break;
+                case BOOTLOADER:
+                case UNKNOWN:
+                case ERROR:
+                    break;
+            }
+
+            return retVal;
+        }
+
+        public String toString()
+        {
+            return getModel().getLabel();
+        }
+    }
+
+    public enum Mode
+    {
+        APPLICATION,
+        BOOTLOADER,
+        ERROR,
+        UNKNOWN;
+
+        public static Mode getMode(String config)
+        {
+            Mode retVal = UNKNOWN;
+
+            if(config == null)
+            {
+                retVal = ERROR;
+            }
+            else
+            {
+                if(config.length() >= 8)
+                {
+                    String mode = config.substring(2, 8).trim();
+
+                    if(mode.equalsIgnoreCase("FCDAPP"))
+                    {
+                        retVal = APPLICATION;
+                    }
+                    else if(mode.equalsIgnoreCase("FCDBL"))
+                    {
+                        retVal = BOOTLOADER;
+                    }
+                }
+            }
+
+            return retVal;
+        }
+    }
 }

--- a/src/source/tuner/fcd/proplusV2/FCD2TunerController.java
+++ b/src/source/tuner/fcd/proplusV2/FCD2TunerController.java
@@ -1,30 +1,27 @@
 /*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014-2016 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
  ******************************************************************************/
 package source.tuner.fcd.proplusV2;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.usb4java.Device;
 import org.usb4java.DeviceDescriptor;
-
 import source.SourceException;
 import source.tuner.MixerTunerType;
 import source.tuner.TunerClass;
@@ -33,197 +30,200 @@ import source.tuner.configuration.TunerConfiguration;
 import source.tuner.fcd.FCDCommand;
 import source.tuner.fcd.FCDTunerController;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 public class FCD2TunerController extends FCDTunerController
 {
-	private final static Logger mLog = LoggerFactory.getLogger( FCD2TunerController.class );
+    private final static Logger mLog = LoggerFactory.getLogger(FCD2TunerController.class);
 
-	public static final int MINIMUM_TUNABLE_FREQUENCY = 150000;
-	public static final int MAXIMUM_TUNABLE_FREQUENCY = 2050000000;
-	public static final int SAMPLE_RATE = 192000;
-	
-	public FCD2TunerController( Device device, DeviceDescriptor descriptor ) 
-	{
-		super( device, descriptor,
-			   (int)MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS.getAudioFormat().getSampleRate(),
-			   MINIMUM_TUNABLE_FREQUENCY, MAXIMUM_TUNABLE_FREQUENCY );
-	}
+    public static final int MINIMUM_TUNABLE_FREQUENCY = 150000;
+    public static final int MAXIMUM_TUNABLE_FREQUENCY = 2050000000;
+    public static final int SAMPLE_RATE = 192000;
 
-	public void init() throws SourceException
-	{
-		super.init();
+    public FCD2TunerController(Device device, DeviceDescriptor descriptor)
+    {
+        super(device, descriptor,
+            (int)MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS.getAudioFormat().getSampleRate(),
+            MINIMUM_TUNABLE_FREQUENCY, MAXIMUM_TUNABLE_FREQUENCY);
+    }
 
-		mFrequencyController.setSampleRate( SAMPLE_RATE );
+    public void init() throws SourceException
+    {
+        super.init();
 
-		try
-		{
-			setFCDMode( Mode.APPLICATION );
-		}
-		catch( Exception e )
-		{
-			throw new SourceException( "error setting Mode to APPLICATION", e );
-		}
-	}
-	
-	public int getCurrentSampleRate()
-	{
-		return SAMPLE_RATE;
-	}
+        mFrequencyController.setSampleRate(SAMPLE_RATE);
 
-	@Override
+        try
+        {
+            setFCDMode(Mode.APPLICATION);
+        }
+        catch(Exception e)
+        {
+            throw new SourceException("error setting Mode to APPLICATION", e);
+        }
+    }
+
+    public int getCurrentSampleRate()
+    {
+        return SAMPLE_RATE;
+    }
+
+    @Override
     public TunerClass getTunerClass()
     {
-	    return TunerClass.FUNCUBE_DONGLE_PRO_PLUS;
+        return TunerClass.FUNCUBE_DONGLE_PRO_PLUS;
     }
 
-	@Override
+    @Override
     public TunerType getTunerType()
     {
-	    return TunerType.FUNCUBE_DONGLE_PRO_PLUS;
+        return TunerType.FUNCUBE_DONGLE_PRO_PLUS;
     }
-	
-	public void setLNAGain( boolean enabled ) throws SourceException
-	{
-		try
-        {
-        	send( FCDCommand.APP_SET_LNA_GAIN, enabled ? 1 : 0 );
-        }
-        catch ( Exception e )
-        {
-        	throw new SourceException( "error while setting LNA Gain", e );
-        }
-	}
 
-	public void setMixerGain( boolean enabled ) throws SourceException
-	{
-		try
-        {
-        	send( FCDCommand.APP_SET_MIXER_GAIN, enabled ? 1 : 0 );
-        }
-        catch ( Exception e )
-        {
-        	throw new SourceException( "error while setting Mixer Gain", e );
-        }
-	}
-
-	@Override
-    public void apply( TunerConfiguration config ) throws SourceException
+    public void setLNAGain(boolean enabled) throws SourceException
     {
-		if( config instanceof FCD2TunerConfiguration )
-		{
-			FCD2TunerConfiguration fcd2 = (FCD2TunerConfiguration)config;
-
-			setFrequencyCorrection( fcd2.getFrequencyCorrection() );
-			setFrequency( fcd2.getFrequency() );
-			setLNAGain( fcd2.getGainLNA() );
-			setMixerGain( fcd2.getGainMixer() );
-			
-			try
-			{
-				setFrequency( fcd2.getFrequency() );
-			}
-			catch( SourceException se )
-			{
-				//Do nothing, we couldn't set the frequency
-			}
-		}
+        try
+        {
+            send(FCDCommand.APP_SET_LNA_GAIN, enabled ? 1 : 0);
+        }
+        catch(Exception e)
+        {
+            throw new SourceException("error while setting LNA Gain", e);
+        }
     }
-	
-	public int getDCCorrection()
-	{
-		int dcCorrection = -999;
-		
-		try
-        {
-			ByteBuffer buffer = send( FCDCommand.APP_GET_DC_CORRECTION );
-			
-			buffer.order( ByteOrder.LITTLE_ENDIAN );
-			
-			return buffer.getInt( 2 );
-        }
-        catch ( Exception e )
-        {
-        	mLog.error( "error getting dc correction value", e );
-        }
-		
-		return dcCorrection;
-	}
-	
-	public void setDCCorrection( int value )
-	{
-		try
-        {
-			send( FCDCommand.APP_SET_DC_CORRECTION, value );
-        }
-        catch ( Exception e )
-        {
-        	mLog.error( "error setting dc correction to [" + value + "]", e );
-        }
-	}
-	
-	public int getIQCorrection()
-	{
-		int iqCorrection = -999;
-		
-		try
-        {
-			ByteBuffer buffer = send( FCDCommand.APP_GET_IQ_CORRECTION );
-			
-			buffer.order( ByteOrder.LITTLE_ENDIAN );
-			
-			return buffer.getInt( 2 );
-        }
-        catch ( Exception e )
-        {
-        	mLog.error( "error reading IQ correction value", e );
-        }
-	        
-		return iqCorrection;
-	}
-	
-	public void setIQCorrection( int value )
-	{
-		try
-        {
-	        send( FCDCommand.APP_SET_IQ_CORRECTION, value );
-        }
-        catch ( Exception e )
-        {
-        	mLog.error( "error setting IQ correction to [" + value + "]", e );
-        }
-	}
-	
-	public enum Block 
-	{ 
-		CELLULAR_BAND_BLOCKED( "Blocked" ),
-		NO_BAND_BLOCK( "Unblocked" ),
-		UNKNOWN( "Unknown" );
-		
-		private String mLabel;
-		
-		private Block( String label )
-		{
-		    mLabel = label;
-		}
-		
-		public String getLabel()
-		{
-		    return mLabel;
-		}
 
-		public static Block getBlock( String block )
-		{
-			Block retVal = UNKNOWN;
+    public void setMixerGain(boolean enabled) throws SourceException
+    {
+        try
+        {
+            send(FCDCommand.APP_SET_MIXER_GAIN, enabled ? 1 : 0);
+        }
+        catch(Exception e)
+        {
+            throw new SourceException("error while setting Mixer Gain", e);
+        }
+    }
 
-			if( block.equalsIgnoreCase( "No blk" ) )
-			{
-				retVal = NO_BAND_BLOCK;
-			}
-			else if( block.equalsIgnoreCase( "Cell blk" ) )
-			{
-				retVal = CELLULAR_BAND_BLOCKED;
-			}
-			
-			return retVal;
-		}
-	}
+    @Override
+    public void apply(TunerConfiguration config) throws SourceException
+    {
+        if(config instanceof FCD2TunerConfiguration)
+        {
+            FCD2TunerConfiguration fcd2 = (FCD2TunerConfiguration)config;
+
+            setFrequencyCorrection(fcd2.getFrequencyCorrection());
+            setFrequency(fcd2.getFrequency());
+            setLNAGain(fcd2.getGainLNA());
+            setMixerGain(fcd2.getGainMixer());
+
+            try
+            {
+                setFrequency(fcd2.getFrequency());
+            }
+            catch(SourceException se)
+            {
+                //Do nothing, we couldn't set the frequency
+            }
+        }
+    }
+
+    public int getDCCorrection()
+    {
+        int dcCorrection = -999;
+
+        try
+        {
+            ByteBuffer buffer = send(FCDCommand.APP_GET_DC_CORRECTION);
+
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+            return buffer.getInt(2);
+        }
+        catch(Exception e)
+        {
+            mLog.error("error getting dc correction value", e);
+        }
+
+        return dcCorrection;
+    }
+
+    public void setDCCorrection(int value)
+    {
+        try
+        {
+            send(FCDCommand.APP_SET_DC_CORRECTION, value);
+        }
+        catch(Exception e)
+        {
+            mLog.error("error setting dc correction to [" + value + "]", e);
+        }
+    }
+
+    public int getIQCorrection()
+    {
+        int iqCorrection = -999;
+
+        try
+        {
+            ByteBuffer buffer = send(FCDCommand.APP_GET_IQ_CORRECTION);
+
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+            return buffer.getInt(2);
+        }
+        catch(Exception e)
+        {
+            mLog.error("error reading IQ correction value", e);
+        }
+
+        return iqCorrection;
+    }
+
+    public void setIQCorrection(int value)
+    {
+        try
+        {
+            send(FCDCommand.APP_SET_IQ_CORRECTION, value);
+        }
+        catch(Exception e)
+        {
+            mLog.error("error setting IQ correction to [" + value + "]", e);
+        }
+    }
+
+    public enum Block
+    {
+        CELLULAR_BAND_BLOCKED("Blocked"),
+        NO_BAND_BLOCK("Unblocked"),
+        UNKNOWN("Unknown");
+
+        private String mLabel;
+
+        private Block(String label)
+        {
+            mLabel = label;
+        }
+
+        public String getLabel()
+        {
+            return mLabel;
+        }
+
+        public static Block getBlock(String block)
+        {
+            Block retVal = UNKNOWN;
+
+            if(block.equalsIgnoreCase("No blk"))
+            {
+                retVal = NO_BAND_BLOCK;
+            }
+            else if(block.equalsIgnoreCase("Cell blk"))
+            {
+                retVal = CELLULAR_BAND_BLOCKED;
+            }
+
+            return retVal;
+        }
+    }
 }

--- a/src/source/tuner/usb/USBTransferProcessor.java
+++ b/src/source/tuner/usb/USBTransferProcessor.java
@@ -1,0 +1,390 @@
+/*******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package source.tuner.usb;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.usb4java.DeviceHandle;
+import org.usb4java.LibUsb;
+import org.usb4java.LibUsbException;
+import org.usb4java.Transfer;
+import org.usb4java.TransferCallback;
+import sample.Broadcaster;
+import sample.Listener;
+import sample.OverflowableTransferQueue;
+import sample.adapter.ISampleAdapter;
+import sample.complex.ComplexBuffer;
+import source.tuner.TunerManager;
+import util.ThreadPool;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class USBTransferProcessor implements TransferCallback
+{
+    private final static Logger mLog = LoggerFactory.getLogger(USBTransferProcessor.class);
+
+    private static final byte USB_BULK_TRANSFER_ENDPOINT = (byte) 0x81;
+    private static final long USB_TIMEOUT_MS = 2000l; //milliseconds
+
+    //Number of native byte buffers to allocate for transferring data from the USB device
+    private static final int TRANSFER_BUFFER_POOL_SIZE = 16;
+
+    //Maximum number of filled buffers for the blocking queue
+    private static final int FILLED_BUFFER_MAX_CAPACITY = 300;
+
+    //Threshold for resetting buffer overflow condition
+    private static final int FILLED_BUFFER_OVERFLOW_RESET_THRESHOLD = 200;
+
+    private String mDeviceName;
+
+    //Handle to the USB bulk transfer device
+    private DeviceHandle mDeviceHandle;
+
+    //Tuner format-specific byte to IQ float sample converter
+    private ISampleAdapter mSampleAdapter;
+
+    //Byte array transfer buffers size in bytes
+    private int mBufferSize;
+
+    private Broadcaster<ComplexBuffer> mComplexBufferBroadcaster = new Broadcaster<>();
+    private OverflowableTransferQueue<byte[]> mFilledBuffers;
+    private LinkedTransferQueue<Transfer> mAvailableTransfers = new LinkedTransferQueue<>();
+    private LinkedTransferQueue<Transfer> mTransfersInProgress = new LinkedTransferQueue<>();
+
+    private AtomicBoolean mRunning = new AtomicBoolean();
+
+    private ByteBuffer mLibUsbHandlerStatus = ByteBuffer.allocateDirect(4);
+
+    private BufferDispatcher mBufferDispatcher = new BufferDispatcher();
+    private ScheduledFuture mBufferDispatcherFuture;
+
+    /**
+     * Manages stream of USB transfer buffers and converts buffers to complex buffer samples for distribution to
+     * any registered listeners.
+     *
+     * @param deviceName to use when logging information or errors
+     * @param deviceHandle to the USB bulk transfer device
+     * @param sampleAdapter specific to the tuner's byte buffer format for converting to floating point I/Q samples
+     * @param bufferSize in bytes.  Should be a multiple of two: 65536, 131072 or 262144.
+     */
+    public USBTransferProcessor(String deviceName,
+                                DeviceHandle deviceHandle,
+                                ISampleAdapter sampleAdapter,
+                                int bufferSize)
+    {
+        mDeviceName = deviceName;
+        mDeviceHandle = deviceHandle;
+        mSampleAdapter = sampleAdapter;
+        mBufferSize = bufferSize;
+
+        mFilledBuffers = new OverflowableTransferQueue<>(FILLED_BUFFER_MAX_CAPACITY, FILLED_BUFFER_OVERFLOW_RESET_THRESHOLD);
+        mFilledBuffers.setStateListener(new Listener<OverflowableTransferQueue.State>()
+        {
+            @Override
+            public void receive(OverflowableTransferQueue.State state)
+            {
+                if(state == OverflowableTransferQueue.State.NORMAL)
+                {
+                    mLog.debug(mDeviceName + " - buffer overflow - temporary pause until processing catches up");
+                }
+                else
+                {
+                    mLog.debug(mDeviceName + " - buffer overflow cleared - resuming normal processing");
+                }
+            }
+        });
+    }
+
+    /**
+     * Start USB transfer buffer processing.  Subsequent calls to this method after started will be ignored.
+     */
+    private void start()
+    {
+        if(mRunning.compareAndSet(false, true))
+        {
+            prepareDeviceStart();
+
+            prepareTransfers();
+
+            while(!mAvailableTransfers.isEmpty())
+            {
+                Transfer transfer = mAvailableTransfers.poll();
+
+                if(transfer != null)
+                {
+                    int result = LibUsb.submitTransfer(transfer);
+
+                    if(result == LibUsb.SUCCESS)
+                    {
+                        mTransfersInProgress.add(transfer);
+                    }
+                    else
+                    {
+                        //TODO: broadcast to each listener that this source has an error and is shutting down
+                        mLog.error(mDeviceName + "- error submitting transfer [" + LibUsb.errorName(result) + "]");
+                    }
+                }
+            }
+
+            //Start transferred buffer dispatcher
+            mBufferDispatcherFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(mBufferDispatcher,
+                20, 20, TimeUnit.MILLISECONDS);
+
+            //Register with LibUSB processor so that it auto-starts LibUSB processing
+            TunerManager.LIBUSB_TRANSFER_PROCESSOR.registerTransferProcessor(this);
+        }
+    }
+
+    /**
+     * Stop USB transfer buffer processing.  Subsequent calls to this method after stopped will be ignored.
+     */
+    private void stop()
+    {
+        if(mRunning.compareAndSet(true, false))
+        {
+            mBufferDispatcherFuture.cancel(true);
+
+            mFilledBuffers.clear();
+
+            //Cancel the lib usb process timer
+            for(Transfer transfer : mTransfersInProgress)
+            {
+                LibUsb.cancelTransfer(transfer);
+            }
+
+
+            //Unregister from LibUSB processor so that it auto-stops LibUSB processing
+            TunerManager.LIBUSB_TRANSFER_PROCESSOR.registerTransferProcessor(this);
+
+            //Directly invoke the timeout handler to ensure that our cancelled transfer buffers are flushed.
+            int result = LibUsb.handleEventsTimeoutCompleted(null, USB_TIMEOUT_MS,
+                mLibUsbHandlerStatus.asIntBuffer());
+
+            if(result != LibUsb.SUCCESS)
+            {
+                mLog.error(mDeviceName + " - error while cancelling transfer buffers during shutdown/pause - error code:" + result);
+            }
+
+            mLibUsbHandlerStatus.rewind();
+
+            executeDeviceStop();
+        }
+    }
+
+    /**
+     * Allows sub-class implementations to execute any device-specific operations to prepare for starting USB transfers
+     */
+    protected void prepareDeviceStart()
+    {
+
+    }
+
+    /**
+     * Allows sub-class implementations to execute any device-specific operations after stopping USB transfers
+     */
+    protected void executeDeviceStop()
+    {
+
+    }
+
+    /**
+     * Indicates if there are complex buffer listeners registered with this processor
+     */
+    public boolean hasListeners()
+    {
+        return mComplexBufferBroadcaster.hasListeners();
+    }
+
+    public void addListener(Listener<ComplexBuffer> listener)
+    {
+        mComplexBufferBroadcaster.addListener(listener);
+
+        start();
+    }
+
+    public void removeListener(Listener<ComplexBuffer> listener)
+    {
+        mComplexBufferBroadcaster.removeListener(listener);
+
+        if(!hasListeners())
+        {
+            stop();
+        }
+    }
+
+    public void removeAllListeners()
+    {
+        mComplexBufferBroadcaster.clear();
+        stop();
+    }
+
+    /**
+     * Prepares (allocates) a set of transfer buffers for use in transferring data from the USB device via the bulk
+     * interface.  Since we're using direct allocation (native), buffers are retained and reused across multiple
+     * start/stop cycles.
+     */
+    private void prepareTransfers() throws LibUsbException
+    {
+        while(mAvailableTransfers.size() < TRANSFER_BUFFER_POOL_SIZE)
+        {
+            Transfer transfer = LibUsb.allocTransfer();
+
+            if(transfer == null)
+            {
+                throw new LibUsbException("Couldn't allocate USB transfer buffer", LibUsb.ERROR_NO_MEM);
+            }
+
+            final ByteBuffer buffer = ByteBuffer.allocateDirect(mBufferSize);
+
+            LibUsb.fillBulkTransfer(transfer, mDeviceHandle, USB_BULK_TRANSFER_ENDPOINT, buffer, this,
+                "Buffer", USB_TIMEOUT_MS);
+
+            mAvailableTransfers.add(transfer);
+        }
+    }
+
+    /**
+     * Process a filled transfer buffer received back from the USB device
+     */
+    @Override
+    public void processTransfer(Transfer transfer)
+    {
+        mTransfersInProgress.remove(transfer);
+
+        switch(transfer.status())
+        {
+            case LibUsb.TRANSFER_COMPLETED:
+            case LibUsb.TRANSFER_STALL:
+                if(transfer.actualLength() > 0)
+                {
+                    ByteBuffer buffer = transfer.buffer();
+
+                    byte[] data = new byte[transfer.actualLength()];
+                    buffer.get(data);
+                    buffer.rewind();
+
+                    if(mRunning.get())
+                    {
+                        mFilledBuffers.offer(data);
+                    }
+                }
+                break;
+            case LibUsb.TRANSFER_CANCELLED:
+                break;
+            default:
+                //Unexpected transfer error
+                mLog.error(mDeviceName + " - transfer error [" + getTransferStatus(transfer.status()) +
+                    "] transferred actual: " + transfer.actualLength());
+        }
+
+
+        if(mRunning.get())
+        {
+            int result = LibUsb.submitTransfer(transfer);
+
+            if(result == LibUsb.SUCCESS)
+            {
+                mTransfersInProgress.add(transfer);
+            }
+            else
+            {
+                mAvailableTransfers.add(transfer);
+                mLog.error(mDeviceName + " - error submitting transfer [" + LibUsb.errorName(result) + "]");
+
+                if(mTransfersInProgress.isEmpty())
+                {
+                    mLog.warn(mDeviceName + " - all transfer buffer processing is stopped");
+                    //TODO: no transfers are in progress ... need to alert the user and the registered complex
+                    //TODO: buffer listeners so that they can respond accordingly
+                }
+            }
+        }
+        else
+        {
+            //We're stopping - park the transfer buffers
+            if(!mAvailableTransfers.contains(transfer))
+            {
+                mAvailableTransfers.add(transfer);
+            }
+        }
+    }
+
+    /**
+     * Converts the USB transfer status number into a descriptive label
+     */
+    public static String getTransferStatus(int status)
+    {
+        switch(status)
+        {
+            case 0:
+                return "TRANSFER COMPLETED (0)";
+            case 1:
+                return "TRANSFER ERROR (1)";
+            case 2:
+                return "TRANSFER TIMED OUT (2)";
+            case 3:
+                return "TRANSFER CANCELLED (3)";
+            case 4:
+                return "TRANSFER STALL (4)";
+            case 5:
+                return "TRANSFER NO DEVICE (5)";
+            case 6:
+                return "TRANSFER OVERFLOW (6)";
+            default:
+                return "UNKNOWN TRANSFER STATUS (" + status + ")";
+        }
+    }
+
+    /**
+     * Fetches byte[] chunks from the raw sample buffer.  Converts each byte
+     * array and broadcasts the array to all registered listeners
+     */
+    public class BufferDispatcher implements Runnable
+    {
+        private List<byte[]> mBuffersToDispatch = new ArrayList<>();
+
+        @Override
+        public void run()
+        {
+            try
+            {
+                mFilledBuffers.drainTo(mBuffersToDispatch, 15);
+
+                for(byte[] buffer : mBuffersToDispatch)
+                {
+                    float[] complexSamples = mSampleAdapter.convert(buffer);
+
+                    mComplexBufferBroadcaster.broadcast(new ComplexBuffer(complexSamples));
+                }
+            }
+            catch(Exception e)
+            {
+                mLog.error(mDeviceName + " - error while dispatching complex IQ buffer samples", e);
+            }
+
+            mBuffersToDispatch.clear();
+        }
+    }
+}


### PR DESCRIPTION
126 - Tuner processing refactor and significant improvement in processor and memory utilization.  Refactors all USB tuner sample processing with a new USBTransferProcessor class.  LibUSB transfer timeout processing is now consolidated under the TunerManager and tuners register with this singleton to auto-start or auto-stop USB bulk transfer processing.  Resolves long-standing issue impacting multi-tuner use where the second and subsequent tuners may have been routinely starved for LibUSB processing time under heavy-loading.  All tuner buffer threaded processing is now handled as runnables in the scheduled thread pool, eliminating tuner-dedicated processing threads.  Added tuner buffer size management to prevent memory blow-out when down-stream processing is either lagging or impacted by java garbage collection operations.  Both tuners and individual DDC channels now have bounded sample buffer queues that automatically enter and exit overflow mode when predefined max/reset thresholds are met.  When any queue goes into overflow mode, sample buffers are simply dropped in favor of preserving program/memory stability.