### PR TITLE
#576 P25 Activity Summary Hex and Decimal Network Values

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/P25ExplicitChannel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/P25ExplicitChannel.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -55,7 +55,8 @@ public class P25ExplicitChannel extends P25Channel implements Comparable<P25Chan
     {
         if(mUplinkFrequencyBand != null)
         {
-            return mUplinkFrequencyBand.getUplinkFrequency(getUplinkChannelNumber());
+            //Note: we explicitly use the downlink frequency from the uplink channel frequency band here
+            return mUplinkFrequencyBand.getDownlinkFrequency(getUplinkChannelNumber());
         }
 
         return 0;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -1357,7 +1357,7 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
                 //Network Configuration Messages
                 case MOTOROLA_OSP_TRAFFIC_CHANNEL_ID:
                 case MOTOROLA_OSP_SYSTEM_LOADING:
-                case MOTOROLA_OSP_CONTROL_CHANNEL_ID:
+                case MOTOROLA_OSP_BASE_STATION_ID:
                 case MOTOROLA_OSP_CONTROL_CHANNEL_PLANNED_SHUTDOWN:
                 case OSP_IDENTIFIER_UPDATE_TDMA:
                 case OSP_IDENTIFIER_UPDATE_VHF_UHF_BANDS:

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1NetworkConfigurationMonitor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1NetworkConfigurationMonitor.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@
 package io.github.dsheirer.module.decode.p25.phase1;
 
 import io.github.dsheirer.channel.IChannelDescriptor;
+import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.module.decode.p25.phase1.message.IFrequencyBand;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.LinkControlWord;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.standard.LCAdjacentSiteStatusBroadcast;
@@ -39,6 +40,7 @@ import io.github.dsheirer.module.decode.p25.phase1.message.pdu.ambtc.osp.AMBTCAd
 import io.github.dsheirer.module.decode.p25.phase1.message.pdu.ambtc.osp.AMBTCNetworkStatusBroadcast;
 import io.github.dsheirer.module.decode.p25.phase1.message.pdu.ambtc.osp.AMBTCRFSSStatusBroadcast;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.TSBKMessage;
+import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.MotorolaBaseStationId;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.standard.osp.AdjacentStatusBroadcast;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.standard.osp.NetworkStatusBroadcast;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.standard.osp.RFSSStatusBroadcast;
@@ -94,6 +96,8 @@ public class P25P1NetworkConfigurationMonitor
     private Map<Integer,LCAdjacentSiteStatusBroadcast> mLCNeighborSites = new HashMap<>();
     private Map<Integer,LCAdjacentSiteStatusBroadcastExplicit> mLCNeighborSitesExplicit = new HashMap<>();
     private Map<Integer,AdjacentStatusBroadcast> mTSBKNeighborSites = new HashMap<>();
+
+    private MotorolaBaseStationId mMotorolaBaseStationId;
 
     private P25P1Decoder.Modulation mModulation;
 
@@ -171,6 +175,12 @@ public class P25P1NetworkConfigurationMonitor
                 if(tsbk instanceof SNDCPDataChannelAnnouncementExplicit)
                 {
                     mSNDCPDataChannel = (SNDCPDataChannelAnnouncementExplicit)tsbk;
+                }
+                break;
+            case MOTOROLA_OSP_TRAFFIC_CHANNEL_ID:
+                if(tsbk instanceof MotorolaBaseStationId)
+                {
+                    mMotorolaBaseStationId = (MotorolaBaseStationId)tsbk;
                 }
                 break;
         }
@@ -314,6 +324,31 @@ public class P25P1NetworkConfigurationMonitor
         mTSBKNeighborSites.clear();
     }
 
+    /**
+     * Formats the identifier with an appended hexadecimal value when the identifier is an integer
+     * @param identifier to format
+     * @param width of the hex value with zero pre-padding
+     * @return formatted identifier
+     */
+    private String format(Identifier identifier, int width)
+    {
+        if(identifier.getValue() instanceof Integer)
+        {
+            String hex = Integer.toHexString((Integer)identifier.getValue());
+
+            while(hex.length() < width)
+            {
+                hex = "0" + hex;
+            }
+
+            return hex.toUpperCase() + "[" + identifier.getValue() + "]";
+        }
+        else
+        {
+            return identifier.toString();
+        }
+    }
+
     public String getActivitySummary()
     {
         StringBuilder sb = new StringBuilder();
@@ -323,26 +358,26 @@ public class P25P1NetworkConfigurationMonitor
         sb.append("\n\nNetwork\n");
         if(mTSBKNetworkStatusBroadcast != null)
         {
-            sb.append("  NAC:").append(mTSBKNetworkStatusBroadcast.getNAC());
-            sb.append(" WACN:").append(mTSBKNetworkStatusBroadcast.getWacn());
-            sb.append(" SYSTEM:").append(mTSBKNetworkStatusBroadcast.getSystem());
-            sb.append(" LRA:").append(mTSBKNetworkStatusBroadcast.getLocationRegistrationArea());
+            sb.append("  WACN:").append(format(mTSBKNetworkStatusBroadcast.getWacn(), 5));
+            sb.append(" SYSTEM:").append(format(mTSBKNetworkStatusBroadcast.getSystem(), 3));
+            sb.append(" NAC:").append(format(mTSBKNetworkStatusBroadcast.getNAC(), 3));
+            sb.append(" LRA:").append(format(mTSBKNetworkStatusBroadcast.getLocationRegistrationArea(), 2));
         }
         else if(mAMBTCNetworkStatusBroadcast != null)
         {
-            sb.append("  NAC:").append(mAMBTCNetworkStatusBroadcast.getNAC());
-            sb.append(" WACN:").append(mAMBTCNetworkStatusBroadcast.getWacn());
-            sb.append(" SYSTEM:").append(mAMBTCNetworkStatusBroadcast.getSystem());
+            sb.append("  WACN:").append(format(mAMBTCNetworkStatusBroadcast.getWacn(), 5));
+            sb.append(" SYSTEM:").append(format(mAMBTCNetworkStatusBroadcast.getSystem(), 3));
+            sb.append(" NAC:").append(format(mAMBTCNetworkStatusBroadcast.getNAC(), 3));
         }
         else if(mLCNetworkStatusBroadcast != null)
         {
-            sb.append("  WACN:").append(mLCNetworkStatusBroadcast.getWACN());
-            sb.append(" SYSTEM:").append(mLCNetworkStatusBroadcast.getSystem());
+            sb.append("  WACN:").append(format(mLCNetworkStatusBroadcast.getWACN(), 5));
+            sb.append(" SYSTEM:").append(format(mLCNetworkStatusBroadcast.getSystem(), 3));
         }
         else if(mLCNetworkStatusBroadcastExplicit != null)
         {
-            sb.append("  WACN:").append(mLCNetworkStatusBroadcastExplicit.getWACN());
-            sb.append(" SYSTEM:").append(mLCNetworkStatusBroadcastExplicit.getSystem());
+            sb.append("  WACN:").append(format(mLCNetworkStatusBroadcastExplicit.getWACN(), 5));
+            sb.append(" SYSTEM:").append(format(mLCNetworkStatusBroadcastExplicit.getSystem(), 3));
         }
         else
         {
@@ -350,12 +385,14 @@ public class P25P1NetworkConfigurationMonitor
         }
 
         sb.append("\n\nCurrent Site\n");
+
         if(mTSBKRFSSStatusBroadcast != null)
         {
-            sb.append("  SYSTEM:").append(mTSBKRFSSStatusBroadcast.getSystem());
-            sb.append(" SITE:").append(mTSBKRFSSStatusBroadcast.getSite());
-            sb.append(" RF SUBSYSTEM:").append(mTSBKRFSSStatusBroadcast.getRfss());
-            sb.append(" LOCATION REGISTRATION AREA:").append(mTSBKRFSSStatusBroadcast.getLocationRegistrationArea());
+            sb.append("  SYSTEM:").append(format(mTSBKRFSSStatusBroadcast.getSystem(), 3));
+            sb.append(" NAC:").append(format(mTSBKRFSSStatusBroadcast.getNAC(), 3));
+            sb.append(" RFSS:").append(format(mTSBKRFSSStatusBroadcast.getRfss(), 2));
+            sb.append(" SITE:").append(format(mTSBKRFSSStatusBroadcast.getSite(), 2));
+            sb.append(" LRA:").append(format(mTSBKRFSSStatusBroadcast.getLocationRegistrationArea(), 2));
             sb.append("  STATUS:").append(mTSBKRFSSStatusBroadcast.isActiveNetworkConnectionToRfssControllerSite() ?
                 "ACTIVE RFSS NETWORK CONNECTION\n" : "\n");
             sb.append("  PRI CONTROL CHANNEL:").append(mTSBKRFSSStatusBroadcast.getChannel());
@@ -364,29 +401,30 @@ public class P25P1NetworkConfigurationMonitor
         }
         else if(mLCRFSSStatusBroadcast != null)
         {
-            sb.append("  SYSTEM:").append(mLCRFSSStatusBroadcast.getSystem());
-            sb.append(" SITE:").append(mLCRFSSStatusBroadcast.getSite());
-            sb.append(" RF SUBSYSTEM:").append(mLCRFSSStatusBroadcast.getRfss());
-            sb.append(" LOCATION REGISTRATION AREA:").append(mLCRFSSStatusBroadcast.getLocationRegistrationArea()).append("\n");
+            sb.append("  SYSTEM:").append(format(mLCRFSSStatusBroadcast.getSystem(), 3));
+            sb.append(" RFSS:").append(format(mLCRFSSStatusBroadcast.getRfss(), 2));
+            sb.append(" SITE:").append(format(mLCRFSSStatusBroadcast.getSite(), 2));
+            sb.append(" LRA:").append(format(mLCRFSSStatusBroadcast.getLocationRegistrationArea(), 2)).append("\n");
             sb.append("  PRI CONTROL CHANNEL:").append(mLCRFSSStatusBroadcast.getChannel());
             sb.append(" DOWNLINK:").append(mLCRFSSStatusBroadcast.getChannel().getDownlinkFrequency());
             sb.append(" UPLINK:").append(mLCRFSSStatusBroadcast.getChannel().getUplinkFrequency()).append("\n");
         }
         else if(mLCRFSSStatusBroadcastExplicit != null)
         {
-            sb.append("  SITE:").append(mLCRFSSStatusBroadcastExplicit.getSite());
-            sb.append(" RF SUBSYSTEM:").append(mLCRFSSStatusBroadcastExplicit.getRfss());
-            sb.append(" LOCATION REGISTRATION AREA:").append(mLCRFSSStatusBroadcastExplicit.getLocationRegistrationArea()).append("\n");
+            sb.append("  RFSS:").append(mLCRFSSStatusBroadcastExplicit.getRfss());
+            sb.append(" SITE:").append(format(mLCRFSSStatusBroadcastExplicit.getSite(), 2));
+            sb.append(" LRA:").append(format(mLCRFSSStatusBroadcastExplicit.getLocationRegistrationArea(), 2)).append("\n");
             sb.append("  PRI CONTROL CHANNEL:").append(mLCRFSSStatusBroadcastExplicit.getChannel());
             sb.append(" DOWNLINK:").append(mLCRFSSStatusBroadcastExplicit.getChannel().getDownlinkFrequency());
             sb.append(" UPLINK:").append(mLCRFSSStatusBroadcastExplicit.getChannel().getUplinkFrequency()).append("\n");
         }
         else if(mAMBTCRFSSStatusBroadcast != null)
         {
-            sb.append("  SYSTEM:").append(mAMBTCRFSSStatusBroadcast.getSystem());
-            sb.append(" SITE:").append(mAMBTCRFSSStatusBroadcast.getSite());
-            sb.append(" RF SUBSYSTEM:").append(mAMBTCRFSSStatusBroadcast.getRFSS());
-            sb.append(" LOCATION REGISTRATION AREA:").append(mAMBTCRFSSStatusBroadcast.getLRA());
+            sb.append("  SYSTEM:").append(format(mAMBTCRFSSStatusBroadcast.getSystem(), 3));
+            sb.append(" NAC:").append(format(mAMBTCRFSSStatusBroadcast.getNAC(), 3));
+            sb.append(" RFSS:").append(format(mAMBTCRFSSStatusBroadcast.getRFSS(), 2));
+            sb.append(" SITE:").append(format(mAMBTCRFSSStatusBroadcast.getSite(), 2));
+            sb.append(" LRA:").append(format(mAMBTCRFSSStatusBroadcast.getLRA(), 2));
             sb.append("  STATUS:").append(mAMBTCRFSSStatusBroadcast.isActiveNetworkConnectionToRfssControllerSite() ?
                 "ACTIVE RFSS NETWORK CONNECTION\n" : "\n");
             sb.append("  PRI CONTROL CHANNEL:").append(mAMBTCRFSSStatusBroadcast.getChannel());
@@ -423,6 +461,11 @@ public class P25P1NetworkConfigurationMonitor
             sb.append(" UPLINK:").append(mSNDCPDataChannel.getChannel().getUplinkFrequency()).append("\n");
         }
 
+        if(mMotorolaBaseStationId != null)
+        {
+            sb.append("  STATION ID/LICENSE: " + mMotorolaBaseStationId.getCWID()).append("\n");
+        }
+
         if(mTSBKSystemServiceBroadcast != null)
         {
             sb.append("  AVAILABLE SERVICES:").append(mTSBKSystemServiceBroadcast.getAvailableServices());
@@ -433,7 +476,6 @@ public class P25P1NetworkConfigurationMonitor
             sb.append("  AVAILABLE SERVICES:").append(mLCSystemServiceBroadcast.getAvailableServices());
             sb.append("  SUPPORTED SERVICES:").append(mLCSystemServiceBroadcast.getSupportedServices());
         }
-
 
         sb.append("\nNeighbor Sites\n");
         Set<Integer> sites = new TreeSet<>();
@@ -456,10 +498,11 @@ public class P25P1NetworkConfigurationMonitor
                 if(mAMBTCNeighborSites.containsKey(site))
                 {
                     AMBTCAdjacentStatusBroadcast ambtc = mAMBTCNeighborSites.get(site);
-                    sb.append("  SYSTEM:").append(ambtc.getSystem());
-                    sb.append(" SITE:").append(ambtc.getSite());
-                    sb.append(" LRA:").append(ambtc.getLocationRegistrationArea());
-                    sb.append(" RFSS:").append(ambtc.getRfss());
+                    sb.append("  SYSTEM:").append(format(ambtc.getSystem(), 3));
+                    sb.append(" NAC:").append(format(ambtc.getNAC(), 3));
+                    sb.append(" RFSS:").append(format(ambtc.getRfss(), 2));
+                    sb.append(" SITE:").append(format(ambtc.getSite(), 2));
+                    sb.append(" LRA:").append(format(ambtc.getLocationRegistrationArea(), 2));
                     sb.append(" CHANNEL:").append(ambtc.getChannel());
                     sb.append(" DOWNLINK:").append(ambtc.getChannel().getDownlinkFrequency());
                     sb.append(" UPLINK:").append(ambtc.getChannel().getUplinkFrequency()).append("\n");
@@ -467,10 +510,10 @@ public class P25P1NetworkConfigurationMonitor
                 if(mLCNeighborSites.containsKey(site))
                 {
                     LCAdjacentSiteStatusBroadcast lc = mLCNeighborSites.get(site);
-                    sb.append("  SYSTEM:").append(lc.getSystem());
-                    sb.append(" SITE:").append(lc.getSite());
-                    sb.append(" LRA:").append(lc.getLocationRegistrationArea());
-                    sb.append(" RFSS:").append(lc.getRfss());
+                    sb.append("  SYSTEM:").append(format(lc.getSystem(), 3));
+                    sb.append(" RFSS:").append(format(lc.getRfss(), 2));
+                    sb.append(" SITE:").append(format(lc.getSite(), 2));
+                    sb.append(" LRA:").append(format(lc.getLocationRegistrationArea(), 2));
                     sb.append(" CHANNEL:").append(lc.getChannel());
                     sb.append(" DOWNLINK:").append(lc.getChannel().getDownlinkFrequency());
                     sb.append(" UPLINK:").append(lc.getChannel().getUplinkFrequency()).append("\n");
@@ -480,9 +523,9 @@ public class P25P1NetworkConfigurationMonitor
                 {
                     LCAdjacentSiteStatusBroadcastExplicit lce = mLCNeighborSitesExplicit.get(site);
                     sb.append("  SYSTEM:---");
-                    sb.append(" SITE:").append(lce.getSite());
-                    sb.append(" LRA:").append(lce.getLocationRegistrationArea());
-                    sb.append(" RFSS:").append(lce.getRfss());
+                    sb.append(" RFSS:").append(format(lce.getRfss(), 2));
+                    sb.append(" SITE:").append(format(lce.getSite(), 2));
+                    sb.append(" LRA:").append(format(lce.getLocationRegistrationArea(), 2));
                     sb.append(" CHANNEL:").append(lce.getChannel());
                     sb.append(" DOWNLINK:").append(lce.getChannel().getDownlinkFrequency());
                     sb.append(" UPLINK:").append(lce.getChannel().getUplinkFrequency()).append("\n");
@@ -490,10 +533,11 @@ public class P25P1NetworkConfigurationMonitor
                 if(mTSBKNeighborSites.containsKey(site))
                 {
                     AdjacentStatusBroadcast asb = mTSBKNeighborSites.get(site);
-                    sb.append("  SYSTEM:").append(asb.getSystem());
-                    sb.append(" SITE:").append(asb.getSite());
-                    sb.append(" LRA:").append(asb.getLocationRegistrationArea());
-                    sb.append(" RFSS:").append(asb.getRfss());
+                    sb.append("  SYSTEM:").append(format(asb.getSystem(), 3));
+                    sb.append(" NAC:").append(format(asb.getNAC(), 3));
+                    sb.append(" RFSS:").append(format(asb.getRfss(), 2));
+                    sb.append(" SITE:").append(format(asb.getSite(), 2));
+                    sb.append(" LRA:").append(format(asb.getLocationRegistrationArea(), 2));
                     sb.append(" CHANNEL:").append(asb.getChannel());
                     sb.append(" DOWNLINK:").append(asb.getChannel().getDownlinkFrequency());
                     sb.append(" UPLINK:").append(asb.getChannel().getUplinkFrequency());

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1NetworkConfigurationMonitor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1NetworkConfigurationMonitor.java
@@ -177,7 +177,7 @@ public class P25P1NetworkConfigurationMonitor
                     mSNDCPDataChannel = (SNDCPDataChannelAnnouncementExplicit)tsbk;
                 }
                 break;
-            case MOTOROLA_OSP_TRAFFIC_CHANNEL_ID:
+            case MOTOROLA_OSP_BASE_STATION_ID:
                 if(tsbk instanceof MotorolaBaseStationId)
                 {
                     mMotorolaBaseStationId = (MotorolaBaseStationId)tsbk;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/lc/standard/LCRFSSStatusBroadcastExplicit.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/lc/standard/LCRFSSStatusBroadcastExplicit.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -42,12 +42,12 @@ import java.util.List;
 public class LCRFSSStatusBroadcastExplicit extends LinkControlWord implements IFrequencyBandReceiver
 {
     private static final int[] LRA = {8, 9, 10, 11, 12, 13, 14, 15};
-    private static final int[] DOWNLINK_FREQUENCY_BAND = {16, 17, 18, 19};
-    private static final int[] DOWNLINK_CHANNEL_NUMBER = {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+    private static final int[] UPLINK_FREQUENCY_BAND = {16, 17, 18, 19};
+    private static final int[] UPLINK_CHANNEL_NUMBER = {20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
     private static final int[] RFSS = {32, 33, 34, 35, 36, 37, 38, 39};
     private static final int[] SITE = {40, 41, 42, 43, 44, 45, 46, 47};
-    private static final int[] UPLINK_FREQUENCY_BAND = {48, 49, 50, 51};
-    private static final int[] UPLINK_CHANNEL_NUMBER = {52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
+    private static final int[] DOWNLINK_FREQUENCY_BAND = {48, 49, 50, 51};
+    private static final int[] DOWNLINK_CHANNEL_NUMBER = {52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
     private static final int[] SERVICE_CLASS = {64, 65, 66, 67, 68, 69, 70, 71};
 
     private List<Identifier> mIdentifiers;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/Opcode.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/Opcode.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -171,10 +171,10 @@ public enum Opcode
     MOTOROLA_OSP_PATCH_GROUP_DELETE(1, "PATCH GROUP DELE", "MOTOROLA PATCH GROUP DELETE"),
     MOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT(2, "PTCH GRP VCHN GR", "MOTOROLA PATCH GROUP CHANNEL GRANT"),
     MOTOROLA_OSP_PATCH_GROUP_CHANNEL_GRANT_UPDATE(3, "PTCH GRP VCH UPD", "MOTOROLA PATCH GROUP CHANNEL GRANT UPDATE"),
-    MOTOROLA_OSP_TRAFFIC_CHANNEL_ID(5, "CHANNEL CWID", "CHANNEL CWID"),
+    MOTOROLA_OSP_TRAFFIC_CHANNEL_ID(5, "TRAFFIC CHANNEL", "TRAFFIC CHANNEL"),
     MOTOROLA_OSP_DENY_RESPONSE(7, "DENY RESPONSE", "MOTOROLA DENY RESPONSE"),
     MOTOROLA_OSP_SYSTEM_LOADING(9, "SYSTEM LOADING", "SYSTEM LOADING"),
-    MOTOROLA_OSP_CONTROL_CHANNEL_ID(11, "CCH BASE STAT ID", "CONTROL CHANNEL BASE STATION ID"),
+    MOTOROLA_OSP_BASE_STATION_ID(11, "CCH BASE STAT ID", "CONTROL CHANNEL BASE STATION ID"),
     MOTOROLA_OSP_CONTROL_CHANNEL_PLANNED_SHUTDOWN(14, "CCH PLND SHUTDWN", "CONTROL CHANNEL PLANNED SHUTDOWN"),
     MOTOROLA_OSP_UNKNOWN(-1, "MOTOROLA OSP UNKNOWN OPCODE", "MOTOROLA OSP UNKNOWN OPCODE"),
 
@@ -332,7 +332,7 @@ public enum Opcode
                         case 0x09:
                             return MOTOROLA_OSP_SYSTEM_LOADING;
                         case 0x0B:
-                            return MOTOROLA_OSP_CONTROL_CHANNEL_ID;
+                            return MOTOROLA_OSP_BASE_STATION_ID;
                         case 0x0E:
                             return MOTOROLA_OSP_CONTROL_CHANNEL_PLANNED_SHUTDOWN;
                         default:

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/TSBKMessageFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/TSBKMessageFactory.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@ import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.isp.Unk
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.ChannelLoading;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.MotorolaBaseStationId;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.MotorolaDenyResponse;
+import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.MotorolaTrafficChannel;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.PatchGroupAdd;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.PatchGroupDelete;
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp.PatchGroupVoiceChannelGrant;
@@ -118,12 +119,15 @@ import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.unknown.isp.Unkn
 import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.unknown.osp.UnknownVendorOSPMessage;
 import io.github.dsheirer.module.decode.p25.reference.Direction;
 import io.github.dsheirer.module.decode.p25.reference.Vendor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Factory for creating Trunking Signalling Block (TSBK) message parser classes
  */
 public class TSBKMessageFactory
 {
+    private final static Logger mLog = LoggerFactory.getLogger(TSBKMessageFactory.class);
     private static final ViterbiDecoder_1_2_P25 VITERBI_HALF_RATE_DECODER = new ViterbiDecoder_1_2_P25();
 
     public static TSBKMessage create(Direction direction, P25P1DataUnitID dataUnitID,
@@ -308,7 +312,7 @@ public class TSBKMessageFactory
             case MOTOROLA_OSP_DENY_RESPONSE:
                 return new MotorolaDenyResponse(dataUnitID, message, nac, timestamp);
             case MOTOROLA_OSP_TRAFFIC_CHANNEL_ID:
-                return new MotorolaBaseStationId(dataUnitID, message, nac, timestamp);
+                return new MotorolaTrafficChannel(dataUnitID, message, nac, timestamp);
             case MOTOROLA_OSP_PATCH_GROUP_ADD:
                 return new PatchGroupAdd(dataUnitID, message, nac, timestamp);
             case MOTOROLA_OSP_PATCH_GROUP_DELETE:

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/TSBKMessageFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/TSBKMessageFactory.java
@@ -305,7 +305,7 @@ public class TSBKMessageFactory
 
             case MOTOROLA_ISP_UNKNOWN:
                 return new UnknownMotorolaISPMessage(dataUnitID, message, nac, timestamp);
-            case MOTOROLA_OSP_CONTROL_CHANNEL_ID:
+            case MOTOROLA_OSP_BASE_STATION_ID:
                 return new MotorolaBaseStationId(dataUnitID, message, nac, timestamp);
             case MOTOROLA_OSP_CONTROL_CHANNEL_PLANNED_SHUTDOWN:
                 return new PlannedChannelShutdown(dataUnitID, message, nac, timestamp);

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/motorola/osp/MotorolaTrafficChannel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/tsbk/motorola/osp/MotorolaTrafficChannel.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
+ *
+ *
+ */
+package io.github.dsheirer.module.decode.p25.phase1.message.tsbk.motorola.osp;
+
+import io.github.dsheirer.bits.CorrectedBinaryMessage;
+import io.github.dsheirer.identifier.Identifier;
+import io.github.dsheirer.module.decode.p25.phase1.P25P1DataUnitID;
+import io.github.dsheirer.module.decode.p25.phase1.message.tsbk.OSPMessage;
+
+import java.util.Collections;
+import java.util.List;
+
+public class MotorolaTrafficChannel extends OSPMessage
+{
+    public MotorolaTrafficChannel(P25P1DataUnitID dataUnitID, CorrectedBinaryMessage message, int nac, long timestamp)
+    {
+        super(dataUnitID, message, nac, timestamp);
+    }
+
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getMessageStub());
+        sb.append(" TRAFFIC CHANNEL ");
+        sb.append(getMessage().toHexString());
+        return sb.toString();
+    }
+
+    @Override
+    public List<Identifier> getIdentifiers()
+    {
+        return Collections.EMPTY_LIST;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2NetworkConfigurationMonitor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2NetworkConfigurationMonitor.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@
 package io.github.dsheirer.module.decode.p25.phase2;
 
 import io.github.dsheirer.channel.IChannelDescriptor;
+import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.module.decode.p25.phase1.message.IFrequencyBand;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacMessage;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacStructure;
@@ -82,6 +83,31 @@ public class P25P2NetworkConfigurationMonitor
      */
     public P25P2NetworkConfigurationMonitor()
     {
+    }
+
+    /**
+     * Formats the identifier with an appended hexadecimal value when the identifier is an integer
+     * @param identifier to format
+     * @param width of the hex value with zero pre-padding
+     * @return formatted identifier
+     */
+    private String format(Identifier identifier, int width)
+    {
+        if(identifier.getValue() instanceof Integer)
+        {
+            String hex = Integer.toHexString((Integer)identifier.getValue());
+
+            while(hex.length() < width)
+            {
+                hex = "0" + hex;
+            }
+
+            return hex.toUpperCase() + "[" + identifier.getValue() + "]";
+        }
+        else
+        {
+            return identifier.toString();
+        }
     }
 
     /**
@@ -207,17 +233,17 @@ public class P25P2NetworkConfigurationMonitor
         sb.append("\n\nNetwork\n");
         if(mNetworkStatusBroadcastAbbreviated != null)
         {
-            sb.append("  NAC:").append(mNetworkStatusBroadcastAbbreviated.getNAC());
-            sb.append(" WACN:").append(mNetworkStatusBroadcastAbbreviated.getWACN());
-            sb.append(" SYSTEM:").append(mNetworkStatusBroadcastAbbreviated.getSystem());
-            sb.append(" LRA:").append(mNetworkStatusBroadcastAbbreviated.getLRA());
+            sb.append("  WACN:").append(format(mNetworkStatusBroadcastAbbreviated.getWACN(), 5));
+            sb.append(" SYSTEM:").append(format(mNetworkStatusBroadcastAbbreviated.getSystem(), 3));
+            sb.append(" NAC:").append(format(mNetworkStatusBroadcastAbbreviated.getNAC(), 3));
+            sb.append(" LRA:").append(format(mNetworkStatusBroadcastAbbreviated.getLRA(), 2));
         }
         else if(mNetworkStatusBroadcastExtended != null)
         {
-            sb.append("  NAC:").append(mNetworkStatusBroadcastExtended.getNAC());
-            sb.append(" WACN:").append(mNetworkStatusBroadcastExtended.getWACN());
-            sb.append(" SYSTEM:").append(mNetworkStatusBroadcastExtended.getSystem());
-            sb.append(" LRA:").append(mNetworkStatusBroadcastExtended.getLRA());
+            sb.append("  WACN:").append(format(mNetworkStatusBroadcastExtended.getWACN(), 5));
+            sb.append(" SYSTEM:").append(format(mNetworkStatusBroadcastExtended.getSystem(), 3));
+            sb.append(" NAC:").append(format(mNetworkStatusBroadcastExtended.getNAC(), 3));
+            sb.append(" LRA:").append(format(mNetworkStatusBroadcastExtended.getLRA(), 2));
         }
         else
         {
@@ -227,20 +253,20 @@ public class P25P2NetworkConfigurationMonitor
         sb.append("\n\nCurrent Site\n");
         if(mRFSSStatusBroadcastAbbreviated != null)
         {
-            sb.append("  SYSTEM:").append(mRFSSStatusBroadcastAbbreviated.getSystem());
-            sb.append(" SITE:").append(mRFSSStatusBroadcastAbbreviated.getSite());
-            sb.append(" RF SUBSYSTEM:").append(mRFSSStatusBroadcastAbbreviated.getRFSS());
-            sb.append(" LOCATION REGISTRATION AREA:").append(mRFSSStatusBroadcastAbbreviated.getLRA());
+            sb.append("  SYSTEM:").append(format(mRFSSStatusBroadcastAbbreviated.getSystem(), 3));
+            sb.append(" RFSS:").append(format(mRFSSStatusBroadcastAbbreviated.getRFSS(), 2));
+            sb.append(" SITE:").append(format(mRFSSStatusBroadcastAbbreviated.getSite(), 2));
+            sb.append(" LRA:").append(format(mRFSSStatusBroadcastAbbreviated.getLRA(), 2));
             sb.append("  PRI CONTROL CHANNEL:").append(mRFSSStatusBroadcastAbbreviated.getChannel());
             sb.append(" DOWNLINK:").append(mRFSSStatusBroadcastAbbreviated.getChannel().getDownlinkFrequency());
             sb.append(" UPLINK:").append(mRFSSStatusBroadcastAbbreviated.getChannel().getUplinkFrequency()).append("\n");
         }
         else if(mRFSSStatusBroadcastExtended != null)
         {
-            sb.append("  SYSTEM:").append(mRFSSStatusBroadcastExtended.getSystem());
-            sb.append(" SITE:").append(mRFSSStatusBroadcastExtended.getSite());
-            sb.append(" RF SUBSYSTEM:").append(mRFSSStatusBroadcastExtended.getRFSS());
-            sb.append(" LOCATION REGISTRATION AREA:").append(mRFSSStatusBroadcastExtended.getLRA());
+            sb.append("  SYSTEM:").append(format(mRFSSStatusBroadcastExtended.getSystem(), 3));
+            sb.append(" RFSS:").append(format(mRFSSStatusBroadcastExtended.getRFSS(), 2));
+            sb.append(" SITE:").append(format(mRFSSStatusBroadcastExtended.getSite(), 2));
+            sb.append(" LRA:").append(format(mRFSSStatusBroadcastExtended.getLRA(), 2));
             sb.append("  PRI CONTROL CHANNEL:").append(mRFSSStatusBroadcastExtended.getChannel());
             sb.append(" DOWNLINK:").append(mRFSSStatusBroadcastExtended.getChannel().getDownlinkFrequency());
             sb.append(" UPLINK:").append(mRFSSStatusBroadcastExtended.getChannel().getUplinkFrequency()).append("\n");
@@ -294,10 +320,10 @@ public class P25P2NetworkConfigurationMonitor
                 if(mNeighborSitesAbbreviated.containsKey(site))
                 {
                     AdjacentStatusBroadcastAbbreviated asb = mNeighborSitesAbbreviated.get(site);
-                    sb.append("  SYSTEM:").append(asb.getSystem());
-                    sb.append(" SITE:").append(asb.getSite());
-                    sb.append(" LRA:").append(asb.getLRA());
-                    sb.append(" RFSS:").append(asb.getRFSS());
+                    sb.append("  SYSTEM:").append(format(asb.getSystem(), 3));
+                    sb.append(" RFSS:").append(format(asb.getRFSS(), 2));
+                    sb.append(" SITE:").append(format(asb.getSite(), 2));
+                    sb.append(" LRA:").append(format(asb.getLRA(), 2));
                     sb.append(" CHANNEL:").append(asb.getChannel());
                     sb.append(" DOWNLINK:").append(asb.getChannel().getDownlinkFrequency());
                     sb.append(" UPLINK:").append(asb.getChannel().getUplinkFrequency());
@@ -306,10 +332,10 @@ public class P25P2NetworkConfigurationMonitor
                 else if(mNeighborSitesAbbreviated.containsKey(site))
                 {
                     AdjacentStatusBroadcastAbbreviated asb = mNeighborSitesAbbreviated.get(site);
-                    sb.append("  SYSTEM:").append(asb.getSystem());
-                    sb.append(" SITE:").append(asb.getSite());
-                    sb.append(" LRA:").append(asb.getLRA());
-                    sb.append(" RFSS:").append(asb.getRFSS());
+                    sb.append("  SYSTEM:").append(format(asb.getSystem(), 3));
+                    sb.append(" RFSS:").append(format(asb.getRFSS(), 2));
+                    sb.append(" SITE:").append(format(asb.getSite(), 2));
+                    sb.append(" LRA:").append(format(asb.getLRA(), 2));
                     sb.append(" CHANNEL:").append(asb.getChannel());
                     sb.append(" DOWNLINK:").append(asb.getChannel().getDownlinkFrequency());
                     sb.append(" UPLINK:").append(asb.getChannel().getUplinkFrequency());

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
@@ -1,18 +1,24 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2019 Dennis Sheirer
+/*
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ */
 
 package io.github.dsheirer.source.tuner.manager;
 
@@ -62,7 +68,6 @@ public class PassThroughSourceManager extends ChannelSourceManager
         PassThroughChannelSource channelSource = new PassThroughChannelSource(new SourceEventProxy(),
                 mTunerController, tunerChannel);
 
-        mLog.debug("Returning a pass through channel");
         mTunerChannels.add(tunerChannel);
 
         return channelSource;
@@ -77,16 +82,18 @@ public class PassThroughSourceManager extends ChannelSourceManager
                 if(event.hasSource() && event.getSource() instanceof PassThroughChannelSource)
                 {
                     mTunerController.addBufferListener((PassThroughChannelSource)event.getSource());
+                    broadcast(SourceEvent.channelCountChange(mTunerChannels.size()));
                 }
                 break;
             case REQUEST_STOP_SAMPLE_STREAM:
                 if(event.hasSource() && event.getSource() instanceof PassThroughChannelSource)
                 {
-                    mTunerController.removeBufferListener((PassThroughChannelSource)event.getSource());
+                    PassThroughChannelSource source = (PassThroughChannelSource)event.getSource();
+                    mTunerController.removeBufferListener(source);
+                    mTunerChannels.remove(source.getTunerChannel());
+                    broadcast(SourceEvent.channelCountChange(mTunerChannels.size()));
                 }
                 break;
-            default:
-                mLog.debug("Got source event: " + event);
         }
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTuner.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@ import io.github.dsheirer.source.SourceEvent;
 import io.github.dsheirer.source.tuner.Tuner;
 import io.github.dsheirer.source.tuner.TunerClass;
 import io.github.dsheirer.source.tuner.TunerType;
-import io.github.dsheirer.source.tuner.manager.ChannelSourceManager;
 import io.github.dsheirer.source.tuner.manager.HeterodyneChannelSourceManager;
 import io.github.dsheirer.source.tuner.manager.PassThroughSourceManager;
 import io.github.dsheirer.source.tuner.manager.PolyphaseChannelSourceManager;
@@ -49,8 +48,6 @@ public class RecordingTuner extends Tuner
         super("Recording Tuner", new RecordingTunerController());
 
         mUserPreferences = userPreferences;
-
-        ChannelSourceManager channelSourceManager = null;
 
         if(getTunerController().getCurrentSampleRate() < 100000.0d)
         {

--- a/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerController.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -177,7 +177,7 @@ public class RecordingTunerController extends TunerController
             }
             catch(IOException ioe)
             {
-                mLog.debug("Error loading recording tuner baseband recording: " + rtc.getPath(), ioe);
+                mLog.debug("Error loading recording tuner baseband recording [" + rtc.getPath() + "] Error: " + ioe.getLocalizedMessage());
             }
         }
     }


### PR DESCRIPTION
#576 Updates P25 activity summaries to list values in hex and decimal.  Resolves issue with P25 explicit channel uplink frequency calculations.  Resolves issue with Motorola base station id messages and traffic channel messages.  Resolves issue with RFSS link control message control channel frequency calculations.  Resolves issue with error when using recording tuners.