### PR TITLE
490 DFT Processor Error On Application Shutdown

### DIFF
--- a/src/main/java/io/github/dsheirer/spectrum/DFTProcessor.java
+++ b/src/main/java/io/github/dsheirer/spectrum/DFTProcessor.java
@@ -1,18 +1,22 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2019 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
 package io.github.dsheirer.spectrum;
 
 import io.github.dsheirer.dsp.filter.Window;
@@ -240,6 +244,17 @@ public class DFTProcessor implements Listener<ReusableComplexBuffer>, ISourceEve
         {
             //No new data, dispatch the previous samples again
             //no-op
+        }
+        catch(Exception e)
+        {
+            if(e instanceof InterruptedException)
+            {
+                mLog.info("FFT Library interrupted exception - this is normal during application shutdown");
+            }
+            else
+            {
+                mLog.error("Error while calculating FFT results", e);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #490

Adds exception handler to DFT processor to catch InterruptedException begin thrown by the FFT library on shutdown.

