### PR TITLE
336 - Audio recording temporary file name

### DIFF
--- a/src/main/java/io/github/dsheirer/record/RecorderManager.java
+++ b/src/main/java/io/github/dsheirer/record/RecorderManager.java
@@ -93,6 +93,7 @@ public class RecorderManager implements Listener<AudioPacket>
 
     /**
      * Primary ingest point for audio packets from all decoding channels
+     *
      * @param audioPacket to process
      */
     @Override
@@ -115,7 +116,7 @@ public class RecorderManager implements Listener<AudioPacket>
 
         while(!audioPackets.isEmpty())
         {
-            for(AudioPacket audioPacket: audioPackets)
+            for(AudioPacket audioPacket : audioPackets)
             {
                 String identifier = audioPacket.getMetadata().getUniqueIdentifier();
 

--- a/src/main/java/io/github/dsheirer/record/wave/AudioPacketWaveRecorder.java
+++ b/src/main/java/io/github/dsheirer/record/wave/AudioPacketWaveRecorder.java
@@ -104,7 +104,7 @@ public class AudioPacketWaveRecorder extends Module implements Listener<AudioPac
                 sb.append(mFilePrefix);
                 sb.append("_");
                 sb.append(TimeStamp.getLongTimeStamp("_"));
-                sb.append(".wav");
+                sb.append(".tmp");
 
                 mFile = Paths.get(sb.toString());
 


### PR DESCRIPTION
Resolves #336.  Updates audio recorder to use a *.tmp file extension while the file is open/in-use and change the file extension to *.wav when the recording is closed.

This change allows better monitoring of audio recording file creation/completion events.