### PR TITLE
374 RTL Tuner Sample Rates Not Supported (1.44 & 2.88 MHz)

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
@@ -314,7 +314,7 @@ public class PolyphaseChannelManager implements ISourceEventProcessor
             case NOTIFICATION_SAMPLE_RATE_CHANGE:
                 //Update channel calculator immediately so that channels can be allocated
                 double sampleRate = sourceEvent.getValue().doubleValue();
-                int channelCount = (int)Math.ceil(sampleRate / MINIMUM_CHANNEL_BANDWIDTH);
+                int channelCount = ComplexPolyphaseChannelizerM2.getChannelCount(sampleRate);
                 mChannelCalculator.setRates(sampleRate, channelCount);
                 break;
             case NOTIFICATION_FREQUENCY_AND_SAMPLE_RATE_LOCKED:


### PR DESCRIPTION
Updates polyphase channel manager to correctly calculate the number of channels for each sample rate change.

Resolves #374