### PR TITLE
431 Tuner Channelizer User Preference

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/cic/ComplexPrimeCICDecimate.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/cic/ComplexPrimeCICDecimate.java
@@ -1,18 +1,22 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.dsp.filter.cic;
 
 import io.github.dsheirer.dsp.filter.design.FilterDesignException;
@@ -445,11 +449,24 @@ public class ComplexPrimeCICDecimate implements Listener<ReusableComplexBuffer>
         public void setListener(Listener<ReusableComplexBuffer> listener)
         {
             mReusableComplexBufferListener = listener;
+
+            if(mReusableComplexBufferListener == null)
+            {
+                removeListener();
+            }
         }
 
         public void removeListener()
         {
-            mReusableComplexBufferListener = null;
+            mReusableComplexBufferListener = new Listener<ReusableComplexBuffer>()
+            {
+                @Override
+                public void receive(ReusableComplexBuffer reusableComplexBuffer)
+                {
+                    //empty receiver
+                    reusableComplexBuffer.decrementUserCount();
+                }
+            };
         }
 
         /**

--- a/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
+++ b/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
@@ -157,7 +157,7 @@ public class SDRTrunk implements Listener<TunerEvent>
 
         mJavaFxWindowManager = new JavaFxWindowManager(mUserPreferences);
 
-        mSourceManager = new SourceManager(tunerModel, mSettingsManager);
+        mSourceManager = new SourceManager(tunerModel, mSettingsManager, mUserPreferences);
 
         mChannelProcessingManager = new ChannelProcessingManager(channelMapModel, eventLogManager, recorderManager,
             mSourceManager, aliasModel);

--- a/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer.java
+++ b/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer.java
@@ -1,20 +1,25 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.gui.channelizer;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.SampleType;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
@@ -79,7 +84,7 @@ public class ChannelizerViewer extends JFrame
      */
     public ChannelizerViewer(int channelsPerRow)
     {
-        mTestTuner = new TestTuner();
+        mTestTuner = new TestTuner(new UserPreferences());
 
 //        mChannelCount = (int)(mTestTuner.getTunerController().getUsableBandwidth() / CHANNEL_BANDWIDTH);
         mChannelCount = (int)(mTestTuner.getTunerController().getBandwidth() / CHANNEL_BANDWIDTH);
@@ -544,7 +549,7 @@ public class ChannelizerViewer extends JFrame
         }
         else
         {
-            TestTuner tuner = new TestTuner();
+            TestTuner tuner = new TestTuner(new UserPreferences());
 
             List<TunerChannel> tunerChannels = getTunerChannels(tuner);
 

--- a/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer2.java
+++ b/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer2.java
@@ -1,20 +1,25 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.gui.channelizer;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.SampleType;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
@@ -72,7 +77,7 @@ public class ChannelizerViewer2 extends JFrame
     private ChannelArrayPanel mBottomChannelArrayPanel;
     private DFTSize mMainPanelDFTSize = DFTSize.FFT32768;
     private DFTSize mChannelPanelDFTSize = DFTSize.FFT04096;
-    private TestTuner mTestTuner = new TestTuner();
+    private TestTuner mTestTuner = new TestTuner(new UserPreferences());
 
     /**
      * GUI Test utility for researching polyphase channelizers.

--- a/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorFactory.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorFactory.java
@@ -1,21 +1,26 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 
 package io.github.dsheirer.gui.preference;
 
+import io.github.dsheirer.gui.preference.tuner.TunerPreferenceEditor;
 import io.github.dsheirer.preference.UserPreferences;
 import javafx.scene.Node;
 
@@ -32,6 +37,8 @@ public class PreferenceEditorFactory
                 return new TalkgroupFormatPreferenceEditor(userPreferences);
             case CHANNEL_EVENT:
                 return new DecodeEventViewPreferenceEditor(userPreferences);
+            case TUNER:
+                return new TunerPreferenceEditor(userPreferences);
         }
 
         return null;

--- a/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorType.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorType.java
@@ -1,18 +1,22 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 
 package io.github.dsheirer.gui.preference;
 
@@ -21,8 +25,9 @@ package io.github.dsheirer.gui.preference;
  */
 public enum PreferenceEditorType
 {
-    CHANNEL_EVENT("Channel Events"),
-    TALKGROUP_FORMAT("Talkgroups");
+    CHANNEL_EVENT("Channel Event"),
+    TALKGROUP_FORMAT("Talkgroup Display"),
+    TUNER("Tuner");
 
     private String mLabel;
 

--- a/src/main/java/io/github/dsheirer/gui/preference/PreferencesEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/PreferencesEditor.java
@@ -1,18 +1,22 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 
 package io.github.dsheirer.gui.preference;
 
@@ -188,6 +192,7 @@ public class PreferencesEditor extends Application
             TreeItem<String> displayItem = new TreeItem<>("Display");
             displayItem.getChildren().add(new TreeItem(PreferenceEditorType.CHANNEL_EVENT));
             displayItem.getChildren().add(new TreeItem(PreferenceEditorType.TALKGROUP_FORMAT));
+            displayItem.getChildren().add(new TreeItem(PreferenceEditorType.TUNER));
             treeRoot.getChildren().add(displayItem);
             displayItem.setExpanded(true);
 

--- a/src/main/java/io/github/dsheirer/gui/preference/TalkgroupFormatPreferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/TalkgroupFormatPreferenceEditor.java
@@ -26,9 +26,11 @@ import io.github.dsheirer.preference.identifier.TalkgroupFormatPreference;
 import io.github.dsheirer.protocol.Protocol;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.Separator;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 
@@ -58,6 +60,7 @@ public class TalkgroupFormatPreferenceEditor extends HBox
 
             mEditorPane.add(new Label("Protocol"), 0, row);
             mEditorPane.add(new Label("Display Format"), 1, row++);
+            mEditorPane.add(new Separator(Orientation.HORIZONTAL), 0, row++, 3, 1);
 
             for(Protocol protocol : Protocol.TALKGROUP_PROTOCOLS)
             {

--- a/src/main/java/io/github/dsheirer/gui/preference/tuner/TunerPreferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/tuner/TunerPreferenceEditor.java
@@ -1,0 +1,159 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.gui.preference.tuner;
+
+import io.github.dsheirer.preference.UserPreferences;
+import io.github.dsheirer.preference.tuner.ChannelizerType;
+import io.github.dsheirer.preference.tuner.TunerPreference;
+import javafx.geometry.HPos;
+import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.Label;
+import javafx.scene.control.Separator;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+
+
+/**
+ * Preference settings for channel event view
+ */
+public class TunerPreferenceEditor extends HBox
+{
+    private static final String HELP_TEXT_POLYPHASE = "Processes all channels from tuner.  This " +
+        "channelizer is more efficient when decoding 3 or more channels.";
+    private static final String HELP_TEXT_HETERODYNE = "Processes each channel on-demand.  This " +
+        "channelizer may work better for computers with constrained resources when processing a small number of channels.";
+
+    private TunerPreference mTunerPreference;
+    private GridPane mEditorPane;
+    private ChoiceBox<ChannelizerType> mChannelizerTypeChoiceBox;
+    private Label mChannelizerLabel;
+    private Label mPolyphaseLabel;
+    private Label mHelpTextPolyphaseLabel;
+    private Label mHeterodyneLabel;
+    private Label mHelpTextHeterodyneLabel;
+
+    public TunerPreferenceEditor(UserPreferences userPreferences)
+    {
+        mTunerPreference = userPreferences.getTunerPreference();
+        getChildren().add(getEditorPane());
+    }
+
+    private GridPane getEditorPane()
+    {
+        if(mEditorPane == null)
+        {
+            mEditorPane = new GridPane();
+            mEditorPane.setPadding(new Insets(10, 10, 10, 10));
+            GridPane.setMargin(getChannelizerLabel(), new Insets(0, 10, 0, 0));
+            GridPane.setHalignment(getChannelizerLabel(), HPos.LEFT);
+            mEditorPane.add(getChannelizerLabel(), 0, 0);
+            mEditorPane.add(getChannelizerTypeChoiceBox(), 1, 0);
+            mEditorPane.add(new Separator(Orientation.HORIZONTAL), 0, 1, 2, 1);
+            mEditorPane.add(getPolyphaseLabel(), 0, 2, 2, 1);
+            mEditorPane.add(getHelpTextPolyphaseLabel(), 0, 3, 2, 3);
+            mEditorPane.add(new Label(" "), 0, 6);
+            mEditorPane.add(getHeterodyneLabel(), 0, 7, 2, 1);
+            mEditorPane.add(getHelpTextHeterodyneLabel(), 0, 8, 2, 3);
+        }
+
+        return mEditorPane;
+    }
+
+    private Label getChannelizerLabel()
+    {
+        if(mChannelizerLabel == null)
+        {
+            mChannelizerLabel = new Label("Channelizer Type");
+        }
+
+        return mChannelizerLabel;
+    }
+
+    private ChoiceBox<ChannelizerType> getChannelizerTypeChoiceBox()
+    {
+        if(mChannelizerTypeChoiceBox == null)
+        {
+            mChannelizerTypeChoiceBox = new ChoiceBox<>();
+            mChannelizerTypeChoiceBox.getItems().addAll(ChannelizerType.values());
+
+            ChannelizerType current = mTunerPreference.getChannelizerType();
+            mChannelizerTypeChoiceBox.getSelectionModel().select(current);
+
+            mChannelizerTypeChoiceBox.setOnAction(event -> {
+                ChannelizerType selected = mChannelizerTypeChoiceBox.getSelectionModel().getSelectedItem();
+                mTunerPreference.setChannelizerType(selected);
+
+                Label label = new Label("Please restart the application for this change to take effect");
+                label.setWrapText(true);
+                Alert alert = new Alert(Alert.AlertType.WARNING);
+                alert.getDialogPane().setContent(label);
+                alert.show();
+            });
+        }
+
+        return mChannelizerTypeChoiceBox;
+    }
+
+    private Label getPolyphaseLabel()
+    {
+        if(mPolyphaseLabel == null)
+        {
+            mPolyphaseLabel = new Label("Polyphase (default)");
+        }
+
+        return mPolyphaseLabel;
+    }
+
+    private Label getHelpTextPolyphaseLabel()
+    {
+        if(mHelpTextPolyphaseLabel == null)
+        {
+            mHelpTextPolyphaseLabel = new Label(HELP_TEXT_POLYPHASE);
+            mHelpTextPolyphaseLabel.setWrapText(true);
+        }
+
+        return mHelpTextPolyphaseLabel;
+    }
+
+    private Label getHeterodyneLabel()
+    {
+        if(mHeterodyneLabel == null)
+        {
+            mHeterodyneLabel = new Label("Heterodyne");
+        }
+
+        return mHeterodyneLabel;
+    }
+
+    private Label getHelpTextHeterodyneLabel()
+    {
+        if(mHelpTextHeterodyneLabel == null)
+        {
+            mHelpTextHeterodyneLabel = new Label(HELP_TEXT_HETERODYNE);
+            mHelpTextHeterodyneLabel.setWrapText(true);
+        }
+
+        return mHelpTextHeterodyneLabel;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25DecoderState.java
@@ -2145,7 +2145,8 @@ public class P25DecoderState extends DecoderState implements IChannelEventListen
                         .build());
                     break;
                 default:
-                    mLog.debug("Unrecognized TSBK Opcode: " + tsbk.getOpcode().name());
+                    mLog.debug("Unrecognized TSBK Opcode: " + tsbk.getOpcode().name() + " VENDOR:" + tsbk.getVendor() +
+                        " OPCODE:" + tsbk.getOpcodeNumber());
                     break;
             }
         }
@@ -2378,7 +2379,8 @@ public class P25DecoderState extends DecoderState implements IChannelEventListen
                     .build());
                 break;
             default:
-                mLog.info("Unrecognized/Unprocessed Link Control Word Opcode: " + lcw.getOpcode().name());
+                mLog.debug("Unrecognized LCW Opcode: " + lcw.getOpcode().name() + " VENDOR:" + lcw.getVendor() +
+                    " OPCODE:" + lcw.getOpcodeNumber());
                 break;
         }
     }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/lc/LinkControlWord.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/lc/LinkControlWord.java
@@ -1,3 +1,23 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
 package io.github.dsheirer.module.decode.p25.message.lc;
 
 import io.github.dsheirer.bits.BinaryMessage;
@@ -113,6 +133,14 @@ public abstract class LinkControlWord
         }
 
         return mLinkControlOpcode;
+    }
+
+    /**
+     * Opcode number for this LCW
+     */
+    public int getOpcodeNumber()
+    {
+        return getMessage().getInt(OPCODE);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/osp/AMBTCGroupDataChannelGrant.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/osp/AMBTCGroupDataChannelGrant.java
@@ -126,6 +126,11 @@ public class AMBTCGroupDataChannelGrant extends AMBTCMessage implements IFrequen
             }
         }
 
+        if(mChannel == null)
+        {
+            mChannel = APCO25Channel.create(-1, 0);
+        }
+
         return mChannel;
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/TSBKMessage.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/TSBKMessage.java
@@ -1,3 +1,23 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
 package io.github.dsheirer.module.decode.p25.message.tsbk;
 
 import io.github.dsheirer.bits.BinaryMessage;
@@ -98,6 +118,14 @@ public abstract class TSBKMessage extends P25Message
     public Opcode getOpcode()
     {
         return getOpcode(getMessage(), getDirection(), getVendor());
+    }
+
+    /**
+     * Opcode numeric value
+     */
+    public int getOpcodeNumber()
+    {
+        return getMessage().getInt(OPCODE);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/preference/UserPreferences.java
+++ b/src/main/java/io/github/dsheirer/preference/UserPreferences.java
@@ -24,6 +24,7 @@ import io.github.dsheirer.eventbus.MyEventBus;
 import io.github.dsheirer.preference.event.DecodeEventPreference;
 import io.github.dsheirer.preference.identifier.TalkgroupFormatPreference;
 import io.github.dsheirer.preference.playlist.FilePreferences;
+import io.github.dsheirer.preference.tuner.TunerPreference;
 import io.github.dsheirer.sample.Listener;
 
 /**
@@ -34,6 +35,7 @@ public class UserPreferences implements Listener<PreferenceType>
     private DecodeEventPreference mDecodeEventPreference;
     private FilePreferences mFilePreferences;
     private TalkgroupFormatPreference mTalkgroupFormatPreference;
+    private TunerPreference mTunerPreference;
 
     /**
      * Constructs a new user preferences instance
@@ -68,6 +70,14 @@ public class UserPreferences implements Listener<PreferenceType>
     }
 
     /**
+     * Tuner preferences
+     */
+    public TunerPreference getTunerPreference()
+    {
+        return mTunerPreference;
+    }
+
+    /**
      * Loads the managed preferences
      */
     private void loadPreferenceTypes()
@@ -75,6 +85,7 @@ public class UserPreferences implements Listener<PreferenceType>
         mDecodeEventPreference = new DecodeEventPreference(this);
         mFilePreferences = new FilePreferences(this::receive);
         mTalkgroupFormatPreference = new TalkgroupFormatPreference(this);
+        mTunerPreference = new TunerPreference(this);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/preference/tuner/ChannelizerType.java
+++ b/src/main/java/io/github/dsheirer/preference/tuner/ChannelizerType.java
@@ -18,15 +18,25 @@
  * *****************************************************************************
  */
 
-package io.github.dsheirer.preference;
+package io.github.dsheirer.preference.tuner;
 
 /**
- * Types of preferences
+ * Channelizer Type - identifies the type of channelizer that the tuner will use to provide DDR channels
  */
-public enum PreferenceType
+public enum ChannelizerType
 {
-    DECODE_EVENT,
-    FILES,
-    IDENTIFIER,
-    TUNER;
+    POLYPHASE("Polyphase"),
+    HETERODYNE(" Heterodyne");
+
+    private String mLabel;
+
+    ChannelizerType(String label)
+    {
+        mLabel = label;
+    }
+
+    public String toString()
+    {
+        return mLabel;
+    }
 }

--- a/src/main/java/io/github/dsheirer/preference/tuner/TunerPreference.java
+++ b/src/main/java/io/github/dsheirer/preference/tuner/TunerPreference.java
@@ -1,0 +1,98 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.preference.tuner;
+
+import io.github.dsheirer.preference.Preference;
+import io.github.dsheirer.preference.PreferenceType;
+import io.github.dsheirer.sample.Listener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.prefs.Preferences;
+
+/**
+ * Tuner preferences
+ */
+public class TunerPreference extends Preference
+{
+    private final static Logger mLog = LoggerFactory.getLogger(TunerPreference.class);
+    private Preferences mPreferences = Preferences.userNodeForPackage(TunerPreference.class);
+    private static final String PREFERENCE_KEY_CHANNELIZER_TYPE = "channelizer.type";
+
+    private ChannelizerType mChannelizerType;
+
+    /**
+     * Constructs a tuner preference with the update listener
+     *
+     * @param updateListener
+     */
+    public TunerPreference(Listener<PreferenceType> updateListener)
+    {
+        super(updateListener);
+    }
+
+    @Override
+    public PreferenceType getPreferenceType()
+    {
+        return PreferenceType.TUNER;
+    }
+
+
+    /**
+     * Channelizer type used by the tuners
+     */
+    public ChannelizerType getChannelizerType()
+    {
+        if(mChannelizerType == null)
+        {
+            String type = mPreferences.get(PREFERENCE_KEY_CHANNELIZER_TYPE, ChannelizerType.POLYPHASE.name());
+
+            if(type != null)
+            {
+                if(type.equalsIgnoreCase(ChannelizerType.POLYPHASE.name()))
+                {
+                    mChannelizerType = ChannelizerType.POLYPHASE;
+                }
+                else if(type.equalsIgnoreCase(ChannelizerType.HETERODYNE.name()))
+                {
+                    mChannelizerType = ChannelizerType.HETERODYNE;
+                }
+            }
+
+            if(type == null)
+            {
+                mChannelizerType = ChannelizerType.POLYPHASE;
+            }
+        }
+
+        return mChannelizerType;
+    }
+
+    /**
+     * Sets the channelizer type use by tuners
+     */
+    public void setChannelizerType(ChannelizerType type)
+    {
+        mChannelizerType = type;
+        mPreferences.put(PREFERENCE_KEY_CHANNELIZER_TYPE, mChannelizerType.name());
+        notifyPreferenceUpdated();
+    }
+}

--- a/src/main/java/io/github/dsheirer/source/SourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/SourceManager.java
@@ -1,6 +1,7 @@
-/*******************************************************************************
+/*
+ * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,10 +15,11 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.settings.SettingsManager;
 import io.github.dsheirer.source.config.SourceConfigTuner;
 import io.github.dsheirer.source.config.SourceConfiguration;
@@ -34,12 +36,12 @@ public class SourceManager
     private TunerManager mTunerManager;
     private TunerModel mTunerModel;
 
-    public SourceManager(TunerModel tunerModel, SettingsManager settingsManager)
+    public SourceManager(TunerModel tunerModel, SettingsManager settingsManager, UserPreferences userPreferences)
     {
         mTunerModel = tunerModel;
         mMixerManager = new MixerManager();
         mRecordingSourceManager = new RecordingSourceManager(settingsManager);
-        mTunerManager = new TunerManager(mMixerManager, tunerModel);
+        mTunerManager = new TunerManager(mMixerManager, tunerModel, userPreferences);
 
         //TODO: change mixer & recording managers to be models and hand them
         //in via the constructor.  Perform loading outside of this class.

--- a/src/main/java/io/github/dsheirer/source/tuner/Tuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/Tuner.java
@@ -1,26 +1,33 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source.tuner;
 
+import io.github.dsheirer.preference.UserPreferences;
+import io.github.dsheirer.preference.tuner.ChannelizerType;
 import io.github.dsheirer.sample.Broadcaster;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.source.ISourceEventProcessor;
 import io.github.dsheirer.source.SourceEvent;
 import io.github.dsheirer.source.tuner.TunerEvent.Event;
 import io.github.dsheirer.source.tuner.manager.ChannelSourceManager;
+import io.github.dsheirer.source.tuner.manager.HeterodyneChannelSourceManager;
 import io.github.dsheirer.source.tuner.manager.PolyphaseChannelSourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,15 +51,28 @@ public abstract class Tuner implements ISourceEventProcessor
      * @param name of the tuner
      * @param tunerController for the tuner
      */
-    public Tuner(String name, TunerController tunerController)
+    public Tuner(String name, TunerController tunerController, UserPreferences userPreferences)
     {
         mName = name;
         mTunerController = tunerController;
         //Register to receive frequency and sample rate change notifications
         mTunerController.addListener(this::process);
 
-        mChannelSourceManager = new PolyphaseChannelSourceManager(mTunerController);
-//        mChannelSourceManager = new HeterodyneChannelSourceManager(mTunerController);
+        ChannelizerType channelizerType = userPreferences.getTunerPreference().getChannelizerType();
+
+        if(channelizerType == ChannelizerType.POLYPHASE)
+        {
+            mChannelSourceManager = new PolyphaseChannelSourceManager(mTunerController);
+        }
+        else if(channelizerType == ChannelizerType.HETERODYNE)
+        {
+            mChannelSourceManager = new HeterodyneChannelSourceManager(mTunerController);
+        }
+        else
+        {
+            throw new IllegalArgumentException("Unrecognized channelizer type: " + channelizerType);
+        }
+
 
         //Register to receive channel count change notifications
         mChannelSourceManager.addSourceEventListener(this::process);

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerManager.java
@@ -1,20 +1,25 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source.tuner;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.mixer.MixerManager;
 import io.github.dsheirer.source.tuner.airspy.AirspyTuner;
@@ -44,7 +49,7 @@ public class TunerManager
 
     private MixerManager mMixerManager;
     private TunerModel mTunerModel;
-
+    private UserPreferences mUserPreferences;
 
     /**
      * Application-wide LibUSB timeout processor for transfer buffers.  All classes that need to use USB transfer
@@ -58,10 +63,11 @@ public class TunerManager
         LIBUSB_TRANSFER_PROCESSOR = new USBMasterProcessor();
     }
 
-    public TunerManager(MixerManager mixerManager, TunerModel tunerModel)
+    public TunerManager(MixerManager mixerManager, TunerModel tunerModel, UserPreferences userPreferences)
     {
         mMixerManager = mixerManager;
         mTunerModel = tunerModel;
+        mUserPreferences = userPreferences;
 
         initTuners();
     }
@@ -251,7 +257,7 @@ public class TunerManager
 
             airspyController.init();
 
-            AirspyTuner tuner = new AirspyTuner(airspyController);
+            AirspyTuner tuner = new AirspyTuner(airspyController, mUserPreferences);
 
             return new TunerInitStatus(tuner, "LOADED");
         }
@@ -286,7 +292,7 @@ public class TunerManager
             {
                 controller.init();
 
-                FCDTuner tuner = new FCDTuner(controller);
+                FCDTuner tuner = new FCDTuner(controller, mUserPreferences);
 
                 return new TunerInitStatus(tuner, "LOADED");
             }
@@ -320,7 +326,7 @@ public class TunerManager
             {
                 controller.init();
 
-                FCDTuner tuner = new FCDTuner(controller);
+                FCDTuner tuner = new FCDTuner(controller, mUserPreferences);
 
                 return new TunerInitStatus(tuner, "LOADED");
             }
@@ -349,7 +355,7 @@ public class TunerManager
 
             hackRFController.init();
 
-            HackRFTuner tuner = new HackRFTuner(hackRFController);
+            HackRFTuner tuner = new HackRFTuner(hackRFController, mUserPreferences);
 
             return new TunerInitStatus(tuner, "LOADED");
         }
@@ -392,7 +398,7 @@ public class TunerManager
 
                     controller.init();
 
-                    RTL2832Tuner rtlTuner = new RTL2832Tuner(tunerClass, controller);
+                    RTL2832Tuner rtlTuner = new RTL2832Tuner(tunerClass, controller, mUserPreferences);
 
                     return new TunerInitStatus(rtlTuner, "LOADED");
                 }
@@ -408,7 +414,7 @@ public class TunerManager
 
                     controller.init();
 
-                    RTL2832Tuner rtlTuner = new RTL2832Tuner(tunerClass, controller);
+                    RTL2832Tuner rtlTuner = new RTL2832Tuner(tunerClass, controller, mUserPreferences);
 
                     return new TunerInitStatus(rtlTuner, "LOADED");
                 }

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTuner.java
@@ -1,22 +1,25 @@
-/*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2015 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
- ******************************************************************************/
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source.tuner.airspy;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.source.tuner.Tuner;
 import io.github.dsheirer.source.tuner.TunerClass;
 import io.github.dsheirer.source.tuner.TunerType;
@@ -26,48 +29,48 @@ import org.slf4j.LoggerFactory;
 
 public class AirspyTuner extends Tuner
 {
-	private final static Logger mLog = LoggerFactory.getLogger( AirspyTuner.class );
+    private final static Logger mLog = LoggerFactory.getLogger(AirspyTuner.class);
 
-	public AirspyTuner( AirspyTunerController controller )
-	{
-		super( "Airspy " + controller.getDeviceInfo().getSerialNumber(), controller );
-	}
+    public AirspyTuner(AirspyTunerController controller, UserPreferences userPreferences)
+    {
+        super("Airspy " + controller.getDeviceInfo().getSerialNumber(), controller, userPreferences);
+    }
 
-	public AirspyTunerController getController()
-	{
-		return (AirspyTunerController)getTunerController();
-	}
+    public AirspyTunerController getController()
+    {
+        return (AirspyTunerController)getTunerController();
+    }
 
-	@Override
-	public String getUniqueID()
-	{
-		try
-		{
-			return getController().getDeviceInfo().getSerialNumber();
-		}
-		catch( Exception e )
-		{
-			mLog.error( "error getting serial number", e );
-		}
+    @Override
+    public String getUniqueID()
+    {
+        try
+        {
+            return getController().getDeviceInfo().getSerialNumber();
+        }
+        catch(Exception e)
+        {
+            mLog.error("error getting serial number", e);
+        }
 
-		return BoardID.AIRSPY.getLabel();
-	}
+        return BoardID.AIRSPY.getLabel();
+    }
 
-	@Override
-	public TunerClass getTunerClass()
-	{
-		return TunerClass.AIRSPY;
-	}
+    @Override
+    public TunerClass getTunerClass()
+    {
+        return TunerClass.AIRSPY;
+    }
 
-	@Override
-	public TunerType getTunerType()
-	{
-		return TunerType.AIRSPY_R820T;
-	}
+    @Override
+    public TunerType getTunerType()
+    {
+        return TunerType.AIRSPY_R820T;
+    }
 
-	@Override
-	public double getSampleSize()
-	{
-		return 13.0;
-	}
+    @Override
+    public double getSampleSize()
+    {
+        return 13.0;
+    }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTuner.java
@@ -1,62 +1,67 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source.tuner.fcd;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.source.tuner.Tuner;
 import io.github.dsheirer.source.tuner.TunerClass;
 import io.github.dsheirer.source.tuner.TunerType;
 
 public class FCDTuner extends Tuner
 {
-	public FCDTuner(FCDTunerController controller)
-	{
-		super( controller.getConfiguration().toString(), controller);
-	}
-	
-	public void dispose()
-	{
-		getController().dispose();
-	}
-	
-	public FCDTunerController getController()
-	{
-		return (FCDTunerController)getTunerController();
-	}
-	
-	@Override
+    public FCDTuner(FCDTunerController controller, UserPreferences userPreferences)
+    {
+        super(controller.getConfiguration().toString(), controller, userPreferences);
+    }
+
+    public void dispose()
+    {
+        getController().dispose();
+    }
+
+    public FCDTunerController getController()
+    {
+        return (FCDTunerController)getTunerController();
+    }
+
+    @Override
     public TunerClass getTunerClass()
     {
-	    return getController().getTunerClass();
+        return getController().getTunerClass();
     }
 
-	@Override
+    @Override
     public TunerType getTunerType()
     {
-	    return getController().getTunerType();
+        return getController().getTunerType();
     }
 
-	@Override
+    @Override
     public String getUniqueID()
     {
-	    return getController().getUSBAddress();
+        return getController().getUSBAddress();
     }
 
-	@Override
-	public double getSampleSize()
-	{
-		return 16.0;
-	}
+    @Override
+    public double getSampleSize()
+    {
+        return 16.0;
+    }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTuner.java
@@ -1,20 +1,25 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source.tuner.hackrf;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.tuner.Tuner;
 import io.github.dsheirer.source.tuner.TunerClass;
@@ -25,11 +30,11 @@ import org.slf4j.LoggerFactory;
 
 public class HackRFTuner extends Tuner
 {
-    private final static Logger mLog = LoggerFactory.getLogger( HackRFTuner.class );
+    private final static Logger mLog = LoggerFactory.getLogger(HackRFTuner.class);
 
-    public HackRFTuner( HackRFTunerController controller ) throws SourceException
+    public HackRFTuner(HackRFTunerController controller, UserPreferences userPreferences) throws SourceException
     {
-        super( "HackRF", controller );
+        super("HackRF", controller, userPreferences);
     }
 
     public HackRFTunerController getController()
@@ -62,9 +67,9 @@ public class HackRFTuner extends Tuner
         {
             return getController().getSerial().getSerialNumber();
         }
-        catch( Exception e )
+        catch(Exception e)
         {
-            mLog.error( "error gettting serial number", e );
+            mLog.error("error gettting serial number", e);
         }
 
         return BoardID.HACKRF_ONE.getLabel();

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832Tuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832Tuner.java
@@ -1,22 +1,25 @@
-/*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014-2016 Dennis Sheirer
- * 
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- * 
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- * 
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
- ******************************************************************************/
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source.tuner.rtl;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.tuner.Tuner;
 import io.github.dsheirer.source.tuner.TunerClass;
@@ -30,10 +33,11 @@ public class RTL2832Tuner extends Tuner
 
     private TunerClass mTunerClass;
 
-    public RTL2832Tuner(TunerClass tunerClass, RTL2832TunerController controller) throws SourceException
+    public RTL2832Tuner(TunerClass tunerClass, RTL2832TunerController controller, UserPreferences userPreferences)
+        throws SourceException
     {
         super(tunerClass.getVendorDeviceLabel() + "/" + controller.getTunerType().getLabel() + " " +
-            controller.getUniqueID(), controller);
+            controller.getUniqueID(), controller, userPreferences);
 
         mTunerClass = tunerClass;
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/test/TestTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/test/TestTuner.java
@@ -1,6 +1,7 @@
-/*******************************************************************************
+/*
+ * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,10 +15,11 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * *****************************************************************************
+ */
 package io.github.dsheirer.source.tuner.test;
 
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.source.tuner.Tuner;
 import io.github.dsheirer.source.tuner.TunerClass;
 import io.github.dsheirer.source.tuner.TunerType;
@@ -34,9 +36,9 @@ public class TestTuner extends Tuner
     private static int mInstanceCounter = 1;
     private final int mInstanceID = mInstanceCounter++;
 
-    public TestTuner()
+    public TestTuner(UserPreferences userPreferences)
     {
-        super("Test Tuner", new TestTunerController());
+        super("Test Tuner", new TestTunerController(), userPreferences);
     }
 
     /**


### PR DESCRIPTION
Resolves #431 
Adds tuner preference editor with channelizer type options.  
Updates tuners to use the preference to select either polyphase or heterodyne channelizers.
