### PR TITLE
Resolves issue with UTF-8 encoding of Shoutcast 2 metadata updates.

### DIFF
--- a/src/audio/broadcast/shoutcast/v2/ultravox/UltravoxMetadata.java
+++ b/src/audio/broadcast/shoutcast/v2/ultravox/UltravoxMetadata.java
@@ -65,7 +65,7 @@ public enum UltravoxMetadata
     {
         StringBuilder sb = new StringBuilder();
         sb.append("<").append(getXMLTag()).append(">");
-        sb.append(URLEncoder.encode(value, "UTF-8"));
+        sb.append(new String(value.getBytes(), "UTF-8"));
         sb.append("</").append(getXMLTag()).append(">");
 
         return sb.toString();


### PR DESCRIPTION
Resolves #199 issue where metadata is UTF-8 URL encoded versus UTF-8 String encoding.