### PR TITLE
#411 Update Tuner Source Manager to provide variable sample rate channels

### DIFF
--- a/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
@@ -212,7 +212,8 @@ public class ChannelProcessingManager implements ChannelEventListener
         try
         {
             source = mSourceManager.getSource(channel.getSourceConfiguration(),
-                channel.getDecodeConfiguration().getDecoderType().getChannelBandwidth());
+                channel.getDecodeConfiguration().getDecoderType().getChannelBandwidth(),
+                channel.getDecodeConfiguration().getDecoderType().getChannelSpecification());
         }
         catch(SourceException se)
         {

--- a/src/main/java/io/github/dsheirer/dsp/filter/cic/ComplexPrimeCICDecimate.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/cic/ComplexPrimeCICDecimate.java
@@ -104,7 +104,7 @@ public class ComplexPrimeCICDecimate implements Listener<ReusableComplexBuffer>
      * @throws FilterDesignException if a final low-pass cleanup filter cannot be created for the output channel rate
      *                               and specified pass/stop frequencies.
      */
-    public ComplexPrimeCICDecimate(double sampleRate, int decimation, int passFrequency, int stopFrequency)
+    public ComplexPrimeCICDecimate(double sampleRate, int decimation, double passFrequency, double stopFrequency)
         throws FilterDesignException
     {
         Validate.isTrue(decimation <= PRIMES[PRIMES.length - 1]);
@@ -400,7 +400,7 @@ public class ComplexPrimeCICDecimate implements Listener<ReusableComplexBuffer>
         private ComplexFIRFilter2 mLowPassFilter;
         private Listener<ReusableComplexBuffer> mReusableComplexBufferListener;
 
-        public Output(double outputSampleRate, int passFrequency, int stopFrequency) throws FilterDesignException
+        public Output(double outputSampleRate, double passFrequency, double stopFrequency) throws FilterDesignException
         {
             mBufferAssembler = new ReusableComplexBufferAssembler(2400, outputSampleRate);
 
@@ -461,7 +461,7 @@ public class ComplexPrimeCICDecimate implements Listener<ReusableComplexBuffer>
          * @return a newly designed filter or a previously designed (cached) filter
          * @throws FilterDesignException
          */
-        private float[] getLowPassFilter(double sampleRate, int passFrequency, int stopFrequency) throws FilterDesignException
+        private float[] getLowPassFilter(double sampleRate, double passFrequency, double stopFrequency) throws FilterDesignException
         {
             //Use existing filter if we've already designed one
             if(sLowPassFilters.containsKey((int)sampleRate))

--- a/src/main/java/io/github/dsheirer/dsp/filter/fir/FIRFilterSpecification.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/fir/FIRFilterSpecification.java
@@ -299,8 +299,8 @@ public class FIRFilterSpecification
         private int mOrder;
         private Boolean mOddLength;
         private int mGridDensity = 16;
-        private int mPassBandEndFrequency;
-        private int mStopBandStartFrequency;
+        private double mPassBandEndFrequency;
+        private double mStopBandStartFrequency;
         private double mPassBandRipple;
         private double mStopBandRipple;
         private double mPassBandAmplitude = 1.0;
@@ -342,13 +342,13 @@ public class FIRFilterSpecification
             return this;
         }
 
-        public LowPassBuilder passBandCutoff(int frequencyHz)
+        public LowPassBuilder passBandCutoff(double frequencyHz)
         {
             mPassBandEndFrequency = frequencyHz;
             return this;
         }
 
-        public LowPassBuilder stopBandStart(int frequencyHz)
+        public LowPassBuilder stopBandStart(double frequencyHz)
         {
             mStopBandStartFrequency = frequencyHz;
             return this;
@@ -905,7 +905,7 @@ public class FIRFilterSpecification
      * @param stopBandRipple stop band ripple in dB
      * @return estimated filter length
      */
-    public static int estimateFilterOrder(double sampleRate, int frequency1, int frequency2,
+    public static int estimateFilterOrder(double sampleRate, double frequency1, double frequency2,
                                           double passBandRipple, double stopBandRipple)
     {
         double df = Math.abs(frequency2 - frequency1) / sampleRate;
@@ -1013,13 +1013,13 @@ public class FIRFilterSpecification
          * @param amplitude of the frequency band relative to unity (0.0 - 1.0)
          * @param ripple of the frequency band specified as db ripple
          */
-        public FrequencyBand(double sampleRate, int start, int end, double amplitude, double ripple)
+        public FrequencyBand(double sampleRate, double start, double end, double amplitude, double ripple)
         {
-            this((double)start / sampleRate, (double)end / sampleRate,
+            this(start / sampleRate, end / sampleRate,
                 amplitude, ripple);
         }
 
-        public FrequencyBand(double sampleRate, int start, int end, double amplitude, double ripple, double weight)
+        public FrequencyBand(double sampleRate, double start, double end, double amplitude, double ripple, double weight)
         {
             this(sampleRate, start, end, amplitude, ripple);
             mWeight = weight;

--- a/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer.java
+++ b/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer.java
@@ -260,7 +260,7 @@ public class ChannelizerViewer extends JFrame
             for(int x = 0; x < mChannelCount; x++)
             {
                 TunerChannel tunerChannel = new TunerChannel(100000000, 12500);
-                TunerChannelSource source = mTestTuner.getChannelSourceManager().getSource(tunerChannel);
+                TunerChannelSource source = mTestTuner.getChannelSourceManager().getSource(tunerChannel, null);
                 DiscreteChannelPanel channelPanel = new DiscreteChannelPanel(mSettingsManager, source, x);
                 channelPanel.setDFTSize(mChannelPanelDFTSize);
 
@@ -362,7 +362,7 @@ public class ChannelizerViewer extends JFrame
             mComplexDecibelConverter.addListener(mSpectrumPanel);
 
             TunerChannel tunerChannel = new TunerChannel(frequency, bandwidth);
-            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel);
+            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel, null);
 
             if(mSource != null)
             {
@@ -556,7 +556,7 @@ public class ChannelizerViewer extends JFrame
             {
                 if(sourceCount < maxSourceCount)
                 {
-                    TunerChannelSource source = tuner.getChannelSourceManager().getSource(tunerChannel);
+                    TunerChannelSource source = tuner.getChannelSourceManager().getSource(tunerChannel, null);
 
                     if(source != null)
                     {

--- a/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer2.java
+++ b/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer2.java
@@ -376,7 +376,7 @@ public class ChannelizerViewer2 extends JFrame
             mComplexDecibelConverter.addListener(mSpectrumPanel);
 
             TunerChannel tunerChannel = new TunerChannel(frequency, bandwidth);
-            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel);
+            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel, null);
 
             if(mSource != null)
             {

--- a/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
@@ -347,7 +347,6 @@ public class DecoderFactory
                 filters.add(new MPT1327MessageFilter());
                 break;
             case P25_PHASE1:
-            case P25_PHASE2:
                 filters.add(new P25MessageFilterSet());
                 break;
             case PASSPORT:

--- a/src/main/java/io/github/dsheirer/module/decode/DecoderType.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderType.java
@@ -1,21 +1,21 @@
 /*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * sdr-trunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License  along with this program.
+ * If not, see <http://www.gnu.org/licenses/>
+ *
  ******************************************************************************/
 package io.github.dsheirer.module.decode;
+
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -25,37 +25,37 @@ import java.util.EnumSet;
  */
 public enum DecoderType
 {
-	ACARS( "ACARS", "ACARS", "images/acars.png", 12500 ),
-	AIS( "AIS", "AIS", "images/ais.png", 12500 ),
-    AM( "AM", "AM", "images/am.png", 10000 ),
-    APRS( "APRS", "APRS", "images/aprs.png", 12500 ),
-    DMR( "DMR", "DMR", "images/dmr.png", 12500 ),
-    FLEETSYNC2( "Fleetsync II", "Fleetsync2", "images/fm.png", 12500 ),
-    LJ_1200( "LJ1200 173.075", "LJ1200", "images/lj1200.png", 12500 ),
-    LTR_STANDARD( "LTR-Standard", "LTR", "images/ltr.png", 10000 ),
-    LTR_NET( "LTR-Net", "LTR-Net", "images/ltr_net.png", 12500 ),
-    MDC1200( "MDC1200", "MDC1200", "images/fm.png", 12500 ),
-    MOTOROLA_TYPE_2( "MOTO T2", "MOTO T2", "images/motorola_type_2.png", 15000 ),
-    MPT1327( "MPT1327", "MPT1327", "images/mpt1327.png", 12500 ),
-    NXDN( "NXDN", "NXDN", "images/nxdn.png", 8000 ),
-    NBFM( "NBFM", "NBFM", "images/fm.png", 12500 ),
-    PASSPORT( "Passport", "Passport", "images/passport.png", 12500 ),
-    P25_PHASE1( "P25 Phase I", "P25-1", "images/p25_1.png", 12500 ),
-    P25_PHASE2( "P25 Phase II", "P25-2", "images/p25_2.png", 15000 ),
-    TAIT_1200( "Tait 1200", "Tait 1200", "images/tait.png", 12500 );
-    
+    //Primary Decoders
+    AM("AM", "AM", 10000, new ChannelSpecification(25000.0, 3000.0, 5000.0)),
+    LTR_STANDARD("LTR-Standard", "LTR", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
+    LTR_NET("LTR-Net", "LTR-Net", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
+    MPT1327("MPT1327", "MPT1327", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
+    NBFM("NBFM", "NBFM", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
+    PASSPORT("Passport", "Passport", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
+    P25_PHASE1("P25 Phase I", "P25-1", 12500, new ChannelSpecification(50000.0, 6000.0, 7000.0)),
+
+    //Auxiliary Decoders
+    FLEETSYNC2("Fleetsync II", "Fleetsync2", 12500),
+    LJ_1200("LJ1200 173.075", "LJ1200", 12500),
+    MDC1200("MDC1200", "MDC1200", 12500),
+    TAIT_1200("Tait 1200", "Tait 1200", 12500);
+
     private String mDisplayString;
     private String mShortDisplayString;
-    private String mIconFilename;
     private int mChannelBandwidth;
-    
-    DecoderType( String displayString, String shortDisplayString, 
-    			 String iconFilename, int bandwidth )
+    private ChannelSpecification mChannelSpecification;
+
+    DecoderType(String displayString, String shortDisplayString, int bandwidth, ChannelSpecification channelSpecification)
     {
         mDisplayString = displayString;
         mShortDisplayString = shortDisplayString;
-        mIconFilename = iconFilename;
         mChannelBandwidth = bandwidth;
+        mChannelSpecification = channelSpecification;
+    }
+
+    DecoderType(String displayString, String shortDisplayString, int bandwidth)
+    {
+        this(displayString, shortDisplayString, bandwidth, null);
     }
 
     /**
@@ -63,68 +63,57 @@ public enum DecoderType
      */
     public static EnumSet<DecoderType> getPrimaryDecoders()
     {
-    	return EnumSet.of( DecoderType.AM,
-    	                   DecoderType.LTR_NET,
-    					   DecoderType.LTR_STANDARD,
-    					   DecoderType.MPT1327,
-    					   DecoderType.NBFM,
-    					   DecoderType.P25_PHASE1,
-    					   DecoderType.PASSPORT );
+        return EnumSet.of(DecoderType.AM,
+            DecoderType.LTR_NET,
+            DecoderType.LTR_STANDARD,
+            DecoderType.MPT1327,
+            DecoderType.NBFM,
+            DecoderType.P25_PHASE1,
+            DecoderType.PASSPORT);
     }
 
-    /**
-     * Decoders that can be used in the viewer application
-     */
-    public static EnumSet<DecoderType> getInstrumentableDecoders()
-    {
-    	return EnumSet.of( DecoderType.FLEETSYNC2,
-    				 	   DecoderType.LJ_1200,
-    	                   DecoderType.LTR_NET,
-    					   DecoderType.MDC1200,
-    					   DecoderType.MPT1327,
-    					   DecoderType.PASSPORT,
-    					   DecoderType.P25_PHASE1,
-    					   DecoderType.TAIT_1200 );
-    }
-    
     /**
      * Available auxiliary decoders.
      */
     public static ArrayList<DecoderType> getAuxDecoders()
     {
-    	ArrayList<DecoderType> decoders = new ArrayList<DecoderType>();
-    	
-    	decoders.add( DecoderType.FLEETSYNC2 );
-    	decoders.add( DecoderType.LJ_1200 );
-    	decoders.add( DecoderType.MDC1200 );
-    	decoders.add( DecoderType.TAIT_1200 );
-    	
-    	return decoders;
+        ArrayList<DecoderType> decoders = new ArrayList<DecoderType>();
+
+        decoders.add(DecoderType.FLEETSYNC2);
+        decoders.add(DecoderType.LJ_1200);
+        decoders.add(DecoderType.MDC1200);
+        decoders.add(DecoderType.TAIT_1200);
+
+        return decoders;
     }
-    
+
     public String getDisplayString()
     {
         return mDisplayString;
     }
-    
+
     public String getShortDisplayString()
     {
-    	return mShortDisplayString;
+        return mShortDisplayString;
     }
-    
-    public String getIconFilename()
-    {
-    	return mIconFilename;
-    }
-    
+
     public int getChannelBandwidth()
     {
-    	return mChannelBandwidth;
+        return mChannelBandwidth;
     }
-    
+
+    /**
+     * Channel specification for a channel for this decoder type.
+     * @return specification or null
+     */
+    public ChannelSpecification getChannelSpecification()
+    {
+        return mChannelSpecification;
+    }
+
     @Override
     public String toString()
     {
-    	return mDisplayString;
+        return mDisplayString;
     }
 }

--- a/src/main/java/io/github/dsheirer/source/SourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/SourceManager.java
@@ -25,6 +25,7 @@ import io.github.dsheirer.source.mixer.MixerManager;
 import io.github.dsheirer.source.recording.RecordingSourceManager;
 import io.github.dsheirer.source.tuner.TunerManager;
 import io.github.dsheirer.source.tuner.TunerModel;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class SourceManager
 {
@@ -73,7 +74,7 @@ public class SourceManager
         return mTunerModel;
     }
 
-    public Source getSource(SourceConfiguration config, int bandwidth)
+    public Source getSource(SourceConfiguration config, int bandwidth, ChannelSpecification channelSpecification)
         throws SourceException
     {
         Source retVal = null;
@@ -84,7 +85,7 @@ public class SourceManager
                 retVal = mMixerManager.getSource(config);
                 break;
             case TUNER:
-                retVal = mTunerModel.getSource((SourceConfigTuner) config, bandwidth);
+                retVal = mTunerModel.getSource((SourceConfigTuner) config, bandwidth, channelSpecification);
                 break;
             case RECORDING:
                 retVal = mRecordingSourceManager.getSource(config, bandwidth);

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerModel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerModel.java
@@ -21,6 +21,7 @@ import io.github.dsheirer.source.Source;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.config.SourceConfigTuner;
 import io.github.dsheirer.source.tuner.TunerEvent.Event;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 import io.github.dsheirer.source.tuner.channel.TunerChannel;
 import io.github.dsheirer.source.tuner.channel.TunerChannelSource;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
@@ -327,7 +328,7 @@ public class TunerModel extends AbstractTableModel implements Listener<TunerEven
      *
      * Returns null if no tuner can source the channel
      */
-    public Source getSource(SourceConfigTuner config, int bandwidth)
+    public Source getSource(SourceConfigTuner config, int bandwidth, ChannelSpecification channelSpecification)
     {
         TunerChannelSource retVal = null;
 
@@ -347,7 +348,7 @@ public class TunerModel extends AbstractTableModel implements Listener<TunerEven
             {
                 try
                 {
-                    retVal = tuner.getChannelSourceManager().getSource(tunerChannel);
+                    retVal = tuner.getChannelSourceManager().getSource(tunerChannel, channelSpecification);
 
                     if(retVal != null)
                     {
@@ -370,7 +371,7 @@ public class TunerModel extends AbstractTableModel implements Listener<TunerEven
 
             try
             {
-                retVal = tuner.getChannelSourceManager().getSource(tunerChannel);
+                retVal = tuner.getChannelSourceManager().getSource(tunerChannel, channelSpecification);
             }
             catch(Exception e)
             {

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/CICTunerChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/CICTunerChannelSource.java
@@ -44,12 +44,6 @@ public class CICTunerChannelSource extends TunerChannelSource implements Listene
     //Threshold for resetting buffer overflow condition
     private static final int BUFFER_OVERFLOW_RESET_THRESHOLD = 100;
 
-    //Pass band cutoff frequency for the complex channel - target = 12.5 kHz channel
-    private static final int CHANNEL_PASS_FREQUENCY = 6000;
-
-    //Stop band frequency for the complex channel
-    private static final int CHANNEL_STOP_FREQUENCY = 6700;
-
     private OverflowableReusableBufferTransferQueue<ReusableComplexBuffer> mBuffer;
     private ReusableComplexBufferQueue mReusableComplexBufferQueue = new ReusableComplexBufferQueue("CICTunerChannelSource");
     private IOscillator mFrequencyCorrectionMixer;
@@ -65,16 +59,19 @@ public class CICTunerChannelSource extends TunerChannelSource implements Listene
      * @param producerSourceEventListener to receive sample stream start/stop requests
      * @param tunerChannel that details the desired channel frequency and bandwidth
      * @param sampleRate of the incoming sample stream
-     * @param decimation to use in the CIC decimation filter.
+     * @param channelSpecification for the requested channel.
      * @throws FilterDesignException if a final cleanup filter cannot be designed using the remez filter
      *                               designer and the filter parameters.
      */
     public CICTunerChannelSource(Listener<SourceEvent> producerSourceEventListener, TunerChannel tunerChannel,
-                                 double sampleRate, int decimation) throws FilterDesignException
+                 double sampleRate, ChannelSpecification channelSpecification) throws FilterDesignException
     {
         super(producerSourceEventListener, tunerChannel);
 
-        mDecimationFilter = new ComplexPrimeCICDecimate(sampleRate, decimation, CHANNEL_PASS_FREQUENCY, CHANNEL_STOP_FREQUENCY);
+        int decimation = (int)(sampleRate / channelSpecification.getMinimumSampleRate());
+
+        mDecimationFilter = new ComplexPrimeCICDecimate(sampleRate, decimation, channelSpecification.getPassFrequency(),
+            channelSpecification.getStopFrequency());
 
         mBuffer = new OverflowableReusableBufferTransferQueue<>(BUFFER_MAX_CAPACITY, BUFFER_OVERFLOW_RESET_THRESHOLD);
         //Setup the frequency mixer to the current source frequency

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/ChannelSpecification.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/ChannelSpecification.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * sdr-trunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License  along with this program.
+ * If not, see <http://www.gnu.org/licenses/>
+ *
+ ******************************************************************************/
+package io.github.dsheirer.source.tuner.channel;
+
+/**
+ * Channel source specification
+ */
+public class ChannelSpecification
+{
+    private double mMinimumSampleRate;
+    private double mPassFrequency;
+    private double mStopFrequency;
+
+    /**
+     * Constructs a channel specification instance.
+     * @param minimumSampleRate requested for the channel
+     * @param passFrequency for the pass band of the channel
+     * @param stopFrequency for the stop band of teh channel
+     */
+    public ChannelSpecification(double minimumSampleRate, double passFrequency, double stopFrequency)
+    {
+        mMinimumSampleRate = minimumSampleRate;
+        mPassFrequency = passFrequency;
+        mStopFrequency = stopFrequency;
+    }
+
+    /**
+     * Minimum requested sample rate for the channel
+     */
+    public double getMinimumSampleRate()
+    {
+        return mMinimumSampleRate;
+    }
+
+    /**
+     * Pass band frequency for filtering the channel
+     */
+    public double getPassFrequency()
+    {
+        return mPassFrequency;
+    }
+
+    /**
+     * Stop band frequency for filtering the channel
+     */
+    public double getStopFrequency()
+    {
+        return mStopFrequency;
+    }
+}

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
@@ -19,6 +19,7 @@ import io.github.dsheirer.sample.Broadcaster;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.source.ISourceEventProcessor;
 import io.github.dsheirer.source.SourceEvent;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 import io.github.dsheirer.source.tuner.channel.TunerChannel;
 import io.github.dsheirer.source.tuner.channel.TunerChannelSource;
 
@@ -50,9 +51,10 @@ public abstract class ChannelSourceManager implements ISourceEventProcessor
      * resources allocated for the tuner channel source.
      *
      * @param tunerChannel for requested source
+     * @param channelSpecification for the requested channel
      * @return tuner channel source or null
      */
-    public abstract TunerChannelSource getSource(TunerChannel tunerChannel);
+    public abstract TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification);
 
     /**
      * Adds a listener to receive source events

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
@@ -22,6 +22,7 @@ import io.github.dsheirer.source.SourceEvent;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.tuner.TunerController;
 import io.github.dsheirer.source.tuner.channel.CICTunerChannelSource;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 import io.github.dsheirer.source.tuner.channel.TunerChannel;
 import io.github.dsheirer.source.tuner.channel.TunerChannelSource;
 import org.slf4j.Logger;
@@ -39,7 +40,6 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
 {
     private final static Logger mLog = LoggerFactory.getLogger(HeterodyneChannelSourceManager.class);
 
-    private final static int OBJECTIVE_CHANNEL_SAMPLE_RATE = 25000;
     private final static int DELAY_BUFFER_DURATION_MILLISECONDS = 2000;
 
     private List<CICTunerChannelSource> mChannelSources = new CopyOnWriteArrayList<>();
@@ -67,17 +67,15 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
     }
 
     @Override
-    public TunerChannelSource getSource(TunerChannel tunerChannel)
+    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification)
     {
         if(CenterFrequencyCalculator.canTune(tunerChannel, mTunerController, mTunerChannels))
         {
-            int decimation = mTunerController.getBandwidth() / OBJECTIVE_CHANNEL_SAMPLE_RATE;
-
             try
             {
                 //Attempt to create the channel source first, in case we get a filter design exception
                 CICTunerChannelSource tunerChannelSource = new CICTunerChannelSource(mChannelSourceEventProcessor,
-                    tunerChannel, mTunerController.getSampleRate(), decimation);
+                    tunerChannel, mTunerController.getSampleRate(), channelSpecification);
 
                 //Add to the list of channel sources so that it will receive the tuner frequency change
                 mChannelSources.add(tunerChannelSource);
@@ -165,7 +163,7 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
      */
     private void broadcastToChannels(SourceEvent sourceEvent)
     {
-        for(CICTunerChannelSource channelSource: mChannelSources)
+        for(CICTunerChannelSource channelSource : mChannelSources)
         {
             try
             {

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
@@ -19,6 +19,7 @@ import io.github.dsheirer.dsp.filter.channelizer.PolyphaseChannelManager;
 import io.github.dsheirer.source.SourceEvent;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.tuner.TunerController;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 import io.github.dsheirer.source.tuner.channel.TunerChannel;
 import io.github.dsheirer.source.tuner.channel.TunerChannelSource;
 import org.slf4j.Logger;
@@ -390,8 +391,13 @@ public class PolyphaseChannelSourceManager extends ChannelSourceManager
      * @return allocated DDC tuner channel source, or null if the channel cannot be provided by this source manager
      */
     @Override
-    public TunerChannelSource getSource(TunerChannel tunerChannel)
+    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification)
     {
+        if(channelSpecification != null)
+        {
+            throw new IllegalArgumentException("Update polyphase source manager to support channel specifications");
+        }
+
         if(isTunable(tunerChannel))
         {
             //Get a new set of currently tuned channels


### PR DESCRIPTION
Resolves #411

Updates decoder types to specify channel sample rate and pass/stop
frequencies for requested channels.  Updates tuner channel source
managers to accept a channel specification for channels that are
allocated.