### PR TITLE
Resolves #155 - adds usb endpoint clear halt when attempting to resubmit transfer buffer

### DIFF
--- a/src/source/tuner/usb/USBTransferProcessor.java
+++ b/src/source/tuner/usb/USBTransferProcessor.java
@@ -331,6 +331,28 @@ public class USBTransferProcessor implements TransferCallback
             {
                 mTransfersInProgress.add(transfer);
             }
+            else if(result == LibUsb.ERROR_PIPE)
+            {
+                int resetResult = LibUsb.clearHalt(mDeviceHandle, USB_BULK_TRANSFER_ENDPOINT);
+
+                if(resetResult == LibUsb.SUCCESS)
+                {
+                    int resubmitResult = LibUsb.submitTransfer(transfer);
+
+                    if(resubmitResult == LibUsb.SUCCESS)
+                    {
+                        mTransfersInProgress.add(transfer);
+                    }
+                    else
+                    {
+                        mLog.error(mDeviceName + " - error resubmitting transfer after endpoint clear halt");
+                    }
+                }
+                else
+                {
+                    mLog.error(mDeviceName + " - unable to clear device endpoint halt");
+                }
+            }
             else
             {
                 mAvailableTransfers.add(transfer);


### PR DESCRIPTION
Adds to the previous commit by adding handler for clearing an endpoint halt when there is a USB pipe error while resubmitting a buffer transfer.