### PR TITLE
507 Detect and Log Talkgroup/Range Collisions or Overlaps

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/AliasList.java
+++ b/src/main/java/io/github/dsheirer/alias/AliasList.java
@@ -505,11 +505,32 @@ public class AliasList implements Listener<AliasEvent>
 
         public void add(Talkgroup talkgroup, Alias alias)
         {
+            //Detect talkgroup collisions
+            if(mTalkgroupAliasMap.containsKey(talkgroup.getValue()))
+            {
+                Alias existing = mTalkgroupAliasMap.get(talkgroup.getValue());
+
+                mLog.warn("Alias [" + alias.getName() + "] talkgroup [" + talkgroup.getValue() +
+                    "] has the same talkgroup value as alias [" + existing.getName() +
+                    "] - alias [" + alias.getName() + "] will be used for alias list [" + getName() + "]");
+            }
+
             mTalkgroupAliasMap.put(talkgroup.getValue(), alias);
         }
 
         public void add(TalkgroupRange talkgroupRange, Alias alias)
         {
+            //Log warning if the new talkgroup range overlaps with any existing ranges
+            for(Map.Entry<TalkgroupRange,Alias> entry: mTalkgroupRangeAliasMap.entrySet())
+            {
+                if(talkgroupRange.overlaps(entry.getKey()))
+                {
+                    mLog.warn("Alias [" + alias.getName() + "] with talkgroup range [" + talkgroupRange.toString() +
+                        "] overlaps with alias [" + entry.getValue().getName() +
+                        "] with talkgroup range [" + entry.getKey().toString() + "] for alias list [" + getName() + "]");
+                }
+            }
+
             mTalkgroupRangeAliasMap.put(talkgroupRange, alias);
         }
 

--- a/src/main/java/io/github/dsheirer/alias/id/talkgroup/TalkgroupRange.java
+++ b/src/main/java/io/github/dsheirer/alias/id/talkgroup/TalkgroupRange.java
@@ -140,6 +140,21 @@ public class TalkgroupRange extends AliasID
         return getMinTalkgroup() <= talkgroupValue && talkgroupValue <= getMaxTalkgroup();
     }
 
+    /**
+     * Indicates if this talkgroup range overlaps the talkgroup range argument.
+     * @param talkgroupRange to check for overlap
+     * @return true if the ranges overlap
+     */
+    public boolean overlaps(TalkgroupRange talkgroupRange)
+    {
+        return contains(talkgroupRange.getMinTalkgroup()) ||
+               contains(talkgroupRange.getMaxTalkgroup()) ||
+               (getMinTalkgroup() < talkgroupRange.getMinTalkgroup() &&
+                   talkgroupRange.getMaxTalkgroup() < getMaxTalkgroup()) ||
+               (talkgroupRange.getMinTalkgroup() < getMinTalkgroup() &&
+                   getMaxTalkgroup() < talkgroupRange.getMaxTalkgroup());
+    }
+
     @JacksonXmlProperty(isAttribute = true, localName = "type", namespace = "http://www.w3.org/2001/XMLSchema-instance")
     @Override
     public AliasIDType getType()


### PR DESCRIPTION
Adds logging/warning when alias list contains talkgroups or talkgroup range collisions or overlaps.

Resolves #507 