### PR TITLE
Bumping Jide to 3.6.18 to fix Java 11 reflections error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     compile 'com.github.wendykierp:JTransforms:3.1'
     compile 'pl.edu.icm:JLargeArrays:1.6'
     compile 'net.coderazzi:tablefilter-swing:5.3.1'
-    compile 'com.jidesoft:jide-oss:3.4.3'
+    compile 'com.jidesoft:jide-oss:3.6.18'
     compile 'org.apache.mina:mina-core:2.0.16'
     compile 'org.apache.mina:mina-http:2.0.16'
     compile 'org.apache.axis:axis-jaxrpc:1.4'


### PR DESCRIPTION
This PR resolves issue #442 Runtime error on Java 11.
