### PR TITLE
405 Airspy Spectrum/Waterfall Freezes

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerManager.java
@@ -71,6 +71,10 @@ public class TunerManager
      */
     public void dispose()
     {
+        mLog.info("Shutting down LibUsb timeout processor ...");
+
+        LIBUSB_TRANSFER_PROCESSOR.shutdown();
+
         mLog.info("Shutting down LibUsb ...");
         try
         {

--- a/src/main/java/io/github/dsheirer/source/tuner/usb/USBMasterProcessor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/usb/USBMasterProcessor.java
@@ -81,7 +81,7 @@ public class USBMasterProcessor
         if(mRunning.compareAndSet(false, true))
         {
             //Set periodicity to an odd multiple to avoid contention with transfer buffer receivers
-            mProcessorFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(mProcessor, 0L, 5L, TimeUnit.MILLISECONDS);
+            mProcessorFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(mProcessor, 0L, 9L, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -98,6 +98,14 @@ public class USBMasterProcessor
                 mProcessorFuture = null;
             }
         }
+    }
+
+    /**
+     * Stops the libusb timeout processor and prepares for shutdown.
+     */
+    public void shutdown()
+    {
+        stop();
     }
 
     /**


### PR DESCRIPTION
Resolves #405

Adds 500 ms delay to initial registering for samples from all tuners to
feed the spectral display/waterfall.  The existing approach of immediately
registering for samples was causing the airspy tuner to lockup
aperiodically.  Investigation via debugger didn't show any application
thread locks ... usb master processor was continuing to service libusb
timeouts.  Unable to debug internal airspy processes.  Adding the delay
to startup seems to be a usable solution.
