### PR TITLE
Resolved #370 Tuner Editor Lock State

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerEditor.java
@@ -21,6 +21,7 @@ import io.github.dsheirer.gui.control.JFrequencyControl;
 import io.github.dsheirer.gui.editor.Editor;
 import io.github.dsheirer.gui.editor.EmptyEditor;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
+import io.github.dsheirer.source.tuner.configuration.TunerConfigurationEditor;
 import io.github.dsheirer.source.tuner.configuration.TunerConfigurationFactory;
 import io.github.dsheirer.source.tuner.configuration.TunerConfigurationModel;
 import net.miginfocom.swing.MigLayout;
@@ -64,6 +65,22 @@ public class TunerEditor extends Editor<Tuner>
     {
         mTunerConfigurationModel = tunerConfigurationModel;
         init();
+    }
+
+    /**
+     * Updates the lock state of the tuner so that the frequency control and sample rate controls
+     * can be adjusted accordingly.
+     *
+     * @param locked true if the tuner is locked and the controls should be locked.
+     */
+    public void setTunerLockState(boolean locked)
+    {
+        mFrequencyControl.setEnabled(!locked);
+
+        if(mEditor instanceof TunerConfigurationEditor)
+        {
+            ((TunerConfigurationEditor)mEditor).setTunerLockState(locked);
+        }
     }
 
     public void init()

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerViewPanel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerViewPanel.java
@@ -100,12 +100,20 @@ public class TunerViewPanel extends JPanel
                 switch(tunerEvent.getEvent())
                 {
                     case LOCK_STATE_CHANGE:
-                        int row = mTunerTable.getSelectedRow();
-
-                        if(row >= 0)
+                        if(tunerEvent.getTuner() != null)
                         {
-                            int modelRow = mTunerTable.convertRowIndexToModel(row);
-                            mTunerEditor.setItem(mTunerModel.getTuner(modelRow));
+                            int row = mTunerTable.getSelectedRow();
+
+                            if(row >= 0)
+                            {
+                                int modelRow = mTunerTable.convertRowIndexToModel(row);
+                                Tuner selectedTuner = mTunerModel.getTuner(modelRow);
+
+                                if(selectedTuner == tunerEvent.getTuner())
+                                {
+                                    mTunerEditor.setTunerLockState(selectedTuner.getTunerController().isLocked());
+                                }
+                            }
                         }
                         break;
                 }

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
@@ -611,6 +611,12 @@ public class AirspyTunerEditor extends TunerConfigurationEditor
         }
     }
 
+    @Override
+    public void setTunerLockState(boolean locked)
+    {
+        mSampleRateCombo.setEnabled(!locked);
+    }
+
     /**
      * Sets all controls to the argument enabled state
      */

--- a/src/main/java/io/github/dsheirer/source/tuner/configuration/TunerConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/configuration/TunerConfigurationEditor.java
@@ -32,4 +32,12 @@ public abstract class TunerConfigurationEditor extends Editor<TunerConfiguration
     {
         return mTunerConfigurationModel;
     }
+
+    /**
+     * Sets the lock state for the tuner so that the frequency and sample rate controls can be
+     * enabled/disabled.
+     *
+     * @param locked true if the tuner is locked.
+     */
+    public abstract void setTunerLockState(boolean locked);
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerEditor.java
@@ -303,6 +303,12 @@ public class FCD1TunerEditor extends TunerConfigurationEditor
         add(mCorrectionPhase);
     }
 
+    @Override
+    public void setTunerLockState(boolean locked)
+    {
+        //no-op
+    }
+
     /**
      * Sets each of the tuner configuration controls to the enabled argument state
      */

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerEditor.java
@@ -207,6 +207,12 @@ public class FCD2TunerEditor extends TunerConfigurationEditor
         add(mMixerGain);
     }
 
+    @Override
+    public void setTunerLockState(boolean locked)
+    {
+        //no-op
+    }
+
     /**
      * Sets each of the tuner configuration controls to the enabled argument state
      */

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
@@ -298,6 +298,12 @@ public class HackRFTunerEditor extends TunerConfigurationEditor
         }
     }
 
+    @Override
+    public void setTunerLockState(boolean locked)
+    {
+        mComboSampleRate.setEnabled(!locked);
+    }
+
     /**
      * Sets each of the tuner configuration controls to the enabled argument state
      */

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
@@ -355,6 +355,13 @@ public class E4KTunerEditor extends TunerConfigurationEditor
         }
     }
 
+    @Override
+    public void setTunerLockState(boolean locked)
+    {
+        mComboSampleRate.setEnabled(!locked);
+    }
+
+
     /**
      * Sets each of the tuner configuration controls to the enabled argument state
      */

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerEditor.java
@@ -409,6 +409,12 @@ public class R820TTunerEditor extends TunerConfigurationEditor
         }
     }
 
+    @Override
+    public void setTunerLockState(boolean locked)
+    {
+        mComboSampleRate.setEnabled(!locked);
+    }
+
     /**
      * Sets each of the tuner configuration controls to the enabled argument state
      */


### PR DESCRIPTION
Resolves an issue with the previous implementation where the tuner
editor was being refreshed repeatedly to update the lock state for the
tuner, rendering the editor almost completely unusable.

Now updates only the frequency control and the sample rate control to
reflect the tuner's lock state.