### PR TITLE
510 Add Alias to Filtered Column View

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/AliasController.java
+++ b/src/main/java/io/github/dsheirer/alias/AliasController.java
@@ -1,3 +1,23 @@
+/*
+ * ******************************************************************************
+ * sdrtrunk
+ * Copyright (C) 2014-2019 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * *****************************************************************************
+ */
+
 package io.github.dsheirer.alias;
 
 import com.jidesoft.swing.JideSplitPane;
@@ -8,11 +28,21 @@ import net.coderazzi.filters.gui.AutoChoices;
 import net.coderazzi.filters.gui.TableFilterHeader;
 import net.miginfocom.swing.MigLayout;
 
-import javax.swing.*;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -212,17 +242,10 @@ public class AliasController extends JPanel
      */
     private void addAlias(Alias alias)
     {
-        //HACK: when inserting a row to the model, the JTable gets
-        //notified and attempts to tell the coderazzi table filter
-        //adaptive choices filter to refresh before the table filter is
-        //notified of the row additions, causing an index out of bounds
-        //exception.  We turn off adaptive choices temporarily, add the
-        //channel, and turn on adaptive choices again.
-        mTableFilterHeader.setAdaptiveChoices(false);
+        //Remove any column headers so that the newly added alias shows correctly.
+        mTableFilterHeader.resetFilter();
 
         int index = mAliasModel.addAlias(alias);
-
-        mTableFilterHeader.setAdaptiveChoices(true);
 
         if(index >= 0)
         {


### PR DESCRIPTION
Resolves #510.

Updates alias controller so that when adding an alias to a filtered column view it doesn't throw an error.
