### PR TITLE
Resolves #176 - resolves 2 streaming related issues

### DIFF
--- a/src/alias/id/broadcast/BroadcastChannel.java
+++ b/src/alias/id/broadcast/BroadcastChannel.java
@@ -25,76 +25,99 @@ import javax.xml.bind.annotation.XmlAttribute;
 
 public class BroadcastChannel extends AliasID implements Comparable<BroadcastChannel>
 {
-	private String mChannelName;
+    private String mChannelName;
 
-	public BroadcastChannel()
-	{
-		//JAXB Constructor
-	}
+    public BroadcastChannel()
+    {
+        //JAXB Constructor
+    }
 
-	@Override
-	public int compareTo(BroadcastChannel other)
-	{
-		if(mChannelName != null && other.getChannelName() != null)
-		{
-			return mChannelName.compareTo(other.getChannelName());
-		}
-		else if(mChannelName != null)
-		{
-			return -1;
-		}
-		else
-		{
-			return 1;
-		}
-	}
+    @Override
+    public int compareTo(BroadcastChannel other)
+    {
+        if(mChannelName != null && other.getChannelName() != null)
+        {
+            return mChannelName.compareTo(other.getChannelName());
+        }
+        else if(mChannelName != null)
+        {
+            return -1;
+        }
+        else
+        {
+            return 1;
+        }
+    }
 
-	/**
-	 * Creates a named broadcast channel
-	 */
-	public BroadcastChannel(String channelName)
-	{
-		mChannelName = channelName;
-	}
+    @Override
+    public boolean equals(Object o)
+    {
+        if(this == o)
+        {
+            return true;
+        }
+        if(!(o instanceof BroadcastChannel))
+        {
+            return false;
+        }
 
-	/**
-	 * Name of the broadcastAudio channel configuration
-	 */
-	@XmlAttribute(name="channel")
-	public String getChannelName()
-	{
-		return mChannelName;
-	}
+        BroadcastChannel that = (BroadcastChannel)o;
 
-	/**
-	 * Sets the name of the broadcastAudio channel configuration
-	 */
-	public void setChannelName(String channel)
-	{
-		mChannelName = channel;
-	}
+        return getChannelName() != null ? getChannelName().equals(that.getChannelName()) : that.getChannelName() == null;
+    }
 
-	@Override
-	public AliasIDType getType()
-	{
-		return AliasIDType.BROADCAST_CHANNEL;
-	}
+    @Override
+    public int hashCode()
+    {
+        return getChannelName() != null ? getChannelName().hashCode() : 0;
+    }
 
-	@Override
-	public boolean isValid()
-	{
-		return mChannelName != null;
-	}
+    /**
+     * Creates a named broadcast channel
+     */
+    public BroadcastChannel(String channelName)
+    {
+        mChannelName = channelName;
+    }
 
-	@Override
-	public boolean matches( AliasID id )
-	{
-		return false;
-	}
-	
-	@Override
-	public String toString()
-	{
+    /**
+     * Name of the broadcastAudio channel configuration
+     */
+    @XmlAttribute(name = "channel")
+    public String getChannelName()
+    {
+        return mChannelName;
+    }
+
+    /**
+     * Sets the name of the broadcastAudio channel configuration
+     */
+    public void setChannelName(String channel)
+    {
+        mChannelName = channel;
+    }
+
+    @Override
+    public AliasIDType getType()
+    {
+        return AliasIDType.BROADCAST_CHANNEL;
+    }
+
+    @Override
+    public boolean isValid()
+    {
+        return mChannelName != null;
+    }
+
+    @Override
+    public boolean matches(AliasID id)
+    {
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
         if(isValid())
         {
             return "Broadcast Channel: " + mChannelName;
@@ -103,5 +126,5 @@ public class BroadcastChannel extends AliasID implements Comparable<BroadcastCha
         {
             return "Broadcast Channel: None Selected";
         }
-	}
+    }
 }

--- a/src/audio/broadcast/BroadcastModel.java
+++ b/src/audio/broadcast/BroadcastModel.java
@@ -707,7 +707,9 @@ public class BroadcastModel extends AbstractTableModel implements Listener<Audio
 
             if(metadata != null && metadata.isStreamable())
             {
-                for(BroadcastChannel broadcastChannel : metadata.getBroadcastChannels())
+                List<BroadcastChannel> broadcastChannels = metadata.getBroadcastChannels();
+
+                for(BroadcastChannel broadcastChannel : broadcastChannels)
                 {
                     String channelName = broadcastChannel.getChannelName();
 

--- a/src/audio/broadcast/icecast/IcecastTCPAudioBroadcaster.java
+++ b/src/audio/broadcast/icecast/IcecastTCPAudioBroadcaster.java
@@ -248,6 +248,12 @@ public class IcecastTCPAudioBroadcaster extends IcecastAudioBroadcaster
                 {
                     String reason = ioe.getMessage();
 
+                    if(connected())
+                    {
+                        mLog.info("Streaming connection error detected - resetting connection - " + reason);
+                        disconnect();
+                        connect();
+                    }
                     if(reason.startsWith("Connection reset"))
                     {
                         mLog.info("Streaming connection reset by remote server - reestablishing connection");
@@ -264,14 +270,14 @@ public class IcecastTCPAudioBroadcaster extends IcecastAudioBroadcaster
                     {
                         setBroadcastState(BroadcastState.ERROR);
                         disconnect();
-                        mLog.error("Unrecognized IO error: " + reason + ". Streaming halted.");
+                        mLog.error("Unrecognized IO error: " + reason + ". Streaming halted.", cause);
                     }
                 }
                 else
                 {
                     setBroadcastState(BroadcastState.ERROR);
                     disconnect();
-                    mLog.error("Unspecified IO error - streaming halted.");
+                    mLog.error("Unspecified IO error - streaming halted.", cause);
                 }
             }
             else


### PR DESCRIPTION
A) streaming connection errors - detects errors and if currently connected, resets the connection.

B)duplicate calls being streamed - issue with comparison of broadcast channels allowed the same broadcast channel to be queued two or more times for the list of channels to stream a recording.