### PR TITLE
299 Traffic Channel Event Logging

### DIFF
--- a/src/channel/traffic/TrafficChannelManager.java
+++ b/src/channel/traffic/TrafficChannelManager.java
@@ -18,8 +18,6 @@
  ******************************************************************************/
 package channel.traffic;
 
-import alias.Alias;
-import alias.id.priority.Priority;
 import channel.state.DecoderStateEvent;
 import channel.state.IDecoderStateEventListener;
 import controller.channel.Channel;
@@ -27,13 +25,13 @@ import controller.channel.Channel.ChannelType;
 import controller.channel.ChannelEvent;
 import controller.channel.ChannelEvent.Event;
 import controller.channel.ChannelModel;
-import controller.channel.ChannelProcessingManager;
 import controller.channel.TrafficChannelEvent;
 import module.Module;
 import module.decode.config.DecodeConfiguration;
 import module.decode.event.CallEvent;
 import module.decode.event.CallEvent.CallEventType;
 import module.decode.event.ICallEventProvider;
+import module.log.config.EventLogConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import record.config.RecordConfiguration;
@@ -64,6 +62,7 @@ public class TrafficChannelManager extends Module implements ICallEventProvider,
 
     private ChannelModel mChannelModel;
     private DecodeConfiguration mDecodeConfiguration;
+    private EventLogConfiguration mEventLogConfiguration;
     private RecordConfiguration mRecordConfiguration;
     private String mSystem;
     private String mSite;
@@ -77,6 +76,7 @@ public class TrafficChannelManager extends Module implements ICallEventProvider,
      * @param channelModel containing channels currently in use
      * @param decodeConfiguration - decoder configuration to use for each
      * traffic channel allocation.
+     * @param eventLogConfiguration - logging configuration to use for traffic channels
      * @param recordConfiguration - recording options for each traffic channel
      * @param system label to use to describe the system
      * @param site label to use to describe the site
@@ -86,6 +86,7 @@ public class TrafficChannelManager extends Module implements ICallEventProvider,
      */
     public TrafficChannelManager(ChannelModel channelModel,
                                  DecodeConfiguration decodeConfiguration,
+                                 EventLogConfiguration eventLogConfiguration,
                                  RecordConfiguration recordConfiguration,
                                  String system,
                                  String site,
@@ -94,6 +95,7 @@ public class TrafficChannelManager extends Module implements ICallEventProvider,
     {
         mChannelModel = channelModel;
         mDecodeConfiguration = decodeConfiguration;
+        mEventLogConfiguration = eventLogConfiguration;
         mRecordConfiguration = recordConfiguration;
         mSystem = system;
         mSite = site;
@@ -148,6 +150,8 @@ public class TrafficChannelManager extends Module implements ICallEventProvider,
                 channel = new Channel("Traffic", ChannelType.TRAFFIC);
 
                 channel.setDecodeConfiguration(mDecodeConfiguration);
+
+                channel.setEventLogConfiguration(mEventLogConfiguration);
 
                 channel.setRecordConfiguration(mRecordConfiguration);
 

--- a/src/module/decode/DecoderFactory.java
+++ b/src/module/decode/DecoderFactory.java
@@ -222,7 +222,7 @@ public class DecoderFactory
 
                 if(channelType == ChannelType.STANDARD)
                 {
-                    modules.add(new TrafficChannelManager(channelModel, decodeConfig,
+                    modules.add(new TrafficChannelManager(channelModel, decodeConfig, channel.getEventLogConfiguration(),
                         channel.getRecordConfiguration(), channel.getSystem(), channel.getSite(),
                         (aliasList != null ? aliasList.getName() : null), mptConfig.getTrafficChannelPoolSize()));
                 }
@@ -263,7 +263,7 @@ public class DecoderFactory
 
                 if(channelType == ChannelType.STANDARD)
                 {
-                    modules.add(new TrafficChannelManager(channelModel, decodeConfig,
+                    modules.add(new TrafficChannelManager(channelModel, decodeConfig, channel.getEventLogConfiguration(),
                         channel.getRecordConfiguration(), channel.getSystem(), channel.getSite(),
                         (aliasList != null ? aliasList.getName() : null), p25Config.getTrafficChannelPoolSize()));
                 }

--- a/src/module/log/EventLogManager.java
+++ b/src/module/log/EventLogManager.java
@@ -1,33 +1,38 @@
 /*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * sdrtrunk
+ * Copyright (C) 2014-2017 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
  ******************************************************************************/
 package module.log;
+
+import module.Module;
+import module.log.MessageEventLogger.Type;
+import module.log.config.EventLogConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import properties.SystemProperties;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import module.Module;
-import module.log.MessageEventLogger.Type;
-import module.log.config.EventLogConfiguration;
-import properties.SystemProperties;
-
 public class EventLogManager
 {
+	private final static Logger mLog = LoggerFactory.getLogger(EventLogManager.class);
+
 	private Path mDirectory;
 	
 	public EventLogManager()

--- a/src/module/log/EventLogger.java
+++ b/src/module/log/EventLogger.java
@@ -80,8 +80,6 @@ public abstract class EventLogger extends Module
 
                 mLogFileName = sb.toString();
 
-                mLog.info("Creating log file:" + mLogFileName);
-
                 mLogFile = new OutputStreamWriter(new FileOutputStream(mLogFileName));
 
                 write(getHeader());
@@ -125,14 +123,17 @@ public abstract class EventLogger extends Module
 
     protected void write(String eventLogEntry)
     {
-        try
+        if(mLogFile != null)
         {
-            mLogFile.write(eventLogEntry + "\n");
-            mLogFile.flush();
-        }
-        catch(IOException e)
-        {
-            mLog.error("Error writing entry to event log file", e);
+            try
+            {
+                mLogFile.write(eventLogEntry + "\n");
+                mLogFile.flush();
+            }
+            catch(IOException e)
+            {
+                mLog.error("Error writing entry to event log file", e);
+            }
         }
     }
 }


### PR DESCRIPTION
#299 - adds support for traffic channel event logging of binary or decoded messages and event logging, as inherited from the parent control channel's configuration.