### PR TITLE
Resolves #161 - E4000 tuner error.  

### DIFF
--- a/src/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/source/tuner/rtl/RTL2832TunerController.java
@@ -78,14 +78,9 @@ public abstract class RTL2832TunerController extends TunerController
 
     private SampleRate mSampleRate = DEFAULT_SAMPLE_RATE;
 
-    private ByteSampleAdapter mSampleAdapter = new ByteSampleAdapter();
-
-    private Broadcaster<ComplexBuffer> mComplexBufferBroadcaster = new Broadcaster<>();
-
+    protected ByteSampleAdapter mSampleAdapter = new ByteSampleAdapter();
     protected int mOscillatorFrequency = 28800000; //28.8 MHz
-
-    private USBTransferProcessor mUSBTransferProcessor;
-
+    protected USBTransferProcessor mUSBTransferProcessor;
     protected Descriptor mDescriptor;
 
     /**

--- a/src/source/tuner/rtl/e4k/E4KTunerController.java
+++ b/src/source/tuner/rtl/e4k/E4KTunerController.java
@@ -249,6 +249,11 @@ public class E4KTunerController extends RTL2832TunerController
             throw new SourceException("E4K Tuner Controller - error during "
                 + "init()", e);
         }
+
+        String deviceName = getTunerType().getLabel() + " " + getUniqueID();
+
+        mUSBTransferProcessor = new RTL2832USBTransferProcessor(deviceName, mDeviceHandle, mSampleAdapter,
+            USB_TRANSFER_BUFFER_SIZE);
     }
 
     /**

--- a/src/source/tuner/usb/USBTransferProcessor.java
+++ b/src/source/tuner/usb/USBTransferProcessor.java
@@ -173,7 +173,7 @@ public class USBTransferProcessor implements TransferCallback
 
             //Start transferred buffer dispatcher
             mBufferDispatcherFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(mBufferDispatcher,
-                20, 20, TimeUnit.MILLISECONDS);
+                0, 11, TimeUnit.MILLISECONDS);
 
             //Register with LibUSB processor so that it auto-starts LibUSB processing
             TunerManager.LIBUSB_TRANSFER_PROCESSOR.registerTransferProcessor(this);


### PR DESCRIPTION
Resolves null pointer error in E4000 tuner and tweaks settings in the USB transfer processor to improve latency in IQ buffer handling.
