### PR TITLE
Traffic channel manager now allocates traffic channels for do not monitor aliases

### DIFF
--- a/src/module/decode/DecoderFactory.java
+++ b/src/module/decode/DecoderFactory.java
@@ -222,7 +222,7 @@ public class DecoderFactory
 
                 if(channelType == ChannelType.STANDARD)
                 {
-                    modules.add(new TrafficChannelManager(channelModel, channelProcessingManager, decodeConfig,
+                    modules.add(new TrafficChannelManager(channelModel, decodeConfig,
                         channel.getRecordConfiguration(), channel.getSystem(), channel.getSite(),
                         (aliasList != null ? aliasList.getName() : null), mptConfig.getTrafficChannelPoolSize()));
                 }
@@ -263,7 +263,7 @@ public class DecoderFactory
 
                 if(channelType == ChannelType.STANDARD)
                 {
-                    modules.add(new TrafficChannelManager(channelModel, channelProcessingManager, decodeConfig,
+                    modules.add(new TrafficChannelManager(channelModel, decodeConfig,
                         channel.getRecordConfiguration(), channel.getSystem(), channel.getSite(),
                         (aliasList != null ? aliasList.getName() : null), p25Config.getTrafficChannelPoolSize()));
                 }


### PR DESCRIPTION
Resolves #228 - traffic channel manager now allocates traffic channels even when the alias is marked as do not monitor