### PR TITLE
Fix for issue #441 Audio Recording Stops After Encountering Error

### DIFF
--- a/src/main/java/io/github/dsheirer/sample/buffer/AbstractReusableBuffer.java
+++ b/src/main/java/io/github/dsheirer/sample/buffer/AbstractReusableBuffer.java
@@ -93,7 +93,7 @@ public abstract class AbstractReusableBuffer
      *
      * This method is thread-safe.
      */
-    public void decrementUserCount()
+    public synchronized void decrementUserCount()
     {
         if(mUserCount.decrementAndGet() <= 0)
         {

--- a/src/main/java/io/github/dsheirer/sample/buffer/AbstractReusableBuffer.java
+++ b/src/main/java/io/github/dsheirer/sample/buffer/AbstractReusableBuffer.java
@@ -93,7 +93,7 @@ public abstract class AbstractReusableBuffer
      *
      * This method is thread-safe.
      */
-    public synchronized void decrementUserCount()
+    public void decrementUserCount()
     {
         if(mUserCount.decrementAndGet() <= 0)
         {
@@ -104,7 +104,7 @@ public abstract class AbstractReusableBuffer
     /**
      * Sends this buffer back to the owning buffer queue for reuse
      */
-    private void recycle()
+    private synchronized void recycle()
     {
         prepareForRecycle();
 


### PR DESCRIPTION
Method doc for decrementUserCount reads that the method is thread-safe, but there exist no locking to ensure thread safety on call into recycle method. Modifying the decrementUserCount method to block other callers to ensure thread-safe access.

This appears to be a hot area of code and there may be a performance hit by doing this, please double check my work here.