### PR TITLE
252 USB transfer processor erroneous logging and performance enhancements

### DIFF
--- a/src/sample/OverflowableTransferQueue.java
+++ b/src/sample/OverflowableTransferQueue.java
@@ -124,10 +124,6 @@ public class OverflowableTransferQueue<E>
             mQueue.clear();
             mCounter.set(0);
             mOverflow.set(false);
-            if(mOverflowListener != null)
-            {
-                mOverflowListener.sourceOverflow(false);
-            }
         }
     }
 }


### PR DESCRIPTION
Resolves #252 issue where the tuner's buffer processor is logging that an overflow state has been cleared, caused by a clearing of the buffer when the tuner is being shutdown because there are no more channel consumers registered on the tuner.

Tweaked buffer size limits and buffer handling to attempt to avoid overflow situations in the first place.

Resolved an issue where the tuner processor was not deregistering correctly from the LIBUSB tuner processor during tuner shutdown.