### PR TITLE
372 Icecast Streaming Reconnect and Metadata Updates

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/AudioBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/AudioBroadcaster.java
@@ -245,7 +245,11 @@ public abstract class AudioBroadcaster implements Listener<AudioRecording>
     {
         if(mBroadcastState != state)
         {
-            mLog.info("[" + getStreamName() + "] status: " + state);
+            if(state == BroadcastState.CONNECTED || state == BroadcastState.DISCONNECTED)
+            {
+                mLog.info("[" + getStreamName() + "] status: " + state);
+            }
+
             mBroadcastState = state;
 
             broadcast(new BroadcastEvent(this, BroadcastEvent.Event.BROADCASTER_STATE_CHANGE));

--- a/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastState.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastState.java
@@ -71,6 +71,11 @@ public enum BroadcastState
     MOUNT_POINT_IN_USE("Mount Point In Use", false),
 
     /**
+     * Network is unavailable or the server address cannot be resolved
+     */
+    NETWORK_UNAVAILABLE("Network Unavailable", false),
+
+    /**
      * Server is not known or reachable
      */
     NO_SERVER("No Server", false),

--- a/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastStatusPanel.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastStatusPanel.java
@@ -20,9 +20,14 @@ package io.github.dsheirer.audio.broadcast;
 
 import net.miginfocom.swing.MigLayout;
 
-import javax.swing.*;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingConstants;
 import javax.swing.table.DefaultTableCellRenderer;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Component;
 
 public class BroadcastStatusPanel extends JPanel
 {
@@ -96,7 +101,8 @@ public class BroadcastStatusPanel extends JPanel
                         setBackground(table.getBackground());
                         setForeground(Color.LIGHT_GRAY);
                     }
-                    else if(state == BroadcastState.INVALID_SETTINGS)
+                    else if(state == BroadcastState.INVALID_SETTINGS ||
+                            state == BroadcastState.NETWORK_UNAVAILABLE)
                     {
                         setBackground(Color.YELLOW);
                         setForeground(table.getForeground());


### PR DESCRIPTION
Resolves #372 - Icecast reconnect following network outage.  Updates
the lost connection timeout from default of 60 seconds down to 5 seconds
so that the connection state updates more quickly.  Removed complex
error handling and replaced with a simpler approach to catch an error
and disconnect and then attempt a reconnect.

Added new 'Network Unavailable' error state that detects when the network
connection is unavaialable.

Updated the icecast metadata updater to close the TCP session after
successfully writing metadata to the socket.