### PR TITLE
#612 P25P2 Bitstream Recording Protocol Type Incorrect

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/DecoderType.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderType.java
@@ -38,7 +38,7 @@ public enum DecoderType
     NBFM("NBFM", "NBFM", Protocol.UNKNOWN),
     PASSPORT("Passport", "Passport", Protocol.PASSPORT),
     P25_PHASE1("P25 Phase 1", "P25-1", Protocol.APCO25),
-    P25_PHASE2("P25 Phase 2", "P25-2", Protocol.APCO25),
+    P25_PHASE2("P25 Phase 2", "P25-2", Protocol.APCO25_PHASE2),
 
     //Auxiliary Decoders
     FLEETSYNC2("Fleetsync II", "Fleetsync2", Protocol.FLEETSYNC),


### PR DESCRIPTION
Resolves #612 P25P2 bit recording filenames indicated incorrect protocol type.
