### PR TITLE
462 AliasList Support For TalkgroupRange and PatchGroup

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/id/talkgroup/TalkgroupRange.java
+++ b/src/main/java/io/github/dsheirer/alias/id/talkgroup/TalkgroupRange.java
@@ -120,6 +120,16 @@ public class TalkgroupRange extends AliasID
         return false;
     }
 
+    /**
+     * Indicates if this talkgroup range contains/includes the talkgroup value
+     * @param talkgroupValue
+     * @return
+     */
+    public boolean contains(int talkgroupValue)
+    {
+        return getMinTalkgroup() <= talkgroupValue && talkgroupValue <= getMaxTalkgroup();
+    }
+
     @JacksonXmlProperty(isAttribute = true, localName = "type", namespace = "http://www.w3.org/2001/XMLSchema-instance")
     @Override
     public AliasIDType getType()


### PR DESCRIPTION
Resolves #462

Updates alias list to support talkgroup range and patch groups.

Note: see also #463 which adds support for multiple aliases matching a patch group.