### PR TITLE
344 Add AGC to P25 C4FM decoder

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/psk/InterpolatingSampleBuffer.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/InterpolatingSampleBuffer.java
@@ -130,7 +130,7 @@ public class InterpolatingSampleBuffer
      */
     public Complex getPrecedingSample()
     {
-        mPrecedingSample.setValues(mDelayLineInphase[mDelayLinePointer + 4], mDelayLineQuadrature[mDelayLinePointer + 3]);
+        mPrecedingSample.setValues(mDelayLineInphase[mDelayLinePointer + 3], mDelayLineQuadrature[mDelayLinePointer + 3]);
         return mPrecedingSample;
     }
 


### PR DESCRIPTION
Adds automatic gain control to P25 C4FM decoder to condition the samples prior to interpolation.

Resolves issue with using incorrect quadrature index when pulling a
sample from the interpolating buffer.

Resolves issue where the instrumented version of the interpolating
buffer was being constructed in the non-interpolated decoder component.