### PR TITLE
#652 USB Tuner Error Handling Enhancements

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -124,6 +124,18 @@ public class PolyphaseChannelManager implements ISourceEventProcessor
     public PolyphaseChannelManager(TunerController tunerController)
     {
         this(tunerController, tunerController.getFrequency(), tunerController.getSampleRate());
+    }
+
+    /**
+     * Signals to all provisioned tuner channel sources that the source complex buffer provider has an error and can
+     * no longer provide channels, so that the tuner channel source can notify the consumer of the error state.
+     */
+    public void setErrorMessage(String errorMessage)
+    {
+        for(TunerChannelSource tunerChannelSource: mChannelSources)
+        {
+            tunerChannelSource.setError(errorMessage);
+        }
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
+++ b/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -474,7 +474,6 @@ public class SDRTrunk implements Listener<TunerEvent>
         mAudioPacketManager.stop();
         mLog.info("Stopping spectral display ...");
         mSpectralPanel.clearTuner();
-        mLog.info("Releasing tuners ...");
         mSourceManager.shutdown();
         mLog.info("Shutdown complete.");
         mApplicationLog.stop();

--- a/src/main/java/io/github/dsheirer/module/ProcessingChain.java
+++ b/src/main/java/io/github/dsheirer/module/ProcessingChain.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -115,14 +115,12 @@ public class ProcessingChain implements Listener<ChannelEvent>
     private Broadcaster<SourceEvent> mSourceEventBroadcaster = new Broadcaster<>();
     private Broadcaster<IMessage> mMessageBroadcaster = new Broadcaster<>();
     private Broadcaster<SquelchStateEvent> mSquelchStateEventBroadcaster = new Broadcaster<>();
-
     private AtomicBoolean mRunning = new AtomicBoolean();
-
-    protected Source mSource;
     private List<Module> mModules = new ArrayList<>();
     private DecodeEventModel mDecodeEventModel;
     private AbstractChannelState mChannelState;
     private MessageActivityModel mMessageActivityModel;
+    protected Source mSource;
 
     /**
      * Creates a processing chain for managing a set of modules
@@ -206,6 +204,14 @@ public class ProcessingChain implements Listener<ChannelEvent>
     public boolean hasSource()
     {
         return mSource != null;
+    }
+
+    /**
+     * Indicates if this chain's source is the same as the source argument
+     */
+    public boolean hasSource(Source source)
+    {
+        return mSource != null && mSource.equals(source);
     }
 
     /**
@@ -798,6 +804,14 @@ public class ProcessingChain implements Listener<ChannelEvent>
         {
             mMessageBroadcaster.addListener(listener);
         }
+    }
+
+    /**
+     * Adds a listener to receive source events from this processing chain
+     */
+    public void addSourceEventListener(Listener<SourceEvent> listener)
+    {
+        mSourceEventBroadcaster.addListener(listener);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/SourceEvent.java
+++ b/src/main/java/io/github/dsheirer/source/SourceEvent.java
@@ -1,21 +1,23 @@
 /*
- * ******************************************************************************
- * sdrtrunk
- * Copyright (C) 2014-2019 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- * *****************************************************************************
  */
 package io.github.dsheirer.source;
 
@@ -39,6 +41,7 @@ public class SourceEvent
         NOTIFICATION_RECORDING_FILE_LOADED,
         NOTIFICATION_SAMPLE_RATE_CHANGE,
         NOTIFICATION_STOP_SAMPLE_STREAM,
+        NOTIFICATION_ERROR_STATE,
 
         REQUEST_CHANNEL_FREQUENCY_CORRECTION_CHANGE,
         REQUEST_FREQUENCY_CHANGE,
@@ -67,6 +70,14 @@ public class SourceEvent
         mSource = source;
         mValue = value;
         mEventDescription = eventDescription;
+    }
+
+    /**
+     * Private constructor.  Use the static constructor methods to create an event.
+     */
+    private SourceEvent(Event event, Source source, String eventDescription)
+    {
+        this(event, source, null, eventDescription);
     }
 
     /**
@@ -165,6 +176,15 @@ public class SourceEvent
     public boolean hasSource()
     {
         return mSource != null;
+    }
+
+
+    /**
+     * Creates a new error state for the specified source and error description
+     */
+    public static SourceEvent errorState(Source source, String errorDescription)
+    {
+        return new SourceEvent(Event.NOTIFICATION_ERROR_STATE, source, errorDescription);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/ITunerErrorListener.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ITunerErrorListener.java
@@ -22,39 +22,11 @@
 
 package io.github.dsheirer.source.tuner;
 
-public class TunerEvent
+public interface ITunerErrorListener
 {
-    private Tuner mTuner;
-    private Event mEvent;
-
-    public TunerEvent(Tuner tuner, Event event)
-    {
-        mTuner = tuner;
-        mEvent = event;
-    }
-
-    public Tuner getTuner()
-    {
-        return mTuner;
-    }
-
-    public Event getEvent()
-    {
-        return mEvent;
-    }
-
-    public enum Event
-    {
-        CHANNEL_COUNT,
-        ERROR_STATE,
-        FREQUENCY_UPDATED,
-        FREQUENCY_ERROR_UPDATED,
-        LOCK_STATE_CHANGE,
-        MEASURED_FREQUENCY_ERROR_UPDATED,
-        SAMPLE_RATE_UPDATED,
-
-        CLEAR_MAIN_SPECTRAL_DISPLAY,
-        REQUEST_MAIN_SPECTRAL_DISPLAY,
-        REQUEST_NEW_SPECTRAL_DISPLAY;
-    }
+    /**
+     * Sets an error message for the tuner listener
+     * @param errorMessage to set
+     */
+    void setErrorMessage(String errorMessage);
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerController.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 import java.util.SortedSet;
 
 public abstract class TunerController implements Tunable, ISourceEventProcessor, ISourceEventListener,
-    IReusableComplexBufferProvider, Listener<ReusableComplexBuffer>
+    IReusableComplexBufferProvider, Listener<ReusableComplexBuffer>, ITunerErrorListener
 {
     private final static Logger mLog = LoggerFactory.getLogger(TunerController.class);
     protected ReusableBufferBroadcaster mReusableBufferBroadcaster = new ReusableBufferBroadcaster();
@@ -52,6 +52,7 @@ public abstract class TunerController implements Tunable, ISourceEventProcessor,
     private Listener<SourceEvent> mSourceEventListener;
     private int mMeasuredFrequencyError;
     private ComplexBufferWaveRecorder mRecorder;
+    private ITunerErrorListener mTunerErrorListener;
 
     /**
      * Abstract tuner controller class.  The tuner controller manages frequency bandwidth and currently tuned channels
@@ -76,6 +77,24 @@ public abstract class TunerController implements Tunable, ISourceEventProcessor,
      * Dispose of this tuner controller and prepare for shutdown.
      */
     public abstract void dispose();
+
+    @Override
+    public void setErrorMessage(String errorMessage)
+    {
+        if(mTunerErrorListener != null)
+        {
+            mTunerErrorListener.setErrorMessage(errorMessage);
+        }
+    }
+
+    /**
+     * Sets the listener for tuner error messages that originate outside of the tuner.  This is normally the enclosing
+     * tuner so that it can receive error signals from the USB processor(s)..
+     */
+    public void setTunerErrorListener(ITunerErrorListener tunerErrorListener)
+    {
+        mTunerErrorListener = tunerErrorListener;
+    }
 
     /**
      * Number of samples contained in each complex buffer provided by this tuner.

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerViewPanel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerViewPanel.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -191,8 +191,15 @@ public class TunerViewPanel extends JPanel
             }
         });
 
-        TableCellRenderer renderer = new LinkCellRenderer();
-        mTunerTable.getColumnModel().getColumn(TunerModel.SPECTRAL_DISPLAY_NEW).setCellRenderer(renderer);
+        TableCellRenderer linkCellRenderer = new LinkCellRenderer();
+        mTunerTable.getColumnModel().getColumn(TunerModel.SPECTRAL_DISPLAY_NEW).setCellRenderer(linkCellRenderer);
+
+        TableCellRenderer errorCellRenderer = new ErrorCellRenderer();
+        mTunerTable.getColumnModel().getColumn(TunerModel.SAMPLE_RATE).setCellRenderer(errorCellRenderer);
+        mTunerTable.getColumnModel().getColumn(TunerModel.FREQUENCY).setCellRenderer(errorCellRenderer);
+        mTunerTable.getColumnModel().getColumn(TunerModel.CHANNEL_COUNT).setCellRenderer(errorCellRenderer);
+        mTunerTable.getColumnModel().getColumn(TunerModel.FREQUENCY_ERROR).setCellRenderer(errorCellRenderer);
+        mTunerTable.getColumnModel().getColumn(TunerModel.MEASURED_FREQUENCY_ERROR).setCellRenderer(errorCellRenderer);
 
         mColumnWidthMonitor = new JTableColumnWidthMonitor(mUserPreferences, mTunerTable, TABLE_PREFERENCE_KEY);
         JScrollPane tunerTableScroller = new JScrollPane(mTunerTable);
@@ -236,6 +243,32 @@ public class TunerViewPanel extends JPanel
         mSplitPane.add(editorScroller);
 
         add(mSplitPane);
+    }
+
+    public class ErrorCellRenderer extends DefaultTableCellRenderer
+    {
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column)
+        {
+            Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+
+            Tuner tuner = mTunerModel.getTuner(mTunerTable.convertRowIndexToModel(row));
+
+            if(isSelected)
+            {
+                component.setBackground(table.getSelectionBackground());
+            }
+            else if(tuner.hasError())
+            {
+                component.setBackground(Color.RED);
+            }
+            else
+            {
+                component.setBackground(table.getBackground());
+            }
+
+            return component;
+        }
     }
 
     public class LinkCellRenderer extends DefaultTableCellRenderer

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
@@ -1,3 +1,25 @@
+/*
+ *
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
+ *
+ *
+ */
+
 package io.github.dsheirer.source.tuner.airspy;
 
 import io.github.dsheirer.source.SourceException;
@@ -19,47 +41,6 @@ import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-
-/**
- * SDR Trunk
- * Copyright (C) 2015-2018 Dennis Sheirer
- *
- * -----------------------------------------------------------------------------
- * Ported from libairspy at:
- * https://github.com/airspy/host/tree/master/libairspy
- *
- * Copyright (c) 2013, Michael Ossmann <mike@ossmann.com>
- * Copyright (c) 2012, Jared Boone <jared@sharebrained.com>
- * Copyright (c) 2014, Youssef Touil <youssef@airspy.com>
- * Copyright (c) 2014, Benjamin Vernoux <bvernoux@airspy.com>
- * Copyright (c) 2015, Ian Gilmour <ian@sdrsharp.com>
- *
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * Neither the name of AirSpy nor the names of its contributors may be used to
- * endorse or promote products derived from this software without specific prior
- * written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- */
 
 public class AirspyTunerController extends USBTunerController
 {
@@ -184,7 +165,7 @@ public class AirspyTunerController extends USBTunerController
         String deviceName = "Airspy " + getDeviceInfo().getSerialNumber();
 
         mUSBTransferProcessor = new USBTransferProcessor(deviceName, mDeviceHandle, mSampleAdapter,
-            USB_TRANSFER_BUFFER_SIZE);
+            USB_TRANSFER_BUFFER_SIZE, this);
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/TunerChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/TunerChannelSource.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -63,6 +63,15 @@ public abstract class TunerChannelSource extends ComplexSource implements ISourc
     public long getFrequency()
     {
         return mTunerChannel.getFrequency();
+    }
+
+    /**
+     * Signals that this tuner channel source has an error state so that any channel processing can be shutdown.
+     * @param errorMessage describing the error
+     */
+    public void setError(String errorMessage)
+    {
+        broadcastConsumerSourceEvent(SourceEvent.errorState(this, errorMessage));
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
@@ -1,56 +1,24 @@
-/*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014-2017 Dennis Sheirer
+/*
  *
- *     Ported from libhackrf at:
- *     https://github.com/mossmann/hackrf/tree/master/host/libhackrf
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- *	   Copyright (c) 2012, Jared Boone <jared@sharebrained.com>
- *     Copyright (c) 2013, Benjamin Vernoux <titanmkd@gmail.com>
- *     copyright (c) 2013, Michael Ossmann <mike@ossmann.com>
  *
- *     All rights reserved.
- *
- *     Redistribution and use in source and binary forms, with or without
- *     modification, are permitted provided that the following conditions are 
- *     met:
- *
- *     Redistributions of source code must retain the above copyright notice,
- *     this list of conditions and the following disclaimer.
- *     Redistributions in binary form must reproduce the above copyright 
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *
- *     Neither the name of Great Scott Gadgets nor the names of its contributors 
- *     may be used to endorse or promote products derived from this software
- *     without specific prior written permission.
- *
- *     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- *     "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
- *     TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
- *     PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT 
- *     HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- *     SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
- *     TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
- *     PROFITS; OR BUSINESS INTERRUPTION)
- *     HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
- *     STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN 
- *     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
- *     POSSIBILITY OF SUCH DAMAGE.
- *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
- ******************************************************************************/
+ */
 package io.github.dsheirer.source.tuner.hackrf;
 
 import io.github.dsheirer.source.SourceException;
@@ -160,7 +128,8 @@ public class HackRFTunerController extends USBTunerController
             name = "HackRF - Unidentified Serial";
         }
 
-        mUSBTransferProcessor = new USBTransferProcessor(name, mDeviceHandle, mNativeBufferConverter, USB_TRANSFER_BUFFER_SIZE);
+        mUSBTransferProcessor = new USBTransferProcessor(name, mDeviceHandle, mNativeBufferConverter,
+            USB_TRANSFER_BUFFER_SIZE, this);
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
@@ -1,18 +1,24 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+/*
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ */
 package io.github.dsheirer.source.tuner.manager;
 
 import io.github.dsheirer.sample.Broadcaster;
@@ -55,6 +61,13 @@ public abstract class ChannelSourceManager implements ISourceEventProcessor
      * @return tuner channel source or null
      */
     public abstract TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification);
+
+    /**
+     * Signals that the complex buffer provider has an error and can no long provider buffers.  The subclass should
+     * implement procedures to gracefully shutdown any tuner channel sources that have been provisioned.
+     * @param errorMessage describing the error state
+     */
+    public abstract void setErrorMessage(String errorMessage);
 
     /**
      * Adds a listener to receive source events

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
@@ -1,18 +1,24 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+/*
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ */
 package io.github.dsheirer.source.tuner.manager;
 
 import io.github.dsheirer.dsp.filter.design.FilterDesignException;
@@ -101,6 +107,15 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
         }
 
         return null;
+    }
+
+    @Override
+    public void setErrorMessage(String errorMessage)
+    {
+        for(TunerChannelSource tunerChannelSource: mChannelSources)
+        {
+            tunerChannelSource.setError(errorMessage);
+        }
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
@@ -1,18 +1,24 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+/*
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ */
 package io.github.dsheirer.source.tuner.manager;
 
 import io.github.dsheirer.dsp.filter.channelizer.PolyphaseChannelManager;
@@ -258,6 +264,16 @@ public class PolyphaseChannelSourceManager extends ChannelSourceManager
 
         throw new IllegalArgumentException("Can't calculate valid center frequency for the channel set");
     }
+
+    @Override
+    public void setErrorMessage(String errorMessage)
+    {
+        if(mPolyphaseChannelManager != null)
+        {
+            mPolyphaseChannelManager.setErrorMessage(errorMessage);
+        }
+    }
+
 
     private long getChannelSetBandwidth(SortedSet<TunerChannel> channels)
     {

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -1,29 +1,30 @@
-/*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014-2018 Dennis Sheirer
+/*
  *
- *     Java version based on librtlsdr
- *     Copyright (C) 2012-2013 by Steve Markgraf <steve@steve-m.de>
- *     Copyright (C) 2012 by Dimitri Stolnikov <horiz0n@gmx.net>
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
- ******************************************************************************/
+ */
 package io.github.dsheirer.source.tuner.rtl;
 
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
 import io.github.dsheirer.source.SourceException;
+import io.github.dsheirer.source.tuner.ITunerErrorListener;
 import io.github.dsheirer.source.tuner.TunerManager;
 import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.usb.USBTransferProcessor;
@@ -160,7 +161,7 @@ public abstract class RTL2832TunerController extends USBTunerController
         String deviceName = getTunerType().getLabel() + " " + getUniqueID();
 
         mUSBTransferProcessor = new RTL2832USBTransferProcessor(deviceName, mDeviceHandle, mNativeBufferConverter,
-            USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE);
+            USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE, this);
     }
 
     @Override
@@ -1563,10 +1564,13 @@ public abstract class RTL2832TunerController extends USBTunerController
          * @param deviceHandle to the USB bulk transfer device
          * @param nativeBufferConverter specific to the tuner's byte buffer format for converting to floating point I/Q samples
          * @param bufferSize in bytes.  Should be a multiple of two: 65536, 131072 or 262144.
+         * @param tunerErrorListener to receive error state message
          */
-        public RTL2832USBTransferProcessor(String deviceName, DeviceHandle deviceHandle, NativeBufferConverter nativeBufferConverter, int bufferSize)
+        public RTL2832USBTransferProcessor(String deviceName, DeviceHandle deviceHandle,
+                                           NativeBufferConverter nativeBufferConverter, int bufferSize,
+                                           ITunerErrorListener tunerErrorListener)
         {
-            super(deviceName, deviceHandle, nativeBufferConverter, bufferSize);
+            super(deviceName, deviceHandle, nativeBufferConverter, bufferSize, tunerErrorListener);
         }
 
         @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerController.java
@@ -1,20 +1,24 @@
-/*******************************************************************************
- *     SDR Trunk 
- *     Copyright (C) 2014 Dennis Sheirer
+/*
  *
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
+ *  * ******************************************************************************
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *  * *****************************************************************************
  *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
  *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>
- ******************************************************************************/
+ */
 package io.github.dsheirer.source.tuner.rtl.e4k;
 
 import io.github.dsheirer.source.SourceException;
@@ -253,7 +257,7 @@ public class E4KTunerController extends RTL2832TunerController
         String deviceName = getTunerType().getLabel() + " " + getUniqueID();
 
         mUSBTransferProcessor = new RTL2832USBTransferProcessor(deviceName, mDeviceHandle, mNativeBufferConverter,
-            USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE);
+            USB_TRANSFER_BUFFER_SIZE_HIGH_SAMPLE_RATE, this);
     }
 
     @Override


### PR DESCRIPTION
-Separates USB timeout event processing to a dedicated thread
-Updates USB transfer buffer processor to better detect errors and auto-restart on error (max 3 times)
-Updates Tuner to add an error state and SourceManager to not select tuners with an error state
-Updates ChannelProcessingManager to auto-shutdown channels sourced from tuners set with error state
-Improves logging of USB related errors.