### PR TITLE
Bumping usb4java to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,9 @@ dependencies {
     compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'com.miglayout:miglayout-swing:5.0'
 
-    compile 'org.usb4java:usb4java-javax:1.2.0'
-    compile 'org.usb4java:usb4java:1.2.0'
-    compile 'org.usb4java:libusb4java:1.2.0'
+    compile 'org.usb4java:usb4java-javax:1.3.0'
+    compile 'org.usb4java:usb4java:1.3.0'
+    compile 'org.usb4java:libusb4java:1.3.0'
     compile 'javax.usb:usb-api:1.0.2'
     compile 'com.github.wendykierp:JTransforms:3.1'
     compile 'pl.edu.icm:JLargeArrays:1.6'


### PR DESCRIPTION
This PR resolves issue #440 -Update java4usb library to 1.3 and libusb to 1.0.22
