### PR TITLE
#651 Streaming Audio - Potential Memory Leak

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/AudioBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/AudioBroadcaster.java
@@ -1,7 +1,7 @@
 /*
  *
  *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
+ *  * Copyright (C) 2014-2020 Dennis Sheirer
  *  *
  *  * This program is free software: you can redistribute it and/or modify
  *  * it under the terms of the GNU General Public License as published by
@@ -203,6 +203,10 @@ public abstract class AudioBroadcaster implements Listener<AudioRecording>
         {
             mAudioRecordingQueue.offer(recording);
             broadcast(new BroadcastEvent(this, BroadcastEvent.Event.BROADCASTER_QUEUE_CHANGE));
+        }
+        else
+        {
+            recording.removePendingReplay();
         }
     }
 


### PR DESCRIPTION
#651 Updates audio broadcaster to decrement pending replay count so that pending recordings don't cause a memory leak when the streaming server is not available.

Closes #651