### PR TITLE
421 Add 25 kHz Channel Bandwidth Support to NBFM Decoder

### DIFF
--- a/src/main/java/io/github/dsheirer/channel/traffic/TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/channel/traffic/TrafficChannelManager.java
@@ -186,7 +186,7 @@ public class TrafficChannelManager extends Module implements ICallEventProvider,
             if(frequency > 0)
             {
                 Channel channel = getChannel(callEvent.getChannel(), new TunerChannel(frequency,
-                    mDecodeConfiguration.getDecoderType().getChannelBandwidth()));
+                    mDecodeConfiguration.getChannelSpecification().getBandwidth()));
 
                 if(channel != null)
                 {

--- a/src/main/java/io/github/dsheirer/controller/channel/Channel.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/Channel.java
@@ -489,14 +489,14 @@ public class Channel extends Configuration implements Listener<SourceEvent>
                 SourceConfigTuner config = (SourceConfigTuner)mSourceConfiguration;
 
                 mTunerChannel = new TunerChannel(config.getFrequency(),
-                    mDecodeConfiguration.getDecoderType().getChannelBandwidth());
+                    mDecodeConfiguration.getChannelSpecification().getBandwidth());
             }
             else if(mSourceConfiguration.getSourceType() == SourceType.RECORDING)
             {
                 SourceConfigRecording config = (SourceConfigRecording)mSourceConfiguration;
 
                 mTunerChannel = new TunerChannel(config.getFrequency(),
-                    mDecodeConfiguration.getDecoderType().getChannelBandwidth());
+                    mDecodeConfiguration.getChannelSpecification().getBandwidth());
             }
         }
 

--- a/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
@@ -212,8 +212,7 @@ public class ChannelProcessingManager implements ChannelEventListener
         try
         {
             source = mSourceManager.getSource(channel.getSourceConfiguration(),
-                channel.getDecodeConfiguration().getDecoderType().getChannelBandwidth(),
-                channel.getDecodeConfiguration().getDecoderType().getChannelSpecification());
+                channel.getDecodeConfiguration().getChannelSpecification());
         }
         catch(SourceException se)
         {

--- a/src/main/java/io/github/dsheirer/dsp/filter/design/FilterViewer.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/design/FilterViewer.java
@@ -62,12 +62,12 @@ public class FilterViewer extends Application
 //            .build();
 
         FIRFilterSpecification specification = FIRFilterSpecification.lowPassBuilder()
-            .sampleRate(50000.0)
+            .sampleRate(25000.0)
             .gridDensity(16)
-            .passBandCutoff(6000)
+            .passBandCutoff(11800)
             .passBandAmplitude(1.0)
             .passBandRipple(0.01)
-            .stopBandStart(6700)
+            .stopBandStart(12400)
             .stopBandAmplitude(0.0)
             .stopBandRipple(0.01)
             .build();

--- a/src/main/java/io/github/dsheirer/module/decode/DecoderType.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderType.java
@@ -15,8 +15,6 @@
  ******************************************************************************/
 package io.github.dsheirer.module.decode;
 
-import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
-
 import java.util.ArrayList;
 import java.util.EnumSet;
 
@@ -26,36 +24,27 @@ import java.util.EnumSet;
 public enum DecoderType
 {
     //Primary Decoders
-    AM("AM", "AM", 10000, new ChannelSpecification(25000.0, 3000.0, 5000.0)),
-    LTR_STANDARD("LTR-Standard", "LTR", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
-    LTR_NET("LTR-Net", "LTR-Net", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
-    MPT1327("MPT1327", "MPT1327", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
-    NBFM("NBFM", "NBFM", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
-    PASSPORT("Passport", "Passport", 12500, new ChannelSpecification(25000.0, 6000.0, 7000.0)),
-    P25_PHASE1("P25 Phase I", "P25-1", 12500, new ChannelSpecification(50000.0, 6000.0, 7000.0)),
+    AM("AM", "AM"),
+    LTR_STANDARD("LTR-Standard", "LTR"),
+    LTR_NET("LTR-Net", "LTR-Net"),
+    MPT1327("MPT1327", "MPT1327"),
+    NBFM("NBFM", "NBFM"),
+    PASSPORT("Passport", "Passport"),
+    P25_PHASE1("P25 Phase I", "P25-1"),
 
     //Auxiliary Decoders
-    FLEETSYNC2("Fleetsync II", "Fleetsync2", 12500),
-    LJ_1200("LJ1200 173.075", "LJ1200", 12500),
-    MDC1200("MDC1200", "MDC1200", 12500),
-    TAIT_1200("Tait 1200", "Tait 1200", 12500);
+    FLEETSYNC2("Fleetsync II", "Fleetsync2"),
+    LJ_1200("LJ1200 173.075", "LJ1200"),
+    MDC1200("MDC1200", "MDC1200"),
+    TAIT_1200("Tait 1200", "Tait 1200");
 
     private String mDisplayString;
     private String mShortDisplayString;
-    private int mChannelBandwidth;
-    private ChannelSpecification mChannelSpecification;
 
-    DecoderType(String displayString, String shortDisplayString, int bandwidth, ChannelSpecification channelSpecification)
+    DecoderType(String displayString, String shortDisplayString)
     {
         mDisplayString = displayString;
         mShortDisplayString = shortDisplayString;
-        mChannelBandwidth = bandwidth;
-        mChannelSpecification = channelSpecification;
-    }
-
-    DecoderType(String displayString, String shortDisplayString, int bandwidth)
-    {
-        this(displayString, shortDisplayString, bandwidth, null);
     }
 
     /**
@@ -95,20 +84,6 @@ public enum DecoderType
     public String getShortDisplayString()
     {
         return mShortDisplayString;
-    }
-
-    public int getChannelBandwidth()
-    {
-        return mChannelBandwidth;
-    }
-
-    /**
-     * Channel specification for a channel for this decoder type.
-     * @return specification or null
-     */
-    public ChannelSpecification getChannelSpecification()
-    {
-        return mChannelSpecification;
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/module/decode/am/DecodeConfigAM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/am/DecodeConfigAM.java
@@ -17,14 +17,27 @@
  ******************************************************************************/
 package io.github.dsheirer.module.decode.am;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigAM extends DecodeConfiguration
 {
 	public DecodeConfigAM()
     {
+    }
+
+    /**
+     * Source channel specification for this decoder
+     */
+    @JsonIgnore
+    @Override
+    public ChannelSpecification getChannelSpecification()
+    {
+        return new ChannelSpecification(25000.0,
+            3000, 3000.0, 5000.0);
     }
 
     @JacksonXmlProperty(isAttribute = true, localName = "type", namespace = "http://www.w3.org/2001/XMLSchema-instance")

--- a/src/main/java/io/github/dsheirer/module/decode/config/DecodeConfiguration.java
+++ b/src/main/java/io/github/dsheirer/module/decode/config/DecodeConfiguration.java
@@ -29,6 +29,7 @@ import io.github.dsheirer.module.decode.mpt1327.DecodeConfigMPT1327;
 import io.github.dsheirer.module.decode.nbfm.DecodeConfigNBFM;
 import io.github.dsheirer.module.decode.p25.DecodeConfigP25Phase1;
 import io.github.dsheirer.module.decode.passport.DecodeConfigPassport;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -58,4 +59,7 @@ public abstract class DecodeConfiguration extends Configuration
 
     @JsonIgnore
     public abstract DecoderType getDecoderType();
+
+    @JsonIgnore
+    public abstract ChannelSpecification getChannelSpecification();
 }

--- a/src/main/java/io/github/dsheirer/module/decode/ltrnet/DecodeConfigLTRNet.java
+++ b/src/main/java/io/github/dsheirer/module/decode/ltrnet/DecodeConfigLTRNet.java
@@ -17,10 +17,12 @@
  ******************************************************************************/
 package io.github.dsheirer.module.decode.ltrnet;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.message.MessageDirection;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigLTRNet extends DecodeConfiguration
 {
@@ -45,5 +47,16 @@ public class DecodeConfigLTRNet extends DecodeConfiguration
     public void setMessageDirection(MessageDirection direction)
     {
         mMessageDirection = direction;
+    }
+
+    /**
+     * Source channel specification for this decoder
+     */
+    @JsonIgnore
+    @Override
+    public ChannelSpecification getChannelSpecification()
+    {
+        return new ChannelSpecification(25000.0,
+            12500, 6000.0, 7000.0);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/ltrstandard/DecodeConfigLTRStandard.java
+++ b/src/main/java/io/github/dsheirer/module/decode/ltrstandard/DecodeConfigLTRStandard.java
@@ -17,10 +17,12 @@
  ******************************************************************************/
 package io.github.dsheirer.module.decode.ltrstandard;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.message.MessageDirection;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigLTRStandard extends DecodeConfiguration
 {
@@ -46,5 +48,16 @@ public class DecodeConfigLTRStandard extends DecodeConfiguration
     public void setMessageDirection(MessageDirection direction)
     {
         mMessageDirection = direction;
+    }
+
+    /**
+     * Source channel specification for this decoder
+     */
+    @JsonIgnore
+    @Override
+    public ChannelSpecification getChannelSpecification()
+    {
+        return new ChannelSpecification(25000.0,
+            12500, 6000.0, 7000.0);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/mpt1327/DecodeConfigMPT1327.java
+++ b/src/main/java/io/github/dsheirer/module/decode/mpt1327/DecodeConfigMPT1327.java
@@ -17,9 +17,11 @@
  ******************************************************************************/
 package io.github.dsheirer.module.decode.mpt1327;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigMPT1327 extends DecodeConfiguration
 {
@@ -101,5 +103,16 @@ public class DecodeConfigMPT1327 extends DecodeConfiguration
     public void setTrafficChannelPoolSize(int size)
     {
         mTrafficChannelPoolSize = size;
+    }
+
+    /**
+     * Source channel specification for this decoder
+     */
+    @JsonIgnore
+    @Override
+    public ChannelSpecification getChannelSpecification()
+    {
+        return new ChannelSpecification(25000.0,
+            12500, 6000.0, 7000.0);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
@@ -17,12 +17,16 @@
  ******************************************************************************/
 package io.github.dsheirer.module.decode.nbfm;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigNBFM extends DecodeConfiguration
 {
+    private Bandwidth mBandwidth = Bandwidth.BW_12_5;
+
     public DecodeConfigNBFM()
     {
     }
@@ -33,4 +37,53 @@ public class DecodeConfigNBFM extends DecodeConfiguration
         return DecoderType.NBFM;
     }
 
+    /**
+     * Channel bandwidth
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "bandwidth")
+    public Bandwidth getBandwidth()
+    {
+        return mBandwidth;
+    }
+
+    @JsonIgnore
+    @Override
+    public ChannelSpecification getChannelSpecification()
+    {
+        if(mBandwidth == Bandwidth.BW_12_5)
+        {
+            return new ChannelSpecification(25000.0, 12500, 6000.0, 7000.0);
+        }
+        else
+        {
+            return new ChannelSpecification(50000.0, 25000, 12500.0, 13500.0);
+        }
+    }
+
+    /**
+     * Sets the channel bandwidth
+     */
+    public void setBandwidth(Bandwidth bandwidth)
+    {
+        mBandwidth = bandwidth;
+    }
+
+    public enum Bandwidth
+    {
+        BW_12_5("12.5 kHz"),
+        BW_25_0("25.0 kHz");
+
+        private String mLabel;
+
+        Bandwidth(String label)
+        {
+            mLabel = label;
+        }
+
+        @Override
+        public String toString()
+        {
+            return mLabel;
+        }
+    };
 }

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoderEditor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoderEditor.java
@@ -1,19 +1,17 @@
 /*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014-2016 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * sdr-trunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License  along with this program.
+ * If not, see <http://www.gnu.org/licenses/>
+ *
  ******************************************************************************/
 package io.github.dsheirer.module.decode.nbfm;
 
@@ -24,70 +22,94 @@ import io.github.dsheirer.gui.editor.ValidatingEditor;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
 import net.miginfocom.swing.MigLayout;
 
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public class NBFMDecoderEditor extends ValidatingEditor<Channel>
 {
     private static final long serialVersionUID = 1L;
-    
-	public NBFMDecoderEditor()
-	{
-		init();
-	}
-	
-	private void init()
-	{
-		setLayout( new MigLayout( "insets 0 0 0 0,wrap 2", "[right][grow,fill]", "" ) );
-		add( new JLabel( "Narrow Band FM Decoder" ) );
-	}
 
-	@Override
-	public void validate( Editor<Channel> editor ) throws EditorValidationException
-	{
-		//No validation
-	}
+    private JComboBox<DecodeConfigNBFM.Bandwidth> mComboBandwidth;
 
-	@Override
-	public void save()
-	{
-		if( hasItem() && isModified() )
-		{
-			DecodeConfigNBFM nbfm = new DecodeConfigNBFM();
-			getItem().setDecodeConfiguration( nbfm );
-		}
-		
-		setModified( false );
-	}
+    public NBFMDecoderEditor()
+    {
+        init();
+    }
 
-	private void setControlsEnabled( boolean enabled )
-	{
-	}
+    private void init()
+    {
+        setLayout(new MigLayout("insets 0 0 0 0,wrap 2", "[right][grow,fill]", ""));
 
-	@Override
-	public void setItem( Channel item )
-	{
-		super.setItem( item );
-		
-		if( hasItem() )
-		{
-			setControlsEnabled( true );
-			
-			DecodeConfiguration config = getItem().getDecodeConfiguration();
-			
-			if( config instanceof DecodeConfigNBFM )
-			{
-				DecodeConfigNBFM nbfm = (DecodeConfigNBFM)config;
-				setModified( false );
-			}
-			else
-			{
-				setModified( true );
-			}
-		}
-		else
-		{
-			setControlsEnabled( false );
-			setModified( false );
-		}
-	}
+        mComboBandwidth = new JComboBox<>();
+        mComboBandwidth.setModel(new DefaultComboBoxModel<DecodeConfigNBFM.Bandwidth>(
+            DecodeConfigNBFM.Bandwidth.values()));
+        mComboBandwidth.setEnabled(false);
+        mComboBandwidth.addActionListener(new ActionListener()
+        {
+            @Override
+            public void actionPerformed(ActionEvent e)
+            {
+                setModified(true);
+            }
+        });
+
+        add(new JLabel("Bandwidth:"));
+        add(mComboBandwidth);
+    }
+
+    @Override
+    public void validate(Editor<Channel> editor) throws EditorValidationException
+    {
+        //No validation
+    }
+
+    @Override
+    public void save()
+    {
+        if(hasItem() && isModified())
+        {
+            DecodeConfigNBFM nbfm = new DecodeConfigNBFM();
+            nbfm.setBandwidth((DecodeConfigNBFM.Bandwidth)mComboBandwidth.getSelectedItem());
+            getItem().setDecodeConfiguration(nbfm);
+        }
+
+        setModified(false);
+    }
+
+    private void setControlsEnabled(boolean enabled)
+    {
+        mComboBandwidth.setEnabled(enabled);
+    }
+
+    @Override
+    public void setItem(Channel item)
+    {
+        super.setItem(item);
+
+        if(hasItem())
+        {
+            setControlsEnabled(true);
+
+            DecodeConfiguration config = getItem().getDecodeConfiguration();
+
+            if(config instanceof DecodeConfigNBFM)
+            {
+                DecodeConfigNBFM nbfm = (DecodeConfigNBFM)config;
+                mComboBandwidth.setSelectedItem(nbfm.getBandwidth());
+                setModified(false);
+            }
+            else
+            {
+                setModified(true);
+            }
+        }
+        else
+        {
+            setControlsEnabled(false);
+            setModified(false);
+        }
+    }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/DecodeConfigP25Phase1.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/DecodeConfigP25Phase1.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigP25Phase1 extends DecodeConfiguration
 {
@@ -103,5 +104,16 @@ public class DecodeConfigP25Phase1 extends DecodeConfiguration
     public void setTrafficChannelPoolSize(int size)
     {
         mTrafficChannelPoolSize = size;
+    }
+
+    /**
+     * Source channel specification for this decoder
+     */
+    @JsonIgnore
+    @Override
+    public ChannelSpecification getChannelSpecification()
+    {
+        return new ChannelSpecification(50000.0,
+            12500, 6000.0, 7000.0);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/passport/DecodeConfigPassport.java
+++ b/src/main/java/io/github/dsheirer/module/decode/passport/DecodeConfigPassport.java
@@ -1,7 +1,6 @@
-/*
- * *********************************************************************************************************************
- * sdrtrunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+/*******************************************************************************
+ * sdr-trunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
  * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
@@ -12,13 +11,15 @@
  *
  * You should have received a copy of the GNU General Public License  along with this program.
  * If not, see <http://www.gnu.org/licenses/>
- * *********************************************************************************************************************
- */
+ *
+ ******************************************************************************/
 package io.github.dsheirer.module.decode.passport;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.config.DecodeConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigPassport extends DecodeConfiguration
 {
@@ -30,5 +31,15 @@ public class DecodeConfigPassport extends DecodeConfiguration
     public DecoderType getDecoderType()
     {
         return DecoderType.PASSPORT;
+    }
+
+    /**
+     * Source channel specification for this decoder
+     */
+    @JsonIgnore
+    @Override
+    public ChannelSpecification getChannelSpecification()
+    {
+        return new ChannelSpecification(25000.0, 12500, 6000.0, 7000.0);
     }
 }

--- a/src/main/java/io/github/dsheirer/source/SourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/SourceManager.java
@@ -74,8 +74,7 @@ public class SourceManager
         return mTunerModel;
     }
 
-    public Source getSource(SourceConfiguration config, int bandwidth, ChannelSpecification channelSpecification)
-        throws SourceException
+    public Source getSource(SourceConfiguration config, ChannelSpecification channelSpecification) throws SourceException
     {
         Source retVal = null;
 
@@ -85,10 +84,10 @@ public class SourceManager
                 retVal = mMixerManager.getSource(config);
                 break;
             case TUNER:
-                retVal = mTunerModel.getSource((SourceConfigTuner) config, bandwidth, channelSpecification);
+                retVal = mTunerModel.getSource((SourceConfigTuner) config, channelSpecification);
                 break;
             case RECORDING:
-                retVal = mRecordingSourceManager.getSource(config, bandwidth);
+                retVal = mRecordingSourceManager.getSource(config, channelSpecification);
             case NONE:
             default:
                 break;

--- a/src/main/java/io/github/dsheirer/source/recording/RecordingSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/recording/RecordingSourceManager.java
@@ -1,19 +1,17 @@
 /*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * sdr-trunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License  along with this program.
+ * If not, see <http://www.gnu.org/licenses/>
+ *
  ******************************************************************************/
 package io.github.dsheirer.source.recording;
 
@@ -22,6 +20,7 @@ import io.github.dsheirer.source.Source;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.config.SourceConfigRecording;
 import io.github.dsheirer.source.config.SourceConfiguration;
+import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 import io.github.dsheirer.source.tuner.channel.TunerChannel;
 import io.github.dsheirer.source.tuner.channel.TunerChannelSource;
 import org.slf4j.Logger;
@@ -33,64 +32,64 @@ import java.util.List;
 
 public class RecordingSourceManager
 {
-	private final static Logger mLog = LoggerFactory.getLogger( RecordingSourceManager.class );
+    private final static Logger mLog = LoggerFactory.getLogger(RecordingSourceManager.class);
 
-	private ArrayList<Recording> mRecordings = new ArrayList<Recording>();
+    private ArrayList<Recording> mRecordings = new ArrayList<Recording>();
 
-	private SettingsManager mSettingsManager;
+    private SettingsManager mSettingsManager;
 
-    public RecordingSourceManager( SettingsManager settingsManager )
-	{
-    	mSettingsManager = settingsManager;
-    	loadRecordings();
-	}
+    public RecordingSourceManager(SettingsManager settingsManager)
+    {
+        mSettingsManager = settingsManager;
+        loadRecordings();
+    }
 
     /**
      * Iterates current recordings to get a tuner channel source for the frequency
      * specified in the channel config's source config object
      */
-    public Source getSource( SourceConfiguration config, int bandwidth )
-    					throws SourceException
+    public Source getSource(SourceConfiguration config, ChannelSpecification channelSpecification)
+        throws SourceException
     {
-    	TunerChannelSource retVal = null;
+        TunerChannelSource retVal = null;
 
-    	if( config instanceof SourceConfigRecording )
-    	{
-    		SourceConfigRecording configRecording = (SourceConfigRecording)config;
-    		
-        	TunerChannel tunerChannel = configRecording.getTunerChannel();
-        	
-        	tunerChannel.setBandwidth( bandwidth );
+        if(config instanceof SourceConfigRecording)
+        {
+            SourceConfigRecording configRecording = (SourceConfigRecording)config;
 
-    		Recording recording = getRecordingFromAlias( 
-    				configRecording.getRecordingAlias() );
-    		
-    		if( recording != null )
-    		{
-    			retVal = recording.getChannel( tunerChannel );
-    		}
-    		else
-    		{
-    			throw new SourceException( "Recording with alias name [" +
-					configRecording.getRecordingAlias() + "] is not currently available" );
-    		}
-    	}
-    	
-    	return retVal;
+            TunerChannel tunerChannel = configRecording.getTunerChannel();
+
+            tunerChannel.setBandwidth(channelSpecification.getBandwidth());
+
+            Recording recording = getRecordingFromAlias(
+                configRecording.getRecordingAlias());
+
+            if(recording != null)
+            {
+                retVal = recording.getChannel(tunerChannel);
+            }
+            else
+            {
+                throw new SourceException("Recording with alias name [" +
+                    configRecording.getRecordingAlias() + "] is not currently available");
+            }
+        }
+
+        return retVal;
     }
-    
-    public Recording getRecordingFromAlias( String alias )
+
+    public Recording getRecordingFromAlias(String alias)
     {
-    	for( Recording recording: mRecordings )
-    	{
-    		if( recording.getRecordingConfiguration()
-    				.getAlias().contentEquals( alias ) )
-    		{
-    			return recording;
-    		}
-    	}
-    	
-    	return null;
+        for(Recording recording : mRecordings)
+        {
+            if(recording.getRecordingConfiguration()
+                .getAlias().contentEquals(alias))
+            {
+                return recording;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -98,47 +97,47 @@ public class RecordingSourceManager
      */
     public List<Recording> getRecordings()
     {
-    	Collections.sort( mRecordings );
-    	
-    	return mRecordings;
-    }
-    
-    public void addRecording( Recording recording )
-    {
-    	mRecordings.add( recording );
-    }
-    
-    public Recording addRecording( RecordingConfiguration config )
-    {
-    	Recording recording = new Recording( mSettingsManager, config );
+        Collections.sort(mRecordings);
 
-    	mRecordings.add( recording );
-    	
-    	return recording;
+        return mRecordings;
     }
-    
-    public void removeRecording( Recording recording )
+
+    public void addRecording(Recording recording)
     {
-    	/* Remove the config from the settings manager */
-    	mSettingsManager.removeRecordingConfiguration( 
-    			recording.getRecordingConfiguration() );
-    	
-    	mRecordings.remove( recording );
+        mRecordings.add(recording);
+    }
+
+    public Recording addRecording(RecordingConfiguration config)
+    {
+        Recording recording = new Recording(mSettingsManager, config);
+
+        mRecordings.add(recording);
+
+        return recording;
+    }
+
+    public void removeRecording(Recording recording)
+    {
+        /* Remove the config from the settings manager */
+        mSettingsManager.removeRecordingConfiguration(
+            recording.getRecordingConfiguration());
+
+        mRecordings.remove(recording);
     }
 
     private void loadRecordings()
     {
-		List<RecordingConfiguration> recordingConfigurations = 
-				mSettingsManager.getRecordingConfigurations();
+        List<RecordingConfiguration> recordingConfigurations =
+            mSettingsManager.getRecordingConfigurations();
 
-		mLog.info( "RecordingSourceManager - discovered [" + 
-		recordingConfigurations.size() + "] recording configurations" );
-		
-		for( RecordingConfiguration config: recordingConfigurations )
-		{
-			Recording recording = new Recording( mSettingsManager, config );
-			
-			mRecordings.add( recording );
-		}
-	}
+        mLog.info("RecordingSourceManager - discovered [" +
+            recordingConfigurations.size() + "] recording configurations");
+
+        for(RecordingConfiguration config : recordingConfigurations)
+        {
+            Recording recording = new Recording(mSettingsManager, config);
+
+            mRecordings.add(recording);
+        }
+    }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerModel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerModel.java
@@ -340,13 +340,13 @@ public class TunerModel extends AbstractTableModel implements Listener<TunerEven
      *
      * Returns null if no tuner can source the channel
      */
-    public Source getSource(SourceConfigTuner config, int bandwidth, ChannelSpecification channelSpecification)
+    public Source getSource(SourceConfigTuner config, ChannelSpecification channelSpecification)
     {
         TunerChannelSource retVal = null;
 
         TunerChannel tunerChannel = config.getTunerChannel();
 
-        tunerChannel.setBandwidth(bandwidth);
+        tunerChannel.setBandwidth(channelSpecification.getBandwidth());
 
         Iterator<Tuner> it = mTuners.iterator();
 

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/ChannelSpecification.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/ChannelSpecification.java
@@ -21,18 +21,21 @@ package io.github.dsheirer.source.tuner.channel;
 public class ChannelSpecification
 {
     private double mMinimumSampleRate;
+    private int mBandwidth;
     private double mPassFrequency;
     private double mStopFrequency;
 
     /**
      * Constructs a channel specification instance.
      * @param minimumSampleRate requested for the channel
+     * @param bandwidth
      * @param passFrequency for the pass band of the channel
      * @param stopFrequency for the stop band of teh channel
      */
-    public ChannelSpecification(double minimumSampleRate, double passFrequency, double stopFrequency)
+    public ChannelSpecification(double minimumSampleRate, int bandwidth, double passFrequency, double stopFrequency)
     {
         mMinimumSampleRate = minimumSampleRate;
+        mBandwidth = bandwidth;
         mPassFrequency = passFrequency;
         mStopFrequency = stopFrequency;
     }
@@ -43,6 +46,14 @@ public class ChannelSpecification
     public double getMinimumSampleRate()
     {
         return mMinimumSampleRate;
+    }
+
+    /**
+     * Bandwidth of the channel in Hertz
+     */
+    public int getBandwidth()
+    {
+        return mBandwidth;
     }
 
     /**


### PR DESCRIPTION
Updates the NBFM decoder to allow user to select between 12.5 and 25.0 kHz channel bandwidth so that 25 kHz channels can be demodulated correctly.
