### PR TITLE
499 Audio Playback Talkgroup Display

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,3 +111,15 @@ runtime {
     modules = ['java.desktop', 'java.naming', 'jdk.unsupported', 'jdk.unsupported.desktop']
     imageZip = file("$buildDir/image/sdr-trunk-" + version + ".zip")
 }
+
+task buildSdr(type: Jar) {
+    manifest {
+        attributes 'Implementation-Title': 'SdrTrunk project',
+                'Implementation-Version': version,
+                'Main-Class': 'io.github.dsheirer.gui.SDRTrunk',
+                'Class-Path': 'jmbe-0.3.2.jar jmbe-0.3.3.jar'
+    }
+    baseName = project.name + '-all'
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
+}

--- a/src/main/java/io/github/dsheirer/audio/playback/AudioChannelPanel.java
+++ b/src/main/java/io/github/dsheirer/audio/playback/AudioChannelPanel.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+ * Copyright (C) 2014-2019 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -236,6 +236,11 @@ public class AudioChannelPanel extends JPanel implements Listener<AudioEvent>, S
         else if(mAliases.size() > 1)
         {
             identifier = Joiner.on(", ").skipNulls().join(mAliases);
+        }
+
+        if(identifier == null && mIdentifier != null)
+        {
+            identifier = mTalkgroupFormatPreference.format(mIdentifier);
         }
 
         if(identifier == null)


### PR DESCRIPTION
Resolves #499 

Resolves issue where non-aliased talkgroup values were not displaying in the audio playback panels (left/right/mono).

Adds buildSdr build target back into gradle script that was previously removed for Java 11 upgrade.