### PR TITLE
Using sound card or mixer as a source throws an error

### DIFF
--- a/src/module/ProcessingChain.java
+++ b/src/module/ProcessingChain.java
@@ -320,7 +320,13 @@ public class ProcessingChain implements IChannelEventListener
 
         if(module instanceof IFrequencyChangeListener)
         {
-            mFrequencyChangeEventBroadcaster.addListener(((IFrequencyChangeListener) module).getFrequencyChangeListener());
+            Listener<FrequencyChangeEvent> frequencyChangeEventListener =
+                ((IFrequencyChangeListener)module).getFrequencyChangeListener();
+
+            if(frequencyChangeEventListener != null)
+            {
+                mFrequencyChangeEventBroadcaster.addListener(frequencyChangeEventListener);
+            }
         }
 
         if(module instanceof IMessageListener)


### PR DESCRIPTION
Resolves #245 where a NPE is thrown for frequency change event listener when using a sound card/mixer as a signal source.

Sound card sources do not expose a frequency change event listener to allow the signal source to be fine tuned ... feature is only exposed by tuners.
