### PR TITLE
394 P25 bit stream output

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/symbol/DibitToByteBufferAssembler.java
+++ b/src/main/java/io/github/dsheirer/dsp/symbol/DibitToByteBufferAssembler.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * sdr-trunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License  along with this program.
+ * If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package io.github.dsheirer.dsp.symbol;
+
+import io.github.dsheirer.sample.Listener;
+import io.github.dsheirer.sample.buffer.IReusableByteBufferProvider;
+import io.github.dsheirer.sample.buffer.ReusableByteBuffer;
+import io.github.dsheirer.sample.buffer.ReusableByteBufferQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Assembles reusable byte buffers from an incoming stream of Dibits.
+ */
+public class DibitToByteBufferAssembler implements Listener<Dibit>, IReusableByteBufferProvider
+{
+    private final static Logger mLog = LoggerFactory.getLogger(DibitToByteBufferAssembler.class);
+
+    private ReusableByteBufferQueue mBufferQueue = new ReusableByteBufferQueue("DibitToByteBufferAssembler");
+    private ReusableByteBuffer mCurrentBuffer;
+    private int mBufferPointer;
+    private int mBufferSize;
+    private byte mCurrentByte;
+    private int mDibitCount;
+    private Listener<ReusableByteBuffer> mBufferListener;
+
+    /**
+     * Constructs an assembler to produce reusable byte buffers of the specified size
+     *
+     * @param bufferSize
+     */
+    public DibitToByteBufferAssembler(int bufferSize)
+    {
+        mBufferSize = bufferSize;
+        getNextBuffer();
+    }
+
+    /**
+     * Broadcasts the current buffer to the registered listener and creates a new buffer, resetting
+     * the buffer pointer to zero so that new dibits can be loaded.
+     */
+    private void getNextBuffer()
+    {
+        if(mCurrentBuffer != null && mBufferListener != null)
+        {
+            mBufferListener.receive(mCurrentBuffer);
+        }
+
+        mCurrentBuffer = mBufferQueue.getBuffer(mBufferSize);
+        mBufferPointer = 0;
+    }
+
+    @Override
+    public void receive(Dibit dibit)
+    {
+        mCurrentByte <<= 2;
+
+        switch(dibit)
+        {
+            case D01_PLUS_3:
+                mCurrentByte |= 0x01;
+                break;
+            case D00_PLUS_1:
+                //no-op - value is already 00
+                break;
+            case D10_MINUS_1:
+                mCurrentByte |= 0x02;
+                break;
+            case D11_MINUS_3:
+                mCurrentByte |= 0x03;
+                break;
+        }
+
+        mDibitCount++;
+
+        if(mDibitCount >= 4)
+        {
+            mCurrentBuffer.getBytes()[mBufferPointer++] = mCurrentByte;
+            mCurrentByte = 0x00;
+            mDibitCount = 0;
+
+            if(mBufferPointer >= mBufferSize)
+            {
+                getNextBuffer();
+            }
+        }
+    }
+
+    /**
+     * Registers the listener to receive fully assembled byte buffers from this assembler.
+     */
+    @Override
+    public void setBufferListener(Listener<ReusableByteBuffer> listener)
+    {
+        mBufferListener = listener;
+    }
+
+    /**
+     * Removes the listener from receiving buffers from this assembler
+     */
+    @Override
+    public void removeBufferListener(Listener<ReusableByteBuffer> listener)
+    {
+        mBufferListener = null;
+    }
+
+    @Override
+    public boolean hasBufferListeners()
+    {
+        return mBufferListener != null;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
@@ -476,9 +476,6 @@ public class DecoderFactory
      */
     public static EnumSet<DecoderType> getBitstreamDecoders()
     {
-//        return EnumSet.of(DecoderType.P25_PHASE1);
-
-        //None of the decoders currently support bitstream output.
-        return EnumSet.noneOf(DecoderType.class);
+        return EnumSet.of(DecoderType.P25_PHASE1);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25Decoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25Decoder.java
@@ -16,19 +16,25 @@
 package io.github.dsheirer.module.decode.p25;
 
 import io.github.dsheirer.alias.AliasList;
+import io.github.dsheirer.dsp.symbol.DibitToByteBufferAssembler;
 import io.github.dsheirer.module.decode.Decoder;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.sample.Listener;
+import io.github.dsheirer.sample.buffer.IReusableByteBufferListener;
+import io.github.dsheirer.sample.buffer.IReusableByteBufferProvider;
 import io.github.dsheirer.sample.buffer.IReusableComplexBufferListener;
+import io.github.dsheirer.sample.buffer.ReusableByteBuffer;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
 import io.github.dsheirer.source.ISourceEventListener;
 import io.github.dsheirer.source.ISourceEventProvider;
 import io.github.dsheirer.source.SourceEvent;
 
-public abstract class P25Decoder extends Decoder implements ISourceEventListener, ISourceEventProvider,
-    IReusableComplexBufferListener, Listener<ReusableComplexBuffer>
+public abstract class P25Decoder extends Decoder
+    implements ISourceEventListener, ISourceEventProvider, IReusableComplexBufferListener, Listener<ReusableComplexBuffer>,
+    IReusableByteBufferProvider, IReusableByteBufferListener
 {
     private double mSampleRate;
+    private DibitToByteBufferAssembler mByteBufferAssembler = new DibitToByteBufferAssembler(300);
     private P25MessageProcessor mMessageProcessor;
     private AliasList mAliasList;
     private Listener<SourceEvent> mSourceEventListener;
@@ -40,6 +46,41 @@ public abstract class P25Decoder extends Decoder implements ISourceEventListener
         mAliasList = aliasList;
         mMessageProcessor = new P25MessageProcessor(mAliasList);
         mMessageProcessor.setMessageListener(getMessageListener());
+    }
+
+    /**
+     * Assembler for packaging Dibit stream into reusable byte buffers.
+     */
+    protected DibitToByteBufferAssembler getByteBufferAssembler()
+    {
+        return mByteBufferAssembler;
+    }
+
+    /**
+     * Implements the IByteBufferProvider interface - delegates to the byte buffer assembler
+     */
+    @Override
+    public void setBufferListener(Listener<ReusableByteBuffer> listener)
+    {
+        getByteBufferAssembler().setBufferListener(listener);
+    }
+
+    /**
+     * Implements the IByteBufferProvider interface - delegates to the byte buffer assembler
+     */
+    @Override
+    public void removeBufferListener(Listener<ReusableByteBuffer> listener)
+    {
+        getByteBufferAssembler().removeBufferListener(listener);
+    }
+
+    /**
+     * Implements the IByteBufferProvider interface - delegates to the byte buffer assembler
+     */
+    @Override
+    public boolean hasBufferListeners()
+    {
+        return getByteBufferAssembler().hasBufferListeners();
     }
 
     protected double getSymbolRate()

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderC4FM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderC4FM.java
@@ -25,6 +25,7 @@ import io.github.dsheirer.dsp.psk.DQPSKDecisionDirectedDemodulator;
 import io.github.dsheirer.dsp.psk.InterpolatingSampleBuffer;
 import io.github.dsheirer.dsp.psk.pll.AdaptivePLLGainMonitor;
 import io.github.dsheirer.dsp.psk.pll.CostasLoop;
+import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
 import io.github.dsheirer.source.SourceEvent;
 import org.slf4j.Logger;
@@ -76,7 +77,15 @@ public class P25DecoderC4FM extends P25Decoder
         mMessageFramer = new P25MessageFramer(getAliasList(), mCostasLoop, mPLLGainMonitor);
         mMessageFramer.setListener(getMessageProcessor());
         mMessageFramer.setSampleRate(sampleRate);
-        mQPSKDemodulator.setSymbolListener(mMessageFramer);
+
+//        mQPSKDemodulator.setSymbolListener(mMessageFramer);
+        mQPSKDemodulator.setSymbolListener(getByteBufferAssembler());
+    }
+
+    @Override
+    public Listener getReusableByteBufferListener()
+    {
+        return mMessageFramer;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderC4FMInstrumented.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderC4FMInstrumented.java
@@ -78,7 +78,8 @@ public class P25DecoderC4FMInstrumented extends P25DecoderC4FM
         instrumented.setPLLFrequencyListener(mPLLFrequencyListener);
         instrumented.setSymbolDecisionDataListener(mSymbolDecisionDataListener);
         instrumented.setSamplesPerSymbolListener(mSamplesPerSymbolListener);
-        instrumented.setSymbolListener(getByteBufferAssembler());
+        instrumented.setSymbolListener(getDibitBroadcaster());
+        getDibitBroadcaster().addListener(mMessageFramer);
     }
 
     public void setComplexSymbolListener(Listener<Complex> listener)

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderC4FMInstrumented.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderC4FMInstrumented.java
@@ -78,7 +78,7 @@ public class P25DecoderC4FMInstrumented extends P25DecoderC4FM
         instrumented.setPLLFrequencyListener(mPLLFrequencyListener);
         instrumented.setSymbolDecisionDataListener(mSymbolDecisionDataListener);
         instrumented.setSamplesPerSymbolListener(mSamplesPerSymbolListener);
-        instrumented.setSymbolListener(mMessageFramer);
+        instrumented.setSymbolListener(getByteBufferAssembler());
     }
 
     public void setComplexSymbolListener(Listener<Complex> listener)

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSM.java
@@ -24,7 +24,6 @@ import io.github.dsheirer.dsp.psk.DQPSKGardnerDemodulator;
 import io.github.dsheirer.dsp.psk.InterpolatingSampleBuffer;
 import io.github.dsheirer.dsp.psk.pll.AdaptivePLLGainMonitor;
 import io.github.dsheirer.dsp.psk.pll.CostasLoop;
-import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
 import io.github.dsheirer.source.SourceEvent;
 
@@ -76,17 +75,17 @@ public class P25DecoderLSM extends P25Decoder
 
         //The Costas Loop receives symbol-inversion correction requests when detected.
         //The PLL gain monitor receives sync detect/loss signals from the message framer
+        if(mMessageFramer != null)
+        {
+            getDibitBroadcaster().removeListener(mMessageFramer);
+            mMessageFramer.dispose();
+        }
+
         mMessageFramer = new P25MessageFramer(getAliasList(), mCostasLoop, mPLLGainMonitor);
         mMessageFramer.setListener(getMessageProcessor());
         mMessageFramer.setSampleRate(sampleRate);
-//        mQPSKDemodulator.setSymbolListener(mMessageFramer);
-        mQPSKDemodulator.setSymbolListener(getByteBufferAssembler());
-    }
-
-    @Override
-    public Listener getReusableByteBufferListener()
-    {
-        return mMessageFramer;
+        mQPSKDemodulator.setSymbolListener(getDibitBroadcaster());
+        getDibitBroadcaster().addListener(mMessageFramer);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSM.java
@@ -24,6 +24,7 @@ import io.github.dsheirer.dsp.psk.DQPSKGardnerDemodulator;
 import io.github.dsheirer.dsp.psk.InterpolatingSampleBuffer;
 import io.github.dsheirer.dsp.psk.pll.AdaptivePLLGainMonitor;
 import io.github.dsheirer.dsp.psk.pll.CostasLoop;
+import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
 import io.github.dsheirer.source.SourceEvent;
 
@@ -78,7 +79,14 @@ public class P25DecoderLSM extends P25Decoder
         mMessageFramer = new P25MessageFramer(getAliasList(), mCostasLoop, mPLLGainMonitor);
         mMessageFramer.setListener(getMessageProcessor());
         mMessageFramer.setSampleRate(sampleRate);
-        mQPSKDemodulator.setSymbolListener(mMessageFramer);
+//        mQPSKDemodulator.setSymbolListener(mMessageFramer);
+        mQPSKDemodulator.setSymbolListener(getByteBufferAssembler());
+    }
+
+    @Override
+    public Listener getReusableByteBufferListener()
+    {
+        return mMessageFramer;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSMInstrumented.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSMInstrumented.java
@@ -79,7 +79,8 @@ public class P25DecoderLSMInstrumented extends P25DecoderLSM
         instrumented.setPLLFrequencyListener(mPLLFrequencyListener);
         instrumented.setSymbolDecisionDataListener(mSymbolDecisionDataListener);
         instrumented.setSamplesPerSymbolListener(mSamplesPerSymbolListener);
-        instrumented.setSymbolListener(getByteBufferAssembler());
+        instrumented.setSymbolListener(getDibitBroadcaster());
+        getDibitBroadcaster().addListener(mMessageFramer);
     }
 
     public void setComplexSymbolListener(Listener<Complex> listener)

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSMInstrumented.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderLSMInstrumented.java
@@ -79,7 +79,7 @@ public class P25DecoderLSMInstrumented extends P25DecoderLSM
         instrumented.setPLLFrequencyListener(mPLLFrequencyListener);
         instrumented.setSymbolDecisionDataListener(mSymbolDecisionDataListener);
         instrumented.setSamplesPerSymbolListener(mSamplesPerSymbolListener);
-        instrumented.setSymbolListener(mMessageFramer);
+        instrumented.setSymbolListener(getByteBufferAssembler());
     }
 
     public void setComplexSymbolListener(Listener<Complex> listener)

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25MessageFramer.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25MessageFramer.java
@@ -32,13 +32,14 @@ import io.github.dsheirer.module.decode.p25.message.vselp.VSELP1Message;
 import io.github.dsheirer.module.decode.p25.message.vselp.VSELP2Message;
 import io.github.dsheirer.module.decode.p25.reference.DataUnitID;
 import io.github.dsheirer.sample.Listener;
+import io.github.dsheirer.sample.buffer.ReusableByteBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class P25MessageFramer implements Listener<Dibit>
+public class P25MessageFramer implements Listener<ReusableByteBuffer>
 {
     private final static Logger mLog = LoggerFactory.getLogger(P25MessageFramer.class);
 
@@ -199,23 +200,29 @@ public class P25MessageFramer implements Listener<Dibit>
     }
 
     @Override
-    public void receive(Dibit symbol)
+    public void receive(ReusableByteBuffer reusableByteBuffer)
     {
-        for(P25MessageAssembler assembler : mAssemblers)
-        {
-            if(assembler.isActive())
-            {
-                assembler.receive(symbol);
-
-                if(assembler.complete())
-                {
-                    assembler.reset();
-                }
-            }
-        }
-
-        mMatcher.receive(symbol.getBit1(), symbol.getBit2());
+        //process the buffer received
     }
+
+    //    @Override
+//    public void receive(Dibit symbol)
+//    {
+//        for(P25MessageAssembler assembler : mAssemblers)
+//        {
+//            if(assembler.isActive())
+//            {
+//                assembler.receive(symbol);
+//
+//                if(assembler.complete())
+//                {
+//                    assembler.reset();
+//                }
+//            }
+//        }
+//
+//        mMatcher.receive(symbol.getBit1(), symbol.getBit2());
+//    }
 
     public void setListener(Listener<Message> listener)
     {

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25MessageProcessor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25MessageProcessor.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * sdr-trunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License  along with this program.
+ * If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
 package io.github.dsheirer.module.decode.p25;
 
 import io.github.dsheirer.alias.AliasList;
@@ -13,8 +28,7 @@ import java.util.HashMap;
 
 public class P25MessageProcessor implements Listener<Message>
 {
-	private final static Logger mLog = 
-			LoggerFactory.getLogger( P25MessageProcessor.class );
+	private final static Logger mLog = LoggerFactory.getLogger( P25MessageProcessor.class );
 
 	private Listener<Message> mMessageListener;
 


### PR DESCRIPTION
Resolves #394 

Updates P25 decoder (C4FM and LSM) to output reusable byte buffers so that the demodulated bit stream can be recorded to a *.bits file.

Updates binary recorder for max recording size of 500 kB