### PR TITLE
Resolves issue with the multi-frequency tuner source and P25/MPT1327

### DIFF
--- a/src/main/java/io/github/dsheirer/channel/state/DecoderStateEvent.java
+++ b/src/main/java/io/github/dsheirer/channel/state/DecoderStateEvent.java
@@ -24,6 +24,14 @@ package io.github.dsheirer.channel.state;
 
 public class DecoderStateEvent
 {
+    private static final DecoderStateEvent ACTIVE_STATE_TIMESLOT_0 =
+        new DecoderStateEvent(null, Event.NOTIFICATION_CHANNEL_ACTIVE_STATE, State.ACTIVE, 0);
+    private static final DecoderStateEvent ACTIVE_STATE_TIMESLOT_1 =
+        new DecoderStateEvent(null, Event.NOTIFICATION_CHANNEL_ACTIVE_STATE, State.ACTIVE, 1);
+    private static final DecoderStateEvent INACTIVE_STATE_TIMESLOT_0 =
+        new DecoderStateEvent(null, Event.NOTIFICATION_CHANNEL_INACTIVE_STATE, State.ACTIVE, 0);
+    private static final DecoderStateEvent INACTIVE_STATE_TIMESLOT_1 =
+        new DecoderStateEvent(null, Event.NOTIFICATION_CHANNEL_INACTIVE_STATE, State.ACTIVE, 1);
     private Object mSource;
     private Event mEvent;
     private State mState;
@@ -52,6 +60,68 @@ public class DecoderStateEvent
     public DecoderStateEvent(Object source, Event event, State state, long frequency)
     {
         this(source, event, state, 0, frequency);
+    }
+
+    /**
+     * Creates a channel state active event for the specified timeslot
+     * @param timeslot that the state applies to
+     * @return new event
+     */
+    public static DecoderStateEvent activeState(int timeslot)
+    {
+        if(timeslot == 0)
+        {
+            return ACTIVE_STATE_TIMESLOT_0;
+        }
+        else if(timeslot == 1)
+        {
+            return ACTIVE_STATE_TIMESLOT_1;
+        }
+        else
+        {
+            throw new IllegalArgumentException("Only timeslots 0 and 1 are currently supported");
+        }
+    }
+
+    /**
+     * Creates a channel state active event for the specified timeslot.
+     * @param state currently
+     * @return new event
+     */
+    public static DecoderStateEvent activeState()
+    {
+        return activeState(0);
+    }
+
+    /**
+     * Creates a channel state inactive event for the specified timeslot
+     * @param timeslot that the state applies to
+     * @return new event
+     */
+    public static DecoderStateEvent inactiveState(int timeslot)
+    {
+        if(timeslot == 0)
+        {
+            return INACTIVE_STATE_TIMESLOT_0;
+        }
+        else if(timeslot == 1)
+        {
+            return INACTIVE_STATE_TIMESLOT_1;
+        }
+        else
+        {
+            throw new IllegalArgumentException("Only timeslots 0 and 1 are currently supported");
+        }
+    }
+
+    /**
+     * Creates a channel state active event for the specified timeslot.
+     * @param state currently
+     * @return new event
+     */
+    public static DecoderStateEvent inactiveState()
+    {
+        return inactiveState(0);
     }
 
     public String toString()
@@ -99,6 +169,8 @@ public class DecoderStateEvent
         CONTINUATION,
         DECODE,
         END,
+        NOTIFICATION_CHANNEL_ACTIVE_STATE,
+        NOTIFICATION_CHANNEL_INACTIVE_STATE,
         RESET,
         SOURCE_FREQUENCY,
         START;

--- a/src/main/java/io/github/dsheirer/channel/state/MultiChannelState.java
+++ b/src/main/java/io/github/dsheirer/channel/state/MultiChannelState.java
@@ -132,6 +132,16 @@ public class MultiChannelState extends AbstractChannelState implements IDecoderS
     @Override
     public void stateChanged(State state, int timeslot)
     {
+        //Broadcast current channel state so that channel rotation monitor can track
+        if(state.isActiveState())
+        {
+            broadcast(DecoderStateEvent.activeState(timeslot));
+        }
+        else
+        {
+            broadcast(DecoderStateEvent.inactiveState(timeslot));
+        }
+
         ChannelStateIdentifier stateIdentifier = ChannelStateIdentifier.create(state);
         mIdentifierCollectionMap.get(timeslot).update(stateIdentifier);
         mChannelMetadataMap.get(timeslot).receive(new IdentifierUpdateNotification(stateIdentifier, IdentifierUpdateNotification.Operation.ADD, timeslot));

--- a/src/main/java/io/github/dsheirer/channel/state/SingleChannelState.java
+++ b/src/main/java/io/github/dsheirer/channel/state/SingleChannelState.java
@@ -122,6 +122,16 @@ public class SingleChannelState extends AbstractChannelState implements IDecoder
     @Override
     public void stateChanged(State state, int timeslot)
     {
+        //Broadcast current channel state so that channel rotation monitor can track
+        if(state.isActiveState())
+        {
+            broadcast(DecoderStateEvent.activeState(timeslot));
+        }
+        else
+        {
+            broadcast(DecoderStateEvent.inactiveState(timeslot));
+        }
+
         ChannelStateIdentifier stateIdentifier = ChannelStateIdentifier.create(state);
         mIdentifierCollection.update(stateIdentifier);
         mChannelMetadata.receive(new IdentifierUpdateNotification(stateIdentifier, IdentifierUpdateNotification.Operation.ADD, timeslot));


### PR DESCRIPTION
rotating channel frequency configurations failing to maintain lock
on the channel.

Converted the ChannelRotationMonitor from using identifier updates to
now using DecoderStateEvents so that the ChannelState can supply a
steady stream of channel state events to the monitor.