### PR TITLE
165 - P25 Channel stops decoding

### DIFF
--- a/src/audio/broadcast/icecast/IcecastBroadcastMetadataUpdater.java
+++ b/src/audio/broadcast/icecast/IcecastBroadcastMetadataUpdater.java
@@ -145,6 +145,10 @@ public class IcecastBroadcastMetadataUpdater implements IBroadcastMetadataUpdate
                                     session.write(updateRequest);
                                 }
                             }
+                            catch(UnresolvedAddressException uae)
+                            {
+                                //Do nothing - the server is temporarily unavailable
+                            }
                             catch(Exception e)
                             {
                                 Throwable throwableCause = e.getCause();


### PR DESCRIPTION
Resolves #165 issue where P25 Patch Group management was causing a logic error and causing the decoder's dispatcher thread to die.