### PR TITLE
Add a Text Label to the Mute Image Button

### DIFF
--- a/src/audio/AudioPanel.java
+++ b/src/audio/AudioPanel.java
@@ -383,6 +383,7 @@ public class AudioPanel extends JPanel implements Listener<AudioEvent>
         {
             setIcon(UNMUTED_ICON);
             setBorderPainted(false);
+            getAccessibleContext().setAccessibleName("Mute");
 
             addActionListener(new ActionListener()
             {
@@ -402,6 +403,7 @@ public class AudioPanel extends JPanel implements Listener<AudioEvent>
                         public void run()
                         {
                             setIcon(mMuted ? MUTED_ICON : UNMUTED_ICON);
+                            getAccessibleContext().setAccessibleName(mMuted ? "Unmute" : "Mute");
                         }
                     });
                 }


### PR DESCRIPTION
Adds a screen reader accessible label to the mute button. Label switches between mute and unmute to match the action that will be taken when the button is next pressed.