### PR TITLE
381 Adaptive USB Transfer Buffer Sizes for RTL2832 Tuners

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -52,7 +52,8 @@ public abstract class RTL2832TunerController extends USBTunerController
 
     public final static int TWO_TO_22_POWER = 4194304;
 
-    public final static int USB_TRANSFER_BUFFER_SIZE = 131072;
+    public final static int USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE = 131072;
+    public final static int USB_TRANSFER_BUFFER_SIZE_LOW_SAMPLE_RATE = 32768;
     public final static byte USB_INTERFACE = (byte) 0x0;
     public final static byte CONTROL_ENDPOINT_IN = (byte) (LibUsb.ENDPOINT_IN | LibUsb.REQUEST_TYPE_VENDOR);
     public final static byte CONTROL_ENDPOINT_OUT = (byte) (LibUsb.ENDPOINT_OUT | LibUsb.REQUEST_TYPE_VENDOR);
@@ -155,7 +156,7 @@ public abstract class RTL2832TunerController extends USBTunerController
         String deviceName = getTunerType().getLabel() + " " + getUniqueID();
 
         mUSBTransferProcessor = new RTL2832USBTransferProcessor(deviceName, mDeviceHandle, mNativeBufferConverter,
-            USB_TRANSFER_BUFFER_SIZE);
+            USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE);
     }
 
     @Override
@@ -985,6 +986,18 @@ public abstract class RTL2832TunerController extends USBTunerController
         mSampleRate = sampleRate;
 
         mFrequencyController.setSampleRate(sampleRate.getRate());
+
+        if(mUSBTransferProcessor != null)
+        {
+            if(sampleRate.getRate() > 300000)
+            {
+                mUSBTransferProcessor.setBufferSize(USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE);
+            }
+            else
+            {
+                mUSBTransferProcessor.setBufferSize(USB_TRANSFER_BUFFER_SIZE_LOW_SAMPLE_RATE);
+            }
+        }
     }
 
     public void setSampleRateFrequencyCorrection(int ppm) throws SourceException

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerController.java
@@ -253,7 +253,7 @@ public class E4KTunerController extends RTL2832TunerController
         String deviceName = getTunerType().getLabel() + " " + getUniqueID();
 
         mUSBTransferProcessor = new RTL2832USBTransferProcessor(deviceName, mDeviceHandle, mNativeBufferConverter,
-            USB_TRANSFER_BUFFER_SIZE);
+            USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE);
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/usb/USBTransferProcessor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/usb/USBTransferProcessor.java
@@ -87,6 +87,32 @@ public class USBTransferProcessor implements TransferCallback
     }
 
     /**
+     * Modifies the usb transfer buffer size used for transfering native byte buffers from the
+     * USB device.  Note: changing the buffer size while the transfer processor is running causes
+     * the transfer to stop momentarily while the existing buffers are destroyed and new buffers
+     * with the correct size are recreated.
+     *
+     * Note: this method is not thread safe.  Ensure that no other threads invoke stop() or start()
+     * while a buffer size change is in progress.
+     *
+     * @param bufferSize to use for native usb buffer transfers
+     */
+    public void setBufferSize(int bufferSize)
+    {
+        if(bufferSize % 2 == 1)
+        {
+            throw new IllegalArgumentException("Buffer size must be a multiple of 2 for complex samples");
+        }
+
+        if(mBufferSize != bufferSize)
+        {
+            stop();
+            mBufferSize = bufferSize;
+            start();
+        }
+    }
+
+    /**
      * Start USB transfer buffer processing.  Subsequent calls to this method after started will be ignored.
      */
     private void start()


### PR DESCRIPTION
Resolves #381.  Updates USB transfer processor to use native transfer
buffer sizes that adapt to the selected sample rate.

This was previously causing choppy buffer processing (and choppy audio output) when the RTL tuner was running at sample rates below 300 kHz.

