### PR TITLE
Long alias names cause audio label to wrap

### DIFF
--- a/src/audio/AudioChannelPanel.java
+++ b/src/audio/AudioChannelPanel.java
@@ -90,7 +90,8 @@ public class AudioChannelPanel extends JPanel
 
     private void init()
     {
-        setLayout(new MigLayout("align center center, insets 0 0 0 0", "[][][align right]0[grow,fill]", ""));
+        setLayout(new MigLayout("align center center, insets 0 0 0 0",
+            "[][][align right]0[grow,fill]", ""));
         setBackground(mBackgroundColor);
 
         mMutedLabel.setFont(mFont);
@@ -159,29 +160,28 @@ public class AudioChannelPanel extends JPanel
      * does not occur on the Swing event thread -- wrap any calls to this
      * method with an event thread call.
      */
-    private void updateLabel(JLabel valueLabel, String value, JLabel aliasLabel, Alias alias)
+    private void updateLabel(JLabel textLabel, String value, JLabel iconLabel, Alias alias)
     {
         if(value != null)
         {
 
             if(alias != null)
             {
-                valueLabel.setText(alias.getName());
-                aliasLabel.setIcon(mIconManager.getIcon(alias.getIconName(), 18));
+                iconLabel.setIcon(mIconManager.getIcon(alias.getIconName(), 18));
+                textLabel.setText(alias.getName());
             }
             else
             {
-                valueLabel.setText(value);
-                aliasLabel.setIcon(null);
+                iconLabel.setIcon(null);
+                textLabel.setText(value);
             }
         }
         else
         {
-            valueLabel.setText("-----");
-            aliasLabel.setIcon(null);
+            iconLabel.setIcon(null);
+            textLabel.setText("-----");
         }
     }
-
 
     /**
      * Processes audio metadata to update this panel's display values

--- a/src/audio/AudioChannelPanel.java
+++ b/src/audio/AudioChannelPanel.java
@@ -168,7 +168,18 @@ public class AudioChannelPanel extends JPanel
             if(alias != null)
             {
                 iconLabel.setIcon(mIconManager.getIcon(alias.getIconName(), 18));
-                textLabel.setText(alias.getName());
+
+                String aliasName = alias.getName();
+
+                //Truncate label if length exceeds 33 characters - hack!
+                if(aliasName.length() > 33)
+                {
+                    textLabel.setText(aliasName.substring(0,30) + "...");
+                }
+                else
+                {
+                    textLabel.setText(aliasName);
+                }
             }
             else
             {

--- a/src/audio/AudioChannelPanel.java
+++ b/src/audio/AudioChannelPanel.java
@@ -110,7 +110,7 @@ public class AudioChannelPanel extends JPanel
 
         mTo.setFont(mFont);
         mTo.setForeground(mValueColor);
-        add(mTo);
+        add(mTo,"wmin 10lp");
     }
 
     @Override

--- a/src/audio/AudioChannelsPanel.java
+++ b/src/audio/AudioChannelsPanel.java
@@ -33,7 +33,6 @@ public class AudioChannelsPanel extends JPanel
 
     public AudioChannelsPanel(IconManager iconManager, SettingsManager settingsManager, IAudioController controller)
     {
-//        setLayout(new MigLayout("insets 0 0 0 0", "[][grow,fill][][grow,fill]", "[grow,fill]"));
         setLayout(new MigLayout("insets 0 0 0 0", "[][sg,grow,fill][][sg,grow,fill]", "[grow,fill]"));
 
         setBackground(Color.BLACK);

--- a/src/audio/AudioChannelsPanel.java
+++ b/src/audio/AudioChannelsPanel.java
@@ -33,7 +33,7 @@ public class AudioChannelsPanel extends JPanel
 
     public AudioChannelsPanel(IconManager iconManager, SettingsManager settingsManager, IAudioController controller)
     {
-        setLayout(new MigLayout("insets 0 0 0 0", "[][sg,grow,fill][][sg,grow,fill]", "[grow,fill]"));
+        setLayout(new MigLayout("insets 0 0 0 0", "[][sg abc,grow,fill][][sg abc,grow,fill]", "[grow,fill]"));
 
         setBackground(Color.BLACK);
 
@@ -43,7 +43,7 @@ public class AudioChannelsPanel extends JPanel
 
         for(int x = 0; x < outputs.size(); x++)
         {
-            add(new AudioChannelPanel(iconManager, settingsManager, outputs.get(x)), "growx");
+            add(new AudioChannelPanel(iconManager, settingsManager, outputs.get(x)));
 
             if(x < outputs.size() - 1)
             {


### PR DESCRIPTION
Resolves #234 - adjusts layout manager to allow jlabel text truncation.