### PR TITLE
419 Heterodyne Channelizer Center Frequency Calculations

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
@@ -108,23 +108,26 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
      */
     private void updateTunerFrequency()
     {
-        long centerFrequency = CenterFrequencyCalculator.getCenterFrequency(mTunerController, getTunerChannels());
-
-        if(centerFrequency == CenterFrequencyCalculator.INVALID_FREQUENCY)
+        if(!mTunerController.isTunedFor(getTunerChannels()))
         {
-            mLog.error("Couldn't calculate center frequency for tuner and tuner channels");
-            return;
-        }
+            long centerFrequency = CenterFrequencyCalculator.getCenterFrequency(mTunerController, getTunerChannels());
 
-        if(centerFrequency != mTunerController.getFrequency())
-        {
-            try
+            if(centerFrequency == CenterFrequencyCalculator.INVALID_FREQUENCY)
             {
-                mTunerController.setFrequency(centerFrequency);
+                mLog.error("Couldn't calculate center frequency for tuner and tuner channels");
+                return;
             }
-            catch(SourceException se)
+
+            if(centerFrequency != mTunerController.getFrequency())
             {
-                mLog.error("Couldn't update tuner center frequency to " + centerFrequency, se);
+                try
+                {
+                    mTunerController.setFrequency(centerFrequency);
+                }
+                catch(SourceException se)
+                {
+                    mLog.error("Couldn't update tuner center frequency to " + centerFrequency, se);
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #419
Updates the heterodyne channelizer's center frequency calculator to only update the center frequency when needed and to place the set of decoding channels adjacent to the right side of the tuner's center
frequency when the complete set of channels fit into the usable half bandwidth of the tuner.
