### PR TITLE
464 List Of Aliases Per Identifier

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/action/AliasActionManager.java
+++ b/src/main/java/io/github/dsheirer/alias/action/AliasActionManager.java
@@ -1,6 +1,7 @@
-/*******************************************************************************
+/*
+ * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,8 +15,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * *****************************************************************************
+ */
 package io.github.dsheirer.alias.action;
 
 import io.github.dsheirer.alias.Alias;
@@ -56,13 +57,16 @@ public class AliasActionManager extends Module implements IMessageListener, List
 
             for(Identifier identifier: identifiers)
             {
-                Alias alias = mAliasList.getAlias(identifier);
+                List<Alias> aliases = mAliasList.getAliases(identifier);
 
-                if(alias != null && alias.hasActions())
+                for(Alias alias: aliases)
                 {
-                    for(AliasAction action: alias.getAction())
+                    if(alias != null && alias.hasActions())
                     {
-                        action.execute(alias, message);
+                        for(AliasAction action: alias.getAction())
+                        {
+                            action.execute(alias, message);
+                        }
                     }
                 }
             }

--- a/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastBroadcastMetadataUpdater.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastBroadcastMetadataUpdater.java
@@ -1,6 +1,7 @@
-/*******************************************************************************
+/*
+ * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,10 +15,11 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * *****************************************************************************
+ */
 package io.github.dsheirer.audio.broadcast.icecast;
 
+import com.google.common.base.Joiner;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasList;
 import io.github.dsheirer.alias.AliasModel;
@@ -47,6 +49,7 @@ import java.net.InetSocketAddress;
 import java.net.URLEncoder;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.LinkedTransferQueue;
@@ -208,11 +211,11 @@ public class IcecastBroadcastMetadataUpdater implements IBroadcastMetadataUpdate
             {
                 sb.append("TO:").append(to);
 
-                Alias toAlias = aliasList != null ? aliasList.getAlias(to) : null;
+                List<Alias> aliases = aliasList.getAliases(to);
 
-                if(toAlias != null)
+                if(!aliases.isEmpty())
                 {
-                    sb.append(" ").append(toAlias.getName());
+                    sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
                 }
             }
             else
@@ -226,11 +229,11 @@ public class IcecastBroadcastMetadataUpdater implements IBroadcastMetadataUpdate
             {
                 sb.append(" FROM:").append(from);
 
-                Alias fromAlias = aliasList != null ? aliasList.getAlias(from) : null;
+                List<Alias> aliases = aliasList.getAliases(from);
 
-                if(fromAlias != null)
+                if(!aliases.isEmpty())
                 {
-                    sb.append(" ").append(fromAlias.getName());
+                    sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
                 }
             }
             else

--- a/src/main/java/io/github/dsheirer/audio/broadcast/shoutcast/v1/ShoutcastV1BroadcastMetadataUpdater.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/shoutcast/v1/ShoutcastV1BroadcastMetadataUpdater.java
@@ -1,6 +1,7 @@
-/*******************************************************************************
+/*
+ * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,10 +15,11 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * *****************************************************************************
+ */
 package io.github.dsheirer.audio.broadcast.shoutcast.v1;
 
+import com.google.common.base.Joiner;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasList;
 import io.github.dsheirer.alias.AliasModel;
@@ -45,6 +47,7 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.LinkedTransferQueue;
@@ -200,15 +203,16 @@ public class ShoutcastV1BroadcastMetadataUpdater implements IBroadcastMetadataUp
                 to = identifierCollection.getIdentifier(IdentifierClass.USER, Form.TALKGROUP, Role.TO);
             }
 
-            Alias toAlias = aliasList != null ? aliasList.getAlias(to) : null;
+            if(to != null)
+            {
+                sb.append("TO:").append(to);
 
-            if(toAlias != null)
-            {
-                sb.append("TO:").append(toAlias.getName());
-            }
-            else if(to != null)
-            {
-                sb.append("TO:").append(to.toString());
+                List<Alias> aliases = aliasList.getAliases(to);
+
+                if(!aliases.isEmpty())
+                {
+                    sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
+                }
             }
             else
             {
@@ -217,15 +221,16 @@ public class ShoutcastV1BroadcastMetadataUpdater implements IBroadcastMetadataUp
 
             Identifier from = identifierCollection.getIdentifier(IdentifierClass.USER, Form.TALKGROUP, Role.FROM);
 
-            Alias fromAlias = aliasList != null ? aliasList.getAlias(from) : null;
+            if(from != null)
+            {
+                sb.append(" FROM:").append(from);
 
-            if(fromAlias != null)
-            {
-                sb.append(" FROM:").append(fromAlias.getName());
-            }
-            else if(from != null)
-            {
-                sb.append(" FROM:").append(from.toString());
+                List<Alias> aliases = aliasList.getAliases(from);
+
+                if(!aliases.isEmpty())
+                {
+                    sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
+                }
             }
             else
             {

--- a/src/main/java/io/github/dsheirer/audio/broadcast/shoutcast/v2/ShoutcastV2AudioBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/shoutcast/v2/ShoutcastV2AudioBroadcaster.java
@@ -1,6 +1,7 @@
-/*******************************************************************************
+/*
+ * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+ * Copyright (C) 2014-2018 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,10 +15,11 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * *****************************************************************************
+ */
 package io.github.dsheirer.audio.broadcast.shoutcast.v2;
 
+import com.google.common.base.Joiner;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasList;
 import io.github.dsheirer.alias.AliasModel;
@@ -279,32 +281,44 @@ public class ShoutcastV2AudioBroadcaster extends AudioBroadcaster implements IBr
                 AliasList aliasList = mAliasModel.getAliasList(identifierCollection);
 
                 Identifier to = identifierCollection.getIdentifier(IdentifierClass.USER, Form.PATCH_GROUP, Role.TO);
+
                 if(to == null)
                 {
                     to = identifierCollection.getIdentifier(IdentifierClass.USER, Form.TALKGROUP, Role.TO);
                 }
 
-                Alias toAlias = aliasList != null ? aliasList.getAlias(to) : null;
+                if(to != null)
+                {
+                    sb.append("TO:").append(to);
 
-                if(toAlias != null)
-                {
-                    sb.append(UltravoxMetadata.TITLE_2.asXML(toAlias.getName()));
+                    List<Alias> aliases = aliasList.getAliases(to);
+
+                    if(!aliases.isEmpty())
+                    {
+                        sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
+                    }
                 }
-                else if(to != null)
+                else
                 {
-                    sb.append(UltravoxMetadata.TITLE_2.asXML(to.toString()));
+                    sb.append("TO:UNKNOWN");
                 }
 
                 Identifier from = identifierCollection.getIdentifier(IdentifierClass.USER, Form.TALKGROUP, Role.FROM);
-                Alias fromAlias = aliasList != null ? aliasList.getAlias(from) : null;
 
-                if(fromAlias != null)
+                if(from != null)
                 {
-                    sb.append(UltravoxMetadata.TITLE_3.asXML("From:" + fromAlias.getName()));
+                    sb.append(" FROM:").append(from);
+
+                    List<Alias> aliases = aliasList.getAliases(from);
+
+                    if(!aliases.isEmpty())
+                    {
+                        sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
+                    }
                 }
-                else if(from != null)
+                else
                 {
-                    sb.append(UltravoxMetadata.TITLE_3.asXML("From:" + from.toString()));
+                    sb.append(" FROM:UNKNOWN");
                 }
             }
             else

--- a/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadata.java
+++ b/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadata.java
@@ -39,6 +39,9 @@ import io.github.dsheirer.sample.Listener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Channel metadata containing details about the channel configuration, decoder state and current
  * set of decoded user identifiers (ie TO and FROM).
@@ -55,9 +58,9 @@ public class ChannelMetadata implements Listener<IdentifierUpdateNotification>, 
     private DecoderLogicalChannelNameIdentifier mDecoderLogicalChannelNameIdentifier;
     private DecoderTypeConfigurationIdentifier mDecoderTypeConfigurationIdentifier;
     private Identifier mFromIdentifier;
-    private Alias mFromIdentifierAlias;
+    private List<Alias> mFromIdentifierAliases;
     private Identifier mToIdentifier;
-    private Alias mToIdentifierAlias;
+    private List<Alias> mToIdentifierAliases;
 
     private IChannelMetadataUpdateListener mIChannelMetadataUpdateListener;
     private AliasModel mAliasModel;
@@ -181,9 +184,9 @@ public class ChannelMetadata implements Listener<IdentifierUpdateNotification>, 
     /**
      * Optional alias associated with the FROM identifier
      */
-    public Alias getFromIdentifierAlias()
+    public List<Alias> getFromIdentifierAliases()
     {
-        return mFromIdentifierAlias;
+        return mFromIdentifierAliases;
     }
 
     /**
@@ -202,9 +205,9 @@ public class ChannelMetadata implements Listener<IdentifierUpdateNotification>, 
     /**
      * Optional alias associated with the TO identifier
      */
-    public Alias getToIdentifierAlias()
+    public List<Alias> getToIdentifierAliases()
     {
-        return mToIdentifierAlias;
+        return mToIdentifierAliases;
     }
 
     /**
@@ -255,11 +258,11 @@ public class ChannelMetadata implements Listener<IdentifierUpdateNotification>, 
                             {
                                 if(mToIdentifier != null)
                                 {
-                                    mToIdentifierAlias = mAliasList.getAlias(mToIdentifier);
+                                    mToIdentifierAliases = mAliasList.getAliases(mToIdentifier);
                                 }
                                 if(mFromIdentifier != null)
                                 {
-                                    mFromIdentifierAlias = mAliasList.getAlias(mFromIdentifier);
+                                    mFromIdentifierAliases = mAliasList.getAliases(mFromIdentifier);
                                 }
                             }
                         }
@@ -306,11 +309,11 @@ public class ChannelMetadata implements Listener<IdentifierUpdateNotification>, 
 
                     if(mAliasList != null && mFromIdentifier != null)
                     {
-                        mFromIdentifierAlias = mAliasList.getAlias(mFromIdentifier);
+                        mFromIdentifierAliases = mAliasList.getAliases(mFromIdentifier);
                     }
                     else
                     {
-                        mFromIdentifierAlias = null;
+                        mFromIdentifierAliases = Collections.EMPTY_LIST;
                     }
 
                     broadcastUpdate(ChannelMetadataField.USER_FROM);
@@ -321,11 +324,11 @@ public class ChannelMetadata implements Listener<IdentifierUpdateNotification>, 
 
                     if(mAliasList != null && mToIdentifier != null)
                     {
-                        mToIdentifierAlias = mAliasList.getAlias(mToIdentifier);
+                        mToIdentifierAliases = mAliasList.getAliases(mToIdentifier);
                     }
                     else
                     {
-                        mToIdentifierAlias = null;
+                        mToIdentifierAliases = Collections.EMPTY_LIST;
                     }
 
                     broadcastUpdate(ChannelMetadataField.USER_TO);

--- a/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataModel.java
+++ b/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataModel.java
@@ -1,18 +1,22 @@
-/*******************************************************************************
- * sdr-trunk
+/*
+ * ******************************************************************************
+ * sdrtrunk
  * Copyright (C) 2014-2018 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.channel.metadata;
 
 import com.google.common.eventbus.Subscribe;
@@ -186,9 +190,9 @@ public class ChannelMetadataModel extends AbstractTableModel implements IChannel
                 case COLUMN_USER_FROM:
                     return channelMetadata;
                 case COLUMN_USER_FROM_ALIAS:
-                    return channelMetadata.getFromIdentifierAlias();
+                    return channelMetadata.getFromIdentifierAliases();
                 case COLUMN_USER_TO_ALIAS:
-                    return channelMetadata.getToIdentifierAlias();
+                    return channelMetadata.getToIdentifierAliases();
             }
         }
 

--- a/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataPanel.java
+++ b/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataPanel.java
@@ -19,6 +19,7 @@
  */
 package io.github.dsheirer.channel.metadata;
 
+import com.google.common.base.Joiner;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.channel.state.State;
 import io.github.dsheirer.controller.channel.Channel;
@@ -52,6 +53,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.DecimalFormat;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ChannelMetadataPanel extends JPanel implements ListSelectionListener
@@ -225,14 +227,22 @@ public class ChannelMetadataPanel extends JPanel implements ListSelectionListene
         {
             JLabel label = (JLabel)super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 
-            if(value instanceof Alias)
+            if(value instanceof List<?>)
             {
-                Alias alias = (Alias)value;
+                List<Alias> aliases = (List<Alias>)value;
 
-                label.setText(alias.getName());
-                label.setIcon(mIconManager.getIcon(alias.getIconName(), IconManager.DEFAULT_ICON_SIZE));
-                label.setForeground(alias.getDisplayColor());
-
+                if(!aliases.isEmpty())
+                {
+                    label.setText(Joiner.on(", ").skipNulls().join(aliases));
+                    label.setIcon(mIconManager.getIcon(aliases.get(0).getIconName(), IconManager.DEFAULT_ICON_SIZE));
+                    label.setForeground(aliases.get(0).getDisplayColor());
+                }
+                else
+                {
+                    label.setText(null);
+                    label.setIcon(null);
+                    label.setForeground(table.getForeground());
+                }
             }
             else
             {

--- a/src/main/java/io/github/dsheirer/identifier/status/UnitStatusIdentifier.java
+++ b/src/main/java/io/github/dsheirer/identifier/status/UnitStatusIdentifier.java
@@ -1,0 +1,44 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.identifier.status;
+
+import io.github.dsheirer.identifier.Form;
+import io.github.dsheirer.identifier.IdentifierClass;
+import io.github.dsheirer.identifier.Role;
+import io.github.dsheirer.identifier.integer.IntegerIdentifier;
+import io.github.dsheirer.protocol.Protocol;
+
+public class UnitStatusIdentifier extends IntegerIdentifier
+{
+    private Protocol mProtocol;
+
+    public UnitStatusIdentifier(int value, Role role, Protocol protocol)
+    {
+        super(value, IdentifierClass.USER, Form.UNIT_STATUS, role);
+        mProtocol = protocol;
+    }
+
+    @Override
+    public Protocol getProtocol()
+    {
+        return mProtocol;
+    }
+}

--- a/src/main/java/io/github/dsheirer/identifier/status/UserStatusIdentifier.java
+++ b/src/main/java/io/github/dsheirer/identifier/status/UserStatusIdentifier.java
@@ -1,0 +1,44 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
+package io.github.dsheirer.identifier.status;
+
+import io.github.dsheirer.identifier.Form;
+import io.github.dsheirer.identifier.IdentifierClass;
+import io.github.dsheirer.identifier.Role;
+import io.github.dsheirer.identifier.integer.IntegerIdentifier;
+import io.github.dsheirer.protocol.Protocol;
+
+public class UserStatusIdentifier extends IntegerIdentifier
+{
+    private Protocol mProtocol;
+
+    public UserStatusIdentifier(int value, Role role, Protocol protocol)
+    {
+        super(value, IdentifierClass.USER, Form.USER_STATUS, role);
+        mProtocol = protocol;
+    }
+
+    @Override
+    public Protocol getProtocol()
+    {
+        return mProtocol;
+    }
+}

--- a/src/main/java/io/github/dsheirer/map/PlottableEntityRenderer.java
+++ b/src/main/java/io/github/dsheirer/map/PlottableEntityRenderer.java
@@ -32,6 +32,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.geom.Point2D;
+import java.util.Collections;
 import java.util.List;
 
 public class PlottableEntityRenderer
@@ -58,7 +59,10 @@ public class PlottableEntityRenderer
                 graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             }
 
-            Alias alias = getAlias(entity);
+            List<Alias> aliases = getAliases(entity);
+
+            Alias alias = aliases.isEmpty() ? null : aliases.get(0);
+
             /**
              * Use the entity's preferred color for lines and labels
              */
@@ -99,16 +103,16 @@ public class PlottableEntityRenderer
     /**
      * Optional alias that matches the identifier for the entity history
      */
-    private Alias getAlias(PlottableEntityHistory entityHistory)
+    private List<Alias> getAliases(PlottableEntityHistory entityHistory)
     {
         AliasList aliasList = mAliasModel.getAliasList(entityHistory.getIdentifierCollection());
 
         if(aliasList != null)
         {
-            return aliasList.getAlias(entityHistory.getIdentifier());
+            return aliasList.getAliases(entityHistory.getIdentifier());
         }
 
-        return null;
+        return Collections.EMPTY_LIST;
     }
 
     private ImageIcon getIcon(Alias alias)

--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
@@ -19,6 +19,7 @@
  */
 package io.github.dsheirer.module.decode.event;
 
+import com.google.common.base.Joiner;
 import com.google.common.eventbus.Subscribe;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasList;
@@ -260,18 +261,17 @@ public class DecodeEventPanel extends JPanel implements Listener<ProcessingChain
 
                         for(Identifier identifier: identifiers)
                         {
-                            Alias alias = aliasList.getAlias(identifier);
+                            List<Alias> aliases = aliasList.getAliases(identifier);
 
-                            if(alias != null)
+                            if(!aliases.isEmpty())
                             {
                                 if(sb.length() > 0)
                                 {
                                     sb.append(",");
                                 }
-                                sb.append(alias.getName());
-
-                                color = alias.getDisplayColor();
-                                icon = mIconManager.getIcon(alias.getIconName(), IconManager.DEFAULT_ICON_SIZE);
+                                sb.append(Joiner.on(", ").skipNulls().join(aliases));
+                                color = aliases.get(0).getDisplayColor();
+                                icon = mIconManager.getIcon(aliases.get(0).getIconName(), IconManager.DEFAULT_ICON_SIZE);
                             }
                         }
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/status/APCO25UnitStatus.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/status/APCO25UnitStatus.java
@@ -1,0 +1,48 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+package io.github.dsheirer.module.decode.p25.identifier.status;
+
+import io.github.dsheirer.identifier.Role;
+import io.github.dsheirer.identifier.status.UnitStatusIdentifier;
+import io.github.dsheirer.protocol.Protocol;
+
+/**
+ * APCO-25 Unit status
+ */
+public class APCO25UnitStatus extends UnitStatusIdentifier
+{
+    /**
+     * Constructs an APCO-25 unit status
+     *
+     * @param status value
+     */
+    public APCO25UnitStatus(int status)
+    {
+        super(status, Role.STATUS, Protocol.APCO25);
+    }
+
+    /**
+     * Creates a unit status
+     */
+    public static APCO25UnitStatus create(int status)
+    {
+        return new APCO25UnitStatus(status);
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/status/APCO25UserStatus.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/status/APCO25UserStatus.java
@@ -19,51 +19,30 @@
  */
 package io.github.dsheirer.module.decode.p25.identifier.status;
 
-import io.github.dsheirer.identifier.Form;
-import io.github.dsheirer.identifier.IdentifierClass;
 import io.github.dsheirer.identifier.Role;
-import io.github.dsheirer.identifier.integer.IntegerIdentifier;
+import io.github.dsheirer.identifier.status.UserStatusIdentifier;
 import io.github.dsheirer.protocol.Protocol;
 
 /**
- * APCO-25 Unit or User status
+ * APCO-25 User status
  */
-public class APCO25Status extends IntegerIdentifier
+public class APCO25UserStatus extends UserStatusIdentifier
 {
-    private Role mRole;
-
     /**
-     * Constructs an APCO-25 status
+     * Constructs an APCO-25 unit status
+     *
      * @param status value
-     * @param role of the user/unit that the status applies to
      */
-    public APCO25Status(int status, IdentifierClass identifierClass, Form form, Role role)
+    public APCO25UserStatus(int status)
     {
-        super(status, identifierClass, form, role);
-        mRole = role;
-    }
-
-    @Override
-    public Protocol getProtocol()
-    {
-        return Protocol.APCO25;
+        super(status, Role.STATUS, Protocol.APCO25);
     }
 
     /**
      * Creates a unit status
-     * @param status
-     * @return
      */
-    public static APCO25Status createUnitStatus(int status)
+    public static APCO25UserStatus create(int status)
     {
-        return new APCO25Status(status, IdentifierClass.USER, Form.UNIT_STATUS, Role.STATUS);
-    }
-
-    /**
-     * Creates a User status
-     */
-    public static APCO25Status createUserStatus(int status)
-    {
-        return new APCO25Status(status, IdentifierClass.USER, Form.USER_STATUS, Role.STATUS);
+        return new APCO25UserStatus(status);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/lc/standard/LCStatusUpdate.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/lc/standard/LCStatusUpdate.java
@@ -22,7 +22,8 @@ package io.github.dsheirer.module.decode.p25.message.lc.standard;
 
 import io.github.dsheirer.bits.BinaryMessage;
 import io.github.dsheirer.identifier.Identifier;
-import io.github.dsheirer.module.decode.p25.identifier.status.APCO25Status;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UnitStatus;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UserStatus;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25FromTalkgroup;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25ToTalkgroup;
 import io.github.dsheirer.module.decode.p25.message.lc.LinkControlWord;
@@ -73,7 +74,7 @@ public class LCStatusUpdate extends LinkControlWord
     {
         if(mUnitStatus == null)
         {
-            mUnitStatus = APCO25Status.createUnitStatus(getMessage().getInt(UNIT_STATUS));
+            mUnitStatus = APCO25UnitStatus.create(getMessage().getInt(UNIT_STATUS));
         }
 
         return mUnitStatus;
@@ -83,7 +84,7 @@ public class LCStatusUpdate extends LinkControlWord
     {
         if(mUserStatus == null)
         {
-            mUserStatus = APCO25Status.createUserStatus(getMessage().getInt(USER_STATUS));
+            mUserStatus = APCO25UserStatus.create(getMessage().getInt(USER_STATUS));
         }
 
         return mUserStatus;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/isp/AMBTCStatusQueryResponse.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/isp/AMBTCStatusQueryResponse.java
@@ -23,7 +23,8 @@ package io.github.dsheirer.module.decode.p25.message.pdu.ambtc.isp;
 import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.module.decode.p25.identifier.APCO25System;
 import io.github.dsheirer.module.decode.p25.identifier.APCO25Wacn;
-import io.github.dsheirer.module.decode.p25.identifier.status.APCO25Status;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UnitStatus;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UserStatus;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25FromTalkgroup;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25ToTalkgroup;
 import io.github.dsheirer.module.decode.p25.message.pdu.PDUSequence;
@@ -90,7 +91,7 @@ public class AMBTCStatusQueryResponse extends AMBTCMessage
     {
         if(mUnitStatus == null)
         {
-            mUnitStatus = APCO25Status.createUnitStatus(getHeader().getMessage().getInt(HEADER_UNIT_STATUS));
+            mUnitStatus = APCO25UnitStatus.create(getHeader().getMessage().getInt(HEADER_UNIT_STATUS));
         }
 
         return mUnitStatus;
@@ -100,7 +101,7 @@ public class AMBTCStatusQueryResponse extends AMBTCMessage
     {
         if(mUserStatus == null)
         {
-            mUserStatus = APCO25Status.createUserStatus(getHeader().getMessage().getInt(HEADER_USER_STATUS));
+            mUserStatus = APCO25UserStatus.create(getHeader().getMessage().getInt(HEADER_USER_STATUS));
         }
 
         return mUserStatus;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/isp/AMBTCStatusUpdateRequest.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/isp/AMBTCStatusUpdateRequest.java
@@ -23,7 +23,8 @@ package io.github.dsheirer.module.decode.p25.message.pdu.ambtc.isp;
 import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.module.decode.p25.identifier.APCO25System;
 import io.github.dsheirer.module.decode.p25.identifier.APCO25Wacn;
-import io.github.dsheirer.module.decode.p25.identifier.status.APCO25Status;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UnitStatus;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UserStatus;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25FromTalkgroup;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25ToTalkgroup;
 import io.github.dsheirer.module.decode.p25.message.pdu.PDUSequence;
@@ -90,7 +91,7 @@ public class AMBTCStatusUpdateRequest extends AMBTCMessage
     {
         if(mUnitStatus == null)
         {
-            mUnitStatus = APCO25Status.createUnitStatus(getHeader().getMessage().getInt(HEADER_UNIT_STATUS));
+            mUnitStatus = APCO25UnitStatus.create(getHeader().getMessage().getInt(HEADER_UNIT_STATUS));
         }
 
         return mUnitStatus;
@@ -100,7 +101,7 @@ public class AMBTCStatusUpdateRequest extends AMBTCMessage
     {
         if(mUserStatus == null)
         {
-            mUserStatus = APCO25Status.createUserStatus(getHeader().getMessage().getInt(HEADER_USER_STATUS));
+            mUserStatus = APCO25UserStatus.create(getHeader().getMessage().getInt(HEADER_USER_STATUS));
         }
 
         return mUserStatus;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/osp/AMBTCStatusUpdate.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/pdu/ambtc/osp/AMBTCStatusUpdate.java
@@ -23,7 +23,8 @@ package io.github.dsheirer.module.decode.p25.message.pdu.ambtc.osp;
 import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.module.decode.p25.identifier.APCO25System;
 import io.github.dsheirer.module.decode.p25.identifier.APCO25Wacn;
-import io.github.dsheirer.module.decode.p25.identifier.status.APCO25Status;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UnitStatus;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UserStatus;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25FromTalkgroup;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25ToTalkgroup;
 import io.github.dsheirer.module.decode.p25.message.pdu.PDUSequence;
@@ -137,7 +138,7 @@ public class AMBTCStatusUpdate extends AMBTCMessage
     {
         if(mUnitStatus == null && hasDataBlock(0))
         {
-            mUnitStatus = APCO25Status.createUnitStatus(getDataBlock(0).getMessage().getInt(BLOCK_0_UNIT_STATUS));
+            mUnitStatus = APCO25UnitStatus.create(getDataBlock(0).getMessage().getInt(BLOCK_0_UNIT_STATUS));
         }
 
         return mUnitStatus;
@@ -147,7 +148,7 @@ public class AMBTCStatusUpdate extends AMBTCMessage
     {
         if(mUserStatus == null && hasDataBlock(0))
         {
-            mUserStatus = APCO25Status.createUserStatus(getDataBlock(0).getMessage().getInt(BLOCK_0_USER_STATUS));
+            mUserStatus = APCO25UserStatus.create(getDataBlock(0).getMessage().getInt(BLOCK_0_USER_STATUS));
         }
 
         return mUserStatus;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/standard/isp/StatusQueryResponse.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/standard/isp/StatusQueryResponse.java
@@ -1,8 +1,29 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
 package io.github.dsheirer.module.decode.p25.message.tsbk.standard.isp;
 
 import io.github.dsheirer.bits.CorrectedBinaryMessage;
 import io.github.dsheirer.identifier.Identifier;
-import io.github.dsheirer.module.decode.p25.identifier.status.APCO25Status;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UnitStatus;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UserStatus;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25FromTalkgroup;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25ToTalkgroup;
 import io.github.dsheirer.module.decode.p25.message.tsbk.ISPMessage;
@@ -52,7 +73,7 @@ public class StatusQueryResponse extends ISPMessage
     {
         if(mUnitStatus == null)
         {
-            mUnitStatus = APCO25Status.createUnitStatus(getMessage().getInt(UNIT_STATUS));
+            mUnitStatus = APCO25UnitStatus.create(getMessage().getInt(UNIT_STATUS));
         }
 
         return mUnitStatus;
@@ -62,7 +83,7 @@ public class StatusQueryResponse extends ISPMessage
     {
         if(mUserStatus == null)
         {
-            mUserStatus = APCO25Status.createUserStatus(getMessage().getInt(USER_STATUS));
+            mUserStatus = APCO25UserStatus.create(getMessage().getInt(USER_STATUS));
         }
 
         return mUserStatus;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/standard/isp/StatusUpdateRequest.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/standard/isp/StatusUpdateRequest.java
@@ -1,8 +1,29 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2018 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
 package io.github.dsheirer.module.decode.p25.message.tsbk.standard.isp;
 
 import io.github.dsheirer.bits.CorrectedBinaryMessage;
 import io.github.dsheirer.identifier.Identifier;
-import io.github.dsheirer.module.decode.p25.identifier.status.APCO25Status;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UnitStatus;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UserStatus;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25FromTalkgroup;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25ToTalkgroup;
 import io.github.dsheirer.module.decode.p25.message.tsbk.ISPMessage;
@@ -52,7 +73,7 @@ public class StatusUpdateRequest extends ISPMessage
     {
         if(mUnitStatus == null)
         {
-            mUnitStatus = APCO25Status.createUnitStatus(getMessage().getInt(UNIT_STATUS));
+            mUnitStatus = APCO25UnitStatus.create(getMessage().getInt(UNIT_STATUS));
         }
 
         return mUnitStatus;
@@ -62,7 +83,7 @@ public class StatusUpdateRequest extends ISPMessage
     {
         if(mUserStatus == null)
         {
-            mUserStatus = APCO25Status.createUserStatus(getMessage().getInt(USER_STATUS));
+            mUserStatus = APCO25UserStatus.create(getMessage().getInt(USER_STATUS));
         }
 
         return mUserStatus;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/standard/osp/StatusUpdate.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/message/tsbk/standard/osp/StatusUpdate.java
@@ -22,7 +22,8 @@ package io.github.dsheirer.module.decode.p25.message.tsbk.standard.osp;
 
 import io.github.dsheirer.bits.CorrectedBinaryMessage;
 import io.github.dsheirer.identifier.Identifier;
-import io.github.dsheirer.module.decode.p25.identifier.status.APCO25Status;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UnitStatus;
+import io.github.dsheirer.module.decode.p25.identifier.status.APCO25UserStatus;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25FromTalkgroup;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25ToTalkgroup;
 import io.github.dsheirer.module.decode.p25.message.tsbk.OSPMessage;
@@ -72,7 +73,7 @@ public class StatusUpdate extends OSPMessage
     {
         if(mUnitStatus == null)
         {
-            mUnitStatus = APCO25Status.createUnitStatus(getMessage().getInt(UNIT_STATUS));
+            mUnitStatus = APCO25UnitStatus.create(getMessage().getInt(UNIT_STATUS));
         }
 
         return mUnitStatus;
@@ -82,7 +83,7 @@ public class StatusUpdate extends OSPMessage
     {
         if(mUserStatus == null)
         {
-            mUserStatus = APCO25Status.createUserStatus(getMessage().getInt(USER_STATUS));
+            mUserStatus = APCO25UserStatus.create(getMessage().getInt(USER_STATUS));
         }
 
         return mUserStatus;

--- a/src/main/java/io/github/dsheirer/record/wave/WaveMetadata.java
+++ b/src/main/java/io/github/dsheirer/record/wave/WaveMetadata.java
@@ -20,6 +20,7 @@
 
 package io.github.dsheirer.record.wave;
 
+import com.google.common.base.Joiner;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasList;
 import io.github.dsheirer.identifier.Form;
@@ -363,22 +364,22 @@ public class WaveMetadata
                 waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_FROM,
                         String.valueOf(((TalkgroupIdentifier)identifier).getValue()));
 
-                Alias alias = aliasList.getAlias(identifier);
+                List<Alias> aliases = aliasList.getAliases(identifier);
 
-                if(alias != null)
+                if(!aliases.isEmpty())
                 {
-                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_FROM_ALIAS, alias.getName());
-                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_FROM_ICON, alias.getIconName());
+                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_FROM_ALIAS, Joiner.on(", ").skipNulls().join(aliases));
+                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_FROM_ICON, aliases.get(0).getIconName());
                 }
             }
             else if(identifier instanceof TalkgroupIdentifier && identifier.getRole() == Role.TO)
             {
-                Alias alias = aliasList.getAlias(identifier);
+                List<Alias> aliases = aliasList.getAliases(identifier);
 
-                if(alias != null)
+                if(!aliases.isEmpty())
                 {
-                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ALIAS, alias.getName());
-                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ICON, alias.getIconName());
+                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ALIAS, Joiner.on(", ").skipNulls().join(aliases));
+                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ICON, aliases.get(0).getIconName());
                 }
             }
             else if(identifier instanceof PatchGroupIdentifier)
@@ -389,12 +390,12 @@ public class WaveMetadata
                 sb.append("P:").append(patchGroup.getPatchGroup()).append(patchGroup.getPatchedGroupIdentifiers());
                 waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO, sb.toString());
 
-                Alias alias = aliasList.getAlias(identifier);
+                List<Alias> aliases = aliasList.getAliases(identifier);
 
-                if(alias != null)
+                if(!aliases.isEmpty())
                 {
-                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ALIAS, alias.getName());
-                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ICON, alias.getIconName());
+                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ALIAS, Joiner.on(", ").skipNulls().join(aliases));
+                    waveMetadata.add(WaveMetadataType.TALKGROUP_PRIMARY_TO_ICON, aliases.get(0).getIconName());
                 }
             }
         }


### PR DESCRIPTION
Resolves #464 

Updates alias list to provide a list of aliases for an identifier so that we can account for multi-alias identifiers like patch groups and ensure that patch group alias intentions are carried throughout the system for recording, streaming, etc.

Updates all consumers of alias list data to ensure it can operate with a list of aliases versus an assumed single alias.

Refactors APCO25 unit/user status identifiers from a base status class so that alias list can support status identifiers.