### PR TITLE
Resolves #140 issue with updating metadata on Icecast2 servers

### DIFF
--- a/src/audio/broadcast/icecast/IcecastBroadcastMetadataUpdater.java
+++ b/src/audio/broadcast/icecast/IcecastBroadcastMetadataUpdater.java
@@ -235,7 +235,7 @@ public class IcecastBroadcastMetadataUpdater implements IBroadcastMetadataUpdate
         {
             StringBuilder sb = new StringBuilder();
             sb.append("mode=updinfo");
-            sb.append("&mount=").append(mIcecastConfiguration.getMountPoint());
+            sb.append("&mount=").append(URLEncoder.encode(mIcecastConfiguration.getMountPoint(), UTF8));
             sb.append("&charset=UTF%2d8");
             sb.append("&song=").append(URLEncoder.encode(song, UTF8));
 


### PR DESCRIPTION
mountpoint was not URL encoded.

Thanks to mcode for the patch!