### PR TITLE
249 Channel TEARDOWN/OVERFLOW state lockup

### DIFF
--- a/src/channel/heartbeat/Heartbeat.java
+++ b/src/channel/heartbeat/Heartbeat.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package channel.heartbeat;
+
+public class Heartbeat
+{
+    /**
+     * Periodic pulse that is broadcast to subscribing modules within the demodulating chain so that
+     * monitoring of state and other attributes can occur on the primary demodulation and decoding
+     * thread.
+     */
+    public Heartbeat()
+    {
+    }
+}

--- a/src/channel/heartbeat/IHeartbeatListener.java
+++ b/src/channel/heartbeat/IHeartbeatListener.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package channel.heartbeat;
+
+import sample.Listener;
+
+public interface IHeartbeatListener
+{
+    public Listener<Heartbeat> getHeartbeatListener();
+}

--- a/src/channel/heartbeat/IHeartbeatProvider.java
+++ b/src/channel/heartbeat/IHeartbeatProvider.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package channel.heartbeat;
+
+import sample.Listener;
+
+public interface IHeartbeatProvider
+{
+    public void setHeartbeatListener(Listener<Heartbeat> listener);
+
+    public void removeHeartbeatListener();
+}

--- a/src/module/decode/p25/P25DecoderState.java
+++ b/src/module/decode/p25/P25DecoderState.java
@@ -1713,33 +1713,41 @@ public class P25DecoderState extends DecoderState
                         .build());
                     break;
                 case SNDCP_RF_CONFIRMED_DATA:
-                    SNDCPUserData sud = (SNDCPUserData)pduc;
-
-                    StringBuilder sbFrom = new StringBuilder();
-                    StringBuilder sbTo = new StringBuilder();
-
-                    sbFrom.append(sud.getSourceIPAddress());
-                    sbTo.append(sud.getDestinationIPAddress());
-
-                    if(sud.getIPProtocol() == IPProtocol.UDP)
+                    if(pduc instanceof SNDCPUserData)
                     {
-                        sbFrom.append(":");
-                        sbFrom.append(sud.getUDPSourcePort());
-                        sbTo.append(":");
-                        sbTo.append(sud.getUDPDestinationPort());
+                        SNDCPUserData sud = (SNDCPUserData)pduc;
+
+                        StringBuilder sbFrom = new StringBuilder();
+                        StringBuilder sbTo = new StringBuilder();
+
+                        sbFrom.append(sud.getSourceIPAddress());
+                        sbTo.append(sud.getDestinationIPAddress());
+
+                        if(sud.getIPProtocol() == IPProtocol.UDP)
+                        {
+                            sbFrom.append(":");
+                            sbFrom.append(sud.getUDPSourcePort());
+                            sbTo.append(":");
+                            sbTo.append(sud.getUDPDestinationPort());
+                        }
+
+                        broadcast(new DecoderStateEvent(this, Event.START, State.DATA));
+
+                        broadcast(new P25CallEvent.Builder(CallEventType.DATA_CALL)
+                            .aliasList(getAliasList())
+                            .channel(mCurrentChannel)
+                            .details("DATA: " + sud.getPayload() +
+                                " RADIO IP:" + sbTo.toString())
+                            .frequency(mCurrentChannelFrequency)
+                            .from(sbFrom.toString())
+                            .to(pduc.getLogicalLinkID())
+                            .build());
                     }
-
-                    broadcast(new DecoderStateEvent(this, Event.START, State.DATA));
-
-                    broadcast(new P25CallEvent.Builder(CallEventType.DATA_CALL)
-                        .aliasList(getAliasList())
-                        .channel(mCurrentChannel)
-                        .details("DATA: " + sud.getPayload() +
-                            " RADIO IP:" + sbTo.toString())
-                        .frequency(mCurrentChannelFrequency)
-                        .from(sbFrom.toString())
-                        .to(pduc.getLogicalLinkID())
-                        .build());
+                    else
+                    {
+                        mLog.error("Error - expected SNDCPUserData instance but class was: " + pduc.getClass() +
+                        " and PDU Type:" + pduc.getPDUType().name());
+                    }
                     break;
                 case SNDCP_RF_UNCONFIRMED_DATA:
                     break;

--- a/src/source/Source.java
+++ b/src/source/Source.java
@@ -17,6 +17,7 @@
  ******************************************************************************/
 package source;
 
+import channel.heartbeat.IHeartbeatProvider;
 import module.Module;
 import sample.SampleType;
 import sample.real.IOverflowListener;
@@ -26,7 +27,8 @@ import source.tuner.frequency.IFrequencyChangeProvider;
 /**
  * Abstract class to define the minimum functionality of a sample data provider.
  */
-public abstract class Source extends Module implements IFrequencyChangeListener, IFrequencyChangeProvider
+public abstract class Source extends Module implements IFrequencyChangeListener, IFrequencyChangeProvider,
+    IHeartbeatProvider
 {
     protected SampleType mSampleType;
     protected IOverflowListener mOverflowListener;

--- a/src/source/wave/ComplexWaveSource.java
+++ b/src/source/wave/ComplexWaveSource.java
@@ -18,19 +18,9 @@
  ******************************************************************************/
 package source.wave;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.concurrent.ScheduledExecutorService;
-
-import javax.sound.sampled.AudioFormat;
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.UnsupportedAudioFileException;
-
+import channel.heartbeat.Heartbeat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import sample.ConversionUtils;
 import sample.Listener;
 import sample.complex.ComplexBuffer;
@@ -39,22 +29,31 @@ import source.IControllableFileSource;
 import source.IFrameLocationListener;
 import source.tuner.frequency.FrequencyChangeEvent;
 
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ScheduledExecutorService;
+
 public class ComplexWaveSource extends ComplexSource implements IControllableFileSource
 {
-	private final static Logger mLog = 
-			LoggerFactory.getLogger( ComplexWaveSource.class );
+    private final static Logger mLog =
+        LoggerFactory.getLogger(ComplexWaveSource.class);
 
-	private IFrameLocationListener mFrameLocationListener;
-	private int mBytesPerFrame;
-	private int mFrameCounter = 0;
+    private IFrameLocationListener mFrameLocationListener;
+    private int mBytesPerFrame;
+    private int mFrameCounter = 0;
     private long mFrequency = 0;
     private Listener<ComplexBuffer> mListener;
     private AudioInputStream mInputStream;
     private File mFile;
-    
-    public ComplexWaveSource( File file ) throws IOException 
+
+    public ComplexWaveSource(File file) throws IOException
     {
-    	mFile = file;
+        mFile = file;
     }
 
     @Override
@@ -76,89 +75,105 @@ public class ComplexWaveSource extends ComplexSource implements IControllableFil
         return null;
     }
 
+    /**
+     * Not implemented
+     */
     @Override
-	public void reset()
-	{
-		stop();
-		start( null );
-	}
-
-	@Override
-	public void start( ScheduledExecutorService executor )
-	{
-		try
-		{
-			open();
-		} 
-		catch ( IOException | UnsupportedAudioFileException e )
-		{
-			mLog.error( "Error starting complex wave source" );
-		}
-	}
-
-	@Override
-	public void stop()
-	{
-		try
-		{
-			close();
-		} 
-		catch ( IOException e )
-		{
-			mLog.error( "Error stopping complex wave source" );
-		}
-	}
-
-	@Override
-	public long getFrameCount() throws IOException
-	{
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
-    public int getSampleRate()
+    public void setHeartbeatListener(Listener<Heartbeat> listener)
     {
-		if( mInputStream != null )
-		{
-			return (int)mInputStream.getFormat().getSampleRate();
-		}
-		
-		return 0;
     }
 
-	/**
-	 * Returns the frequency set for this file.  Normally returns zero, but
-	 * the value can be set with setFrequency() method.
-	 */
+    /**
+     * Not implemented
+     */
+    @Override
+    public void removeHeartbeatListener()
+    {
+    }
+
+    @Override
+    public void reset()
+    {
+        stop();
+        start(null);
+    }
+
+    @Override
+    public void start(ScheduledExecutorService executor)
+    {
+        try
+        {
+            open();
+        }
+        catch(IOException | UnsupportedAudioFileException e)
+        {
+            mLog.error("Error starting complex wave source");
+        }
+    }
+
+    @Override
+    public void stop()
+    {
+        try
+        {
+            close();
+        }
+        catch(IOException e)
+        {
+            mLog.error("Error stopping complex wave source");
+        }
+    }
+
+    @Override
+    public long getFrameCount() throws IOException
+    {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
+    public int getSampleRate()
+    {
+        if(mInputStream != null)
+        {
+            return (int)mInputStream.getFormat().getSampleRate();
+        }
+
+        return 0;
+    }
+
+    /**
+     * Returns the frequency set for this file.  Normally returns zero, but
+     * the value can be set with setFrequency() method.
+     */
     public long getFrequency()
     {
-	    return mFrequency;
+        return mFrequency;
     }
 
     /**
      * Changes the value returned from getFrequency() for this source.
      */
-    public void setFrequency( long frequency )
+    public void setFrequency(long frequency)
     {
-    	mFrequency = frequency;
+        mFrequency = frequency;
     }
-    
+
     /**
      * Closes the source file
      */
     public void close() throws IOException
     {
-    	if( mInputStream != null )
-    	{
-        	mInputStream.close();
-    	}
-    	else
-    	{
-    		throw new IOException( "Can't close wave source - was not opened" );
-    	}
-    	
-    	mInputStream = null;
+        if(mInputStream != null)
+        {
+            mInputStream.close();
+        }
+        else
+        {
+            throw new IOException("Can't close wave source - was not opened");
+        }
+
+        mInputStream = null;
     }
 
     /**
@@ -166,121 +181,121 @@ public class ComplexWaveSource extends ComplexSource implements IControllableFil
      */
     public void open() throws IOException, UnsupportedAudioFileException
     {
-    	if( mInputStream == null )
-    	{
-        	mInputStream = AudioSystem.getAudioInputStream( mFile );
-    	}
-    	else
-    	{
-    		throw new IOException( "Can't open wave source - is already opened" );
-    	}
+        if(mInputStream == null)
+        {
+            mInputStream = AudioSystem.getAudioInputStream(mFile);
+        }
+        else
+        {
+            throw new IOException("Can't open wave source - is already opened");
+        }
 
 
         AudioFormat format = mInputStream.getFormat();
-        
+
         mBytesPerFrame = format.getFrameSize();
 
-        if( format.getChannels() != 2 || format.getSampleSizeInBits() != 16 )
+        if(format.getChannels() != 2 || format.getSampleSizeInBits() != 16)
         {
-        	throw new IOException( "Unsupported Wave Format - EXPECTED: 2 " +
-        		"channels 16-bit samples FOUND: " + 
-    			mInputStream.getFormat().getChannels() + " channels " + 
-        		mInputStream.getFormat().getSampleSizeInBits() + "-bit samples" );
+            throw new IOException("Unsupported Wave Format - EXPECTED: 2 " +
+                "channels 16-bit samples FOUND: " +
+                mInputStream.getFormat().getChannels() + " channels " +
+                mInputStream.getFormat().getSampleSizeInBits() + "-bit samples");
         }
 
         /* Broadcast that we're at frame location 0 */
-        broadcast( 0 );
+        broadcast(0);
     }
 
     /**
      * Reads the number of frames and sends a buffer to the listener
      */
-	@Override
-	public void next( int frames ) throws IOException
-	{
-		next( frames, true );
-	}
-
-	/**
-	 * Reads the number of frames and optionally sends the buffer to the listener
-	 */
-    public void next( int frames, boolean broadcast ) throws IOException
+    @Override
+    public void next(int frames) throws IOException
     {
-        if( mInputStream != null )
+        next(frames, true);
+    }
+
+    /**
+     * Reads the number of frames and optionally sends the buffer to the listener
+     */
+    public void next(int frames, boolean broadcast) throws IOException
+    {
+        if(mInputStream != null)
         {
-        	byte[] buffer = new byte[ mBytesPerFrame * frames ];
-        	
+            byte[] buffer = new byte[mBytesPerFrame * frames];
+
         	/* Fill the buffer with samples from the file */
-        	int samplesRead = mInputStream.read( buffer );
+            int samplesRead = mInputStream.read(buffer);
 
-        	mFrameCounter += samplesRead;
-        	
-        	broadcast( mFrameCounter );
-        	
-        	if( broadcast && mListener != null )
-        	{
-            	if( samplesRead < buffer.length )
-            	{
-            		buffer = Arrays.copyOf( buffer, samplesRead );
-            	}
+            mFrameCounter += samplesRead;
 
-            	float[] samples = ConversionUtils
-            			.convertFromSigned16BitSamples( buffer );
-            	
-            	mListener.receive( new ComplexBuffer( samples ) );
-        	}
+            broadcast(mFrameCounter);
+
+            if(broadcast && mListener != null)
+            {
+                if(samplesRead < buffer.length)
+                {
+                    buffer = Arrays.copyOf(buffer, samplesRead);
+                }
+
+                float[] samples = ConversionUtils
+                    .convertFromSigned16BitSamples(buffer);
+
+                mListener.receive(new ComplexBuffer(samples));
+            }
         }
     }
-    
+
     /**
-     * Registers the listener to receive sample buffers as they are read from 
+     * Registers the listener to receive sample buffers as they are read from
      * the wave file
      */
-	@Override
-	public void setListener( Listener<ComplexBuffer> listener )
-	{
-        mListener = listener;
-	}
-
-	/**
-	 * Unregisters the listener from receiving sample buffers
-	 */
-    public void removeListener( Listener<ComplexBuffer> listener )
+    @Override
+    public void setListener(Listener<ComplexBuffer> listener)
     {
-    	mListener = null;
+        mListener = listener;
     }
 
-	@Override
+    /**
+     * Unregisters the listener from receiving sample buffers
+     */
+    public void removeListener(Listener<ComplexBuffer> listener)
+    {
+        mListener = null;
+    }
+
+    @Override
     public void dispose()
     {
-		mListener = null;
+        mListener = null;
     }
 
-	@Override
-	public File getFile()
-	{
-		return mFile;
-	}
+    @Override
+    public File getFile()
+    {
+        return mFile;
+    }
 
-	private void broadcast( int byteLocation )
-	{
-		int frameLocation = (int)( byteLocation / mBytesPerFrame );
-		
-		if( mFrameLocationListener != null )
-		{
-			mFrameLocationListener.frameLocationUpdated( frameLocation );
-		}
-	}
-	
-	@Override
-	public void setListener( IFrameLocationListener listener )
-	{
-		mFrameLocationListener = listener;
-	}
+    private void broadcast(int byteLocation)
+    {
+        int frameLocation = (int)(byteLocation / mBytesPerFrame);
 
-	@Override
-	public void removeListener( IFrameLocationListener listener )
-	{
-		mFrameLocationListener = null;
-	}
+        if(mFrameLocationListener != null)
+        {
+            mFrameLocationListener.frameLocationUpdated(frameLocation);
+        }
+    }
+
+    @Override
+    public void setListener(IFrameLocationListener listener)
+    {
+        mFrameLocationListener = listener;
+    }
+
+    @Override
+    public void removeListener(IFrameLocationListener listener)
+    {
+        mFrameLocationListener = null;
+    }
 }

--- a/src/source/wave/RealWaveSource.java
+++ b/src/source/wave/RealWaveSource.java
@@ -1,35 +1,25 @@
 /*******************************************************************************
  *     SDR Trunk 
  *     Copyright (C) 2014,2015 Dennis Sheirer
- * 
+ *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU General Public License as published by
  *     the Free Software Foundation, either version 3 of the License, or
  *     (at your option) any later version.
- * 
+ *
  *     This program is distributed in the hope that it will be useful,
  *     but WITHOUT ANY WARRANTY; without even the implied warranty of
  *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *     GNU General Public License for more details.
- * 
+ *
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>
  ******************************************************************************/
 package source.wave;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.concurrent.ScheduledExecutorService;
-
-import javax.sound.sampled.AudioFormat;
-import javax.sound.sampled.AudioInputStream;
-import javax.sound.sampled.AudioSystem;
-import javax.sound.sampled.UnsupportedAudioFileException;
-
+import channel.heartbeat.Heartbeat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import sample.ConversionUtils;
 import sample.Listener;
 import sample.real.RealBuffer;
@@ -38,131 +28,154 @@ import source.IFrameLocationListener;
 import source.RealSource;
 import source.tuner.frequency.FrequencyChangeEvent;
 
-public class RealWaveSource extends RealSource 
-	implements IControllableFileSource, AutoCloseable
-{
-	private final static Logger mLog = 
-			LoggerFactory.getLogger( RealWaveSource.class );
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ScheduledExecutorService;
 
-	private IFrameLocationListener mFrameLocationListener;
-	private int mBytesPerFrame;
-	private int mFrameCounter = 0;
+public class RealWaveSource extends RealSource implements IControllableFileSource, AutoCloseable
+{
+    private final static Logger mLog = LoggerFactory.getLogger(RealWaveSource.class);
+
+    private IFrameLocationListener mFrameLocationListener;
+    private int mBytesPerFrame;
+    private int mFrameCounter = 0;
     private long mFrequency = 0;
     private Listener<RealBuffer> mListener;
     private AudioInputStream mInputStream;
     private File mFile;
-    
-    public RealWaveSource( File file ) throws IOException 
+
+    public RealWaveSource(File file) throws IOException
     {
-    	mFile = file;
+        mFile = file;
     }
 
-	@Override
-	public void setFrequencyChangeListener(Listener<FrequencyChangeEvent> listener)
-	{
-		//Not implemented
-	}
+    @Override
+    public void setFrequencyChangeListener(Listener<FrequencyChangeEvent> listener)
+    {
+        //Not implemented
+    }
 
-	@Override
-	public void removeFrequencyChangeListener()
-	{
-		//Not implemented
-	}
+    @Override
+    public void removeFrequencyChangeListener()
+    {
+        //Not implemented
+    }
 
-	@Override
-	public Listener<FrequencyChangeEvent> getFrequencyChangeListener()
-	{
-		//Not implemented
-		return null;
-	}
+    @Override
+    public Listener<FrequencyChangeEvent> getFrequencyChangeListener()
+    {
+        //Not implemented
+        return null;
+    }
 
+    /**
+     * Not implemented
+     */
+    @Override
+    public void setHeartbeatListener(Listener<Heartbeat> listener)
+    {
+    }
 
-	@Override
-	public void reset()
-	{
-		stop();
-		start( null );
-	}
-
-
-	@Override
-	public void start( ScheduledExecutorService executor )
-	{
-		try
-		{
-			open();
-		} 
-		catch ( IOException | UnsupportedAudioFileException e )
-		{
-			mLog.error( "Error starting real wave source", e );
-		}
-	}
+    /**
+     * Not implemented
+     */
+    @Override
+    public void removeHeartbeatListener()
+    {
+    }
 
 
-	@Override
-	public void stop()
-	{
-		try
-		{
-			close();
-		} 
-		catch ( IOException e )
-		{
-			mLog.error( "Error stopping real wave source", e );
-		}
-	}
+    @Override
+    public void reset()
+    {
+        stop();
+        start(null);
+    }
 
 
-	@Override
-	public long getFrameCount() throws IOException
-	{
-		// TODO Auto-generated method stub
-		return 0;
-	}
+    @Override
+    public void start(ScheduledExecutorService executor)
+    {
+        try
+        {
+            open();
+        }
+        catch(IOException | UnsupportedAudioFileException e)
+        {
+            mLog.error("Error starting real wave source", e);
+        }
+    }
 
-	@Override
+
+    @Override
+    public void stop()
+    {
+        try
+        {
+            close();
+        }
+        catch(IOException e)
+        {
+            mLog.error("Error stopping real wave source", e);
+        }
+    }
+
+
+    @Override
+    public long getFrameCount() throws IOException
+    {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+
+    @Override
     public int getSampleRate()
     {
-		if( mInputStream != null )
-		{
-			return (int)mInputStream.getFormat().getSampleRate();
-		}
-		
-		return 0;
+        if(mInputStream != null)
+        {
+            return (int)mInputStream.getFormat().getSampleRate();
+        }
+
+        return 0;
     }
 
-	/**
-	 * Returns the frequency set for this file.  Normally returns zero, but
-	 * the value can be set with setFrequency() method.
-	 */
+    /**
+     * Returns the frequency set for this file.  Normally returns zero, but
+     * the value can be set with setFrequency() method.
+     */
     public long getFrequency()
     {
-	    return mFrequency;
+        return mFrequency;
     }
 
     /**
      * Changes the value returned from getFrequency() for this source.
      */
-    public void setFrequency( long frequency )
+    public void setFrequency(long frequency)
     {
-    	mFrequency = frequency;
+        mFrequency = frequency;
     }
-    
+
     /**
      * Closes the source file
      */
     public void close() throws IOException
     {
-    	if( mInputStream != null )
-    	{
-        	mInputStream.close();
-    	}
-    	else
-    	{
-    		throw new IOException( "Can't close wave source - was not opened" );
-    	}
-    	
-    	mInputStream = null;
+        if(mInputStream != null)
+        {
+            mInputStream.close();
+        }
+        else
+        {
+            throw new IOException("Can't close wave source - was not opened");
+        }
+
+        mInputStream = null;
     }
 
     /**
@@ -170,126 +183,126 @@ public class RealWaveSource extends RealSource
      */
     public void open() throws IOException, UnsupportedAudioFileException
     {
-    	if( mInputStream == null )
-    	{
-        	mInputStream = AudioSystem.getAudioInputStream( mFile );
-    	}
-    	else
-    	{
-    		throw new IOException( "Can't open wave source - is already opened" );
-    	}
+        if(mInputStream == null)
+        {
+            mInputStream = AudioSystem.getAudioInputStream(mFile);
+        }
+        else
+        {
+            throw new IOException("Can't open wave source - is already opened");
+        }
 
 
         AudioFormat format = mInputStream.getFormat();
-        
+
         mBytesPerFrame = format.getFrameSize();
 
-        if( format.getChannels() != 1 || format.getSampleSizeInBits() != 16 )
+        if(format.getChannels() != 1 || format.getSampleSizeInBits() != 16)
         {
-        	throw new IOException( "Unsupported Wave Format - EXPECTED: 1 " +
-        		"channel 16-bit samples FOUND: " + 
-    			mInputStream.getFormat().getChannels() + " channels " + 
-        		mInputStream.getFormat().getSampleSizeInBits() + "-bit samples" );
+            throw new IOException("Unsupported Wave Format - EXPECTED: 1 " +
+                "channel 16-bit samples FOUND: " +
+                mInputStream.getFormat().getChannels() + " channels " +
+                mInputStream.getFormat().getSampleSizeInBits() + "-bit samples");
         }
         
         /* Broadcast that we're at frame location 0 */
-        broadcast( 0 );
+        broadcast(0);
     }
 
     /**
      * Reads the number of frames and sends a buffer to the listener
      */
-	@Override
-	public void next( int frames ) throws IOException
-	{
-		next( frames, true );
-	}
-
-	/**
-	 * Reads the number of frames and optionally sends the buffer to the listener
-	 */
-    public void next( int frames, boolean broadcast ) throws IOException
+    @Override
+    public void next(int frames) throws IOException
     {
-        if( mInputStream != null )
-        {
-        	byte[] buffer = new byte[ mBytesPerFrame * frames ];
-        	
-        	/* Fill the buffer with samples from the file */
-        	int samplesRead = mInputStream.read( buffer );
-        	
-        	mFrameCounter += samplesRead;
-        	
-        	broadcast( mFrameCounter );
-        	
-        	if( broadcast && mListener != null )
-        	{
-            	if( samplesRead < buffer.length )
-            	{
-            		if( samplesRead == -1 )
-            		{
-            			throw new IOException( "End of recording" );
-            		}
-            		
-            		buffer = Arrays.copyOf( buffer, samplesRead );
-            	}
+        next(frames, true);
+    }
 
-            	float[] samples = ConversionUtils
-            			.convertFromSigned16BitSamples( buffer );
-            	
-            	mListener.receive( new RealBuffer( samples ) );
-        	}
+    /**
+     * Reads the number of frames and optionally sends the buffer to the listener
+     */
+    public void next(int frames, boolean broadcast) throws IOException
+    {
+        if(mInputStream != null)
+        {
+            byte[] buffer = new byte[mBytesPerFrame * frames];
+
+        	/* Fill the buffer with samples from the file */
+            int samplesRead = mInputStream.read(buffer);
+
+            mFrameCounter += samplesRead;
+
+            broadcast(mFrameCounter);
+
+            if(broadcast && mListener != null)
+            {
+                if(samplesRead < buffer.length)
+                {
+                    if(samplesRead == -1)
+                    {
+                        throw new IOException("End of recording");
+                    }
+
+                    buffer = Arrays.copyOf(buffer, samplesRead);
+                }
+
+                float[] samples = ConversionUtils
+                    .convertFromSigned16BitSamples(buffer);
+
+                mListener.receive(new RealBuffer(samples));
+            }
         }
     }
-    
+
     /**
-     * Registers the listener to receive sample buffers as they are read from 
+     * Registers the listener to receive sample buffers as they are read from
      * the wave file
      */
-	@Override
-	public void setListener( Listener<RealBuffer> listener )
-	{
-        mListener = listener;
-	}
-
-	/**
-	 * Unregisters the listener from receiving sample buffers
-	 */
-    public void removeListener( Listener<RealBuffer> listener )
+    @Override
+    public void setListener(Listener<RealBuffer> listener)
     {
-    	mListener = null;
+        mListener = listener;
     }
 
-	@Override
+    /**
+     * Unregisters the listener from receiving sample buffers
+     */
+    public void removeListener(Listener<RealBuffer> listener)
+    {
+        mListener = null;
+    }
+
+    @Override
     public void dispose()
     {
-		mListener = null;
+        mListener = null;
     }
 
-	@Override
-	public File getFile()
-	{
-		return mFile;
-	}
-	
-	private void broadcast( int byteLocation )
-	{
-		int frameLocation = (int)( byteLocation / mBytesPerFrame );
-		
-		if( mFrameLocationListener != null )
-		{
-			mFrameLocationListener.frameLocationUpdated( frameLocation );
-		}
-	}
-	
-	@Override
-	public void setListener( IFrameLocationListener listener )
-	{
-		mFrameLocationListener = listener;
-	}
+    @Override
+    public File getFile()
+    {
+        return mFile;
+    }
 
-	@Override
-	public void removeListener( IFrameLocationListener listener )
-	{
-		mFrameLocationListener = null;
-	}
+    private void broadcast(int byteLocation)
+    {
+        int frameLocation = (int)(byteLocation / mBytesPerFrame);
+
+        if(mFrameLocationListener != null)
+        {
+            mFrameLocationListener.frameLocationUpdated(frameLocation);
+        }
+    }
+
+    @Override
+    public void setListener(IFrameLocationListener listener)
+    {
+        mFrameLocationListener = listener;
+    }
+
+    @Override
+    public void removeListener(IFrameLocationListener listener)
+    {
+        mFrameLocationListener = null;
+    }
 }


### PR DESCRIPTION
Resolves #249 - removes the state monitor runnable from the channel state and replaces it with a processing chain heartbeat that is generated by the sample source.

Previously, the state monitor was running on a separate thread and this was causing multi-threading issues.  With this update, all channel state operations (and all module operations) occur on the source's buffer processing thread.