### PR TITLE
504 Talkgroup Format - Missing Case Statements

### DIFF
--- a/src/main/java/io/github/dsheirer/preference/identifier/talkgroup/APCO25TalkgroupFormatter.java
+++ b/src/main/java/io/github/dsheirer/preference/identifier/talkgroup/APCO25TalkgroupFormatter.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+ * Copyright (C) 2014-2019 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ public class APCO25TalkgroupFormatter extends IntegerFormatter
             switch(format)
             {
                 case DECIMAL:
+                case FORMATTED:
                     return toDecimal(identifier.getValue(),
                         (identifier.isGroup() ? GROUP_DECIMAL_WIDTH : UNIT_DECIMAL_WIDTH));
                 case HEXADECIMAL:

--- a/src/main/java/io/github/dsheirer/preference/identifier/talkgroup/MDC1200TalkgroupFormatter.java
+++ b/src/main/java/io/github/dsheirer/preference/identifier/talkgroup/MDC1200TalkgroupFormatter.java
@@ -38,6 +38,7 @@ public class MDC1200TalkgroupFormatter extends IntegerFormatter
             switch(format)
             {
                 case DECIMAL:
+                case FORMATTED:
                     return toDecimal(identifier.getValue(), DECIMAL_WIDTH);
                 case HEXADECIMAL:
                     return toHex(identifier.getValue(), HEXADECIMAL_WIDTH);

--- a/src/main/java/io/github/dsheirer/preference/identifier/talkgroup/PassportTalkgroupFormatter.java
+++ b/src/main/java/io/github/dsheirer/preference/identifier/talkgroup/PassportTalkgroupFormatter.java
@@ -38,6 +38,7 @@ public class PassportTalkgroupFormatter extends IntegerFormatter
             switch(format)
             {
                 case DECIMAL:
+                case FORMATTED:
                     return toDecimal(identifier.getValue(), DECIMAL_WIDTH);
                 case HEXADECIMAL:
                     return toHex(identifier.getValue(), HEXADECIMAL_WIDTH);


### PR DESCRIPTION
Resolves issue with missing case statements in talkgroup format classes.

Resolves #504 