### PR TITLE
433 Channel Auto Start Window To Front

### DIFF
--- a/src/main/java/io/github/dsheirer/controller/channel/ChannelAutoStartFrame.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/ChannelAutoStartFrame.java
@@ -74,6 +74,7 @@ public class ChannelAutoStartFrame extends JFrame
 
         EventQueue.invokeLater(() -> {
             setVisible(true);
+            toFront();
             startTimer();
         });
     }


### PR DESCRIPTION
Resolves #433
Adds toFront() to channel auto start frame to force the window to the front
