### PR TITLE
535 Icecast Http Reconnect After Errors

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastHTTPAudioBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastHTTPAudioBroadcaster.java
@@ -1,21 +1,23 @@
 /*
- * ******************************************************************************
- * sdrtrunk
- * Copyright (C) 2014-2019 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- * *****************************************************************************
  */
 package io.github.dsheirer.audio.broadcast.icecast;
 
@@ -146,12 +148,12 @@ public class IcecastHTTPAudioBroadcaster extends IcecastAudioBroadcaster
                         }
                         else if(throwableCause != null)
                         {
-                            setBroadcastState(BroadcastState.ERROR);
+                            setBroadcastState(BroadcastState.DISCONNECTED);
                             mLog.debug("Failed to connect", rie);
                         }
                         else
                         {
-                            setBroadcastState(BroadcastState.ERROR);
+                            setBroadcastState(BroadcastState.DISCONNECTED);
                             mLog.debug("Failed to connect - no exception is available");
                         }
 
@@ -282,14 +284,14 @@ public class IcecastHTTPAudioBroadcaster extends IcecastAudioBroadcaster
                 else
                 {
                     mLog.error("HTTP protocol decoder error", throwable);
-                    setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+                    setBroadcastState(BroadcastState.DISCONNECTED);
                     disconnect();
                 }
             }
             else
             {
                 mLog.error("Broadcast error", throwable);
-                setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+                setBroadcastState(BroadcastState.DISCONNECTED);
                 disconnect();
             }
 


### PR DESCRIPTION
Updates Icecast HTTP (2.4) streaming client to perpetually attempt to
reconnect to the server, even if there are (temp) errors.

Resolves #535