### PR TITLE
501 Beryx Gradle Plugin - Launch Script 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'org.openjfx.javafxplugin' version '0.0.6'
-    id 'org.beryx.runtime' version '1.1.1'
+    id 'org.beryx.runtime' version '1.1.2'
 }
 
 repositories {


### PR DESCRIPTION
Resolves #501
Updates beryx gradle plugin to resolve issue where launcher script did not like '&' ampersand in the execution path.

