### PR TITLE
#644 Icecast Metadata Updater NoClassDefFound Error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
     mavenCentral()
 }
 
-version = '0.4.0-beta.3'
+version = '0.4.0-beta.4'
 sourceCompatibility = '11'
 
 sourceSets {
@@ -156,7 +156,7 @@ runtime {
     }
 
     options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
-    modules = ['java.desktop', 'java.naming', 'jdk.unsupported', 'jdk.unsupported.desktop']
+    modules = ['java.desktop', 'java.naming', 'jdk.unsupported', 'jdk.unsupported.desktop', 'java.net.http']
     imageZip = file("$buildDir/image/sdr-trunk-" + version + ".zip")
 }
 


### PR DESCRIPTION
Resolves #644 
NoClassDefFound error when Icecast metadata updater runs.  

Updates build to version 0.4.0 Beta 4
