### PR TITLE
519 Stale Patch Groups and Audio Playback Display

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/playback/AudioChannelPanel.java
+++ b/src/main/java/io/github/dsheirer/audio/playback/AudioChannelPanel.java
@@ -83,8 +83,6 @@ public class AudioChannelPanel extends JPanel implements Listener<AudioEvent>, S
     private JLabel mIdentifierLabel = new JLabel("-----");
     private Identifier mIdentifier;
     private List<Alias> mAliases = Collections.EMPTY_LIST;
-
-    private boolean mConfigured = false;
     private AliasModel mAliasModel;
 
     public AudioChannelPanel(IconManager iconManager, UserPreferences userPreferences, SettingsManager settingsManager,
@@ -191,31 +189,71 @@ public class AudioChannelPanel extends JPanel implements Listener<AudioEvent>, S
     }
 
     /**
-     * Resets the from and to labels.  Note: this does not happen on the swing
-     * event thread.  Only invoke from the swing thread.
+     * Resets the from and to labels.
      */
     private void resetLabels()
     {
+        boolean updated = mIdentifier != null;
         mIdentifier = null;
         mAliases = Collections.EMPTY_LIST;
-        updateLabels();
-        mConfigured = false;
+
+        if(updated)
+        {
+            updateLabels();
+        }
     }
 
-    /**
-     * Truncates the string to the specified length using an ellipses at the end
-     * @param value to optionally truncate
-     * @param length of the final formatted string
-     * @return formatted string or null
-     */
-    private static String truncate(String value, int length)
+    private void updateIdentifiers(IdentifierCollection identifierCollection)
     {
-        if(value != null && value.length() > length)
+        if(identifierCollection == null || identifierCollection.isEmpty())
         {
-            return value.substring(0, length - 3) + "...";
+            resetLabels();
+            return;
         }
 
-        return value;
+        List<Identifier> toIds = identifierCollection.getIdentifiers(IdentifierClass.USER, Role.TO);
+
+        if(toIds.isEmpty())
+        {
+            resetLabels();
+            return;
+        }
+
+        boolean updated = false;
+
+        if(toIds.size() == 1)
+        {
+            Identifier currentIdentifier = mIdentifier;
+
+            if(currentIdentifier == null || currentIdentifier != toIds.get(0))
+            {
+                mIdentifier = toIds.get(0);
+                AliasList aliasList = mAliasModel.getAliasList(identifierCollection);
+
+                if(aliasList != null)
+                {
+                    mAliases = aliasList.getAliases(mIdentifier);
+                }
+                updated = true;
+            }
+        }
+        else
+        {
+            mLog.warn("Multiple To Identifiers in Collection: " + Joiner.on(",").join(toIds));
+            mIdentifier = toIds.get(0);
+            AliasList aliasList = mAliasModel.getAliasList(identifierCollection);
+
+            if(aliasList != null)
+            {
+                mAliases = aliasList.getAliases(mIdentifier);
+            }
+            updated = true;
+        }
+
+        if(updated)
+        {
+            updateLabels();
+        }
     }
 
     /**
@@ -249,7 +287,8 @@ public class AudioChannelPanel extends JPanel implements Listener<AudioEvent>, S
         }
 
         final ImageIcon icon = iconName != null ? mIconManager.getIcon(iconName, 18) : null;
-        final String identifierText = truncate(identifier, 33);
+
+        final String identifierText = identifier;
 
         EventQueue.invokeLater(new Runnable()
         {
@@ -258,7 +297,6 @@ public class AudioChannelPanel extends JPanel implements Listener<AudioEvent>, S
             {
                 mIdentifierLabel.setText(identifierText);
                 mIconLabel.setIcon(icon);
-                mConfigured = true;
             }
         });
 
@@ -272,22 +310,9 @@ public class AudioChannelPanel extends JPanel implements Listener<AudioEvent>, S
         @Override
         public void receive(final IdentifierCollection identifierCollection)
         {
-            if(identifierCollection != null && (identifierCollection.isUpdated() || !mConfigured))
-            {
-                List<Identifier> toIds = identifierCollection.getIdentifiers(IdentifierClass.USER, Role.TO);
-                mIdentifier = !toIds.isEmpty() ? toIds.get(0) : null;
-                AliasList aliasList = mAliasModel.getAliasList(identifierCollection);
-
-                if(aliasList != null)
-                {
-                    mAliases = aliasList.getAliases(mIdentifier);
-                }
-
-                updateLabels();
-            }
+            updateIdentifiers(identifierCollection);
         }
     }
-
 
     @Override
     public void settingChanged(Setting setting)

--- a/src/main/java/io/github/dsheirer/audio/playback/AudioChannelsPanel.java
+++ b/src/main/java/io/github/dsheirer/audio/playback/AudioChannelsPanel.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+ * Copyright (C) 2014-2019 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +39,8 @@ public class AudioChannelsPanel extends JPanel
     public AudioChannelsPanel(IconManager iconManager, UserPreferences userPreferences, SettingsManager settingsManager,
                               IAudioController controller, AliasModel aliasModel)
     {
-        setLayout(new MigLayout("insets 0 0 0 0", "[][sg abc,grow,fill][][sg abc,grow,fill]", "[grow,fill]"));
+        setLayout(new MigLayout("insets 0 0 0 0",
+            "[][sizegroup abc,grow,fill][][sizegroup abc,grow,fill]", "[grow,fill]"));
 
         setBackground(Color.BLACK);
 

--- a/src/main/java/io/github/dsheirer/audio/playback/AudioOutput.java
+++ b/src/main/java/io/github/dsheirer/audio/playback/AudioOutput.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+ * Copyright (C) 2014-2019 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -54,6 +54,11 @@ public abstract class AudioOutput implements Listener<ReusableAudioPacket>, Line
     private LinkedTransferQueue<ReusableAudioPacket> mBuffer = new LinkedTransferQueue<>();
     private int mBufferStartThreshold;
     private int mBufferStopThreshold;
+    private static IdentifierCollection EMPTY_IDENTIFIER_COLLECTION = new IdentifierCollection();
+    static
+    {
+        EMPTY_IDENTIFIER_COLLECTION.setUpdated(true);
+    }
 
     private Listener<IdentifierCollection> mIdentifierCollectionListener;
     private Broadcaster<AudioEvent> mAudioEventBroadcaster = new Broadcaster<>();
@@ -380,12 +385,11 @@ public abstract class AudioOutput implements Listener<ReusableAudioPacket>, Line
          */
         private void checkStop()
         {
-            if(mCanProcessAudio &&
-                mOutput.isRunning() &&
-                mOutput.available() >= mBufferStopThreshold)
+            if(mCanProcessAudio && mOutput.isRunning() && mOutput.available() >= mBufferStopThreshold)
             {
                 mOutput.drain();
                 mOutput.stop();
+                broadcast(EMPTY_IDENTIFIER_COLLECTION);
             }
         }
     }

--- a/src/main/java/io/github/dsheirer/channel/state/ChannelState.java
+++ b/src/main/java/io/github/dsheirer/channel/state/ChannelState.java
@@ -28,6 +28,7 @@ import io.github.dsheirer.controller.channel.Channel;
 import io.github.dsheirer.controller.channel.Channel.ChannelType;
 import io.github.dsheirer.controller.channel.ChannelEvent;
 import io.github.dsheirer.controller.channel.IChannelEventProvider;
+import io.github.dsheirer.identifier.IdentifierClass;
 import io.github.dsheirer.identifier.IdentifierUpdateListener;
 import io.github.dsheirer.identifier.IdentifierUpdateNotification;
 import io.github.dsheirer.identifier.IdentifierUpdateProvider;
@@ -203,6 +204,7 @@ public class ChannelState extends Module implements IChannelEventProvider, IDeco
     {
         mState = State.IDLE;
         broadcast(new DecoderStateEvent(this, Event.RESET, State.IDLE));
+        mIdentifierCollection.remove(IdentifierClass.USER);
         mIdentifierCollection.update(ChannelStateIdentifier.IDLE);
         mSourceOverflow = false;
     }

--- a/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
+++ b/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
@@ -1,7 +1,7 @@
 /*
  * ******************************************************************************
  * sdrtrunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+ * Copyright (C) 2014-2019 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -84,7 +84,7 @@ public class IdentifierCollection
         return mUpdated;
     }
 
-    protected void setUpdated(boolean updated)
+    public void setUpdated(boolean updated)
     {
         mUpdated = updated;
     }
@@ -112,6 +112,14 @@ public class IdentifierCollection
     public List<Identifier> getIdentifiers()
     {
         return Collections.unmodifiableList(mIdentifiers);
+    }
+
+    /**
+     * Indicates if this collection has no identifiers
+     */
+    public boolean isEmpty()
+    {
+        return mIdentifiers.isEmpty();
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/identifier/MutableIdentifierCollection.java
+++ b/src/main/java/io/github/dsheirer/identifier/MutableIdentifierCollection.java
@@ -22,6 +22,8 @@ package io.github.dsheirer.identifier;
 
 import io.github.dsheirer.identifier.configuration.AliasListConfigurationIdentifier;
 import io.github.dsheirer.sample.Listener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -32,6 +34,7 @@ import java.util.Iterator;
 public class MutableIdentifierCollection extends IdentifierCollection implements IdentifierUpdateProvider,
     Listener<IdentifierUpdateNotification>
 {
+    private final static Logger mLog = LoggerFactory.getLogger(MutableIdentifierCollection.class);
     private Listener<IdentifierUpdateNotification> mListener;
 
     public MutableIdentifierCollection()


### PR DESCRIPTION
Resolves #519
- Clears stale patch groups
- Reworks the audio playback panel label update code to properly update
  talkgroups and aliases in concert with the audio playback.
- Removes code that was truncating playback aliases at 32 characters.