### PR TITLE
#680 Audio Playback - Do Not Monitor Not Working

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/AudioSegment.java
+++ b/src/main/java/io/github/dsheirer/audio/AudioSegment.java
@@ -161,7 +161,7 @@ public class AudioSegment implements Listener<IdentifierUpdateNotification>
      */
     public boolean isDoNotMonitor()
     {
-        return mMonitorPriority.get() == Priority.DO_NOT_MONITOR;
+        return mMonitorPriority.get() <= Priority.DO_NOT_MONITOR;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
@@ -422,7 +422,6 @@ public class ChannelProcessingManager implements Listener<ChannelEvent>
 
         for(Channel channel : channelsToStop)
         {
-            mLog.info("Stopping channel: " + channel.toString());
             stopProcessing(channel, true);
         }
     }

--- a/src/main/java/io/github/dsheirer/gui/preference/playback/PlaybackPreferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/playback/PlaybackPreferenceEditor.java
@@ -71,10 +71,14 @@ public class PlaybackPreferenceEditor extends HBox
     private Button mTestStartToneButton;
     private ToggleSwitch mUseAudioSegmentPreemptToneSwitch;
     private Button mTestPreemptToneButton;
+    private ToggleSwitch mUseAudioSegmentDropToneSwitch;
+    private Button mTestDropToneButton;
     private ComboBox<ToneFrequency> mStartToneFrequencyComboBox;
     private ComboBox<ToneVolume> mStartToneVolumeComboBox;
     private ComboBox<ToneFrequency> mPreemptToneFrequencyComboBox;
     private ComboBox<ToneVolume> mPreemptToneVolumeComboBox;
+    private ComboBox<ToneFrequency> mDropToneFrequencyComboBox;
+    private ComboBox<ToneVolume> mDropToneVolumeComboBox;
 
     public PlaybackPreferenceEditor(UserPreferences userPreferences)
     {
@@ -100,6 +104,7 @@ public class PlaybackPreferenceEditor extends HBox
             mEditorPane.add(getMixerTestButton(), 5, row);
             mEditorPane.add(new Separator(Orientation.HORIZONTAL), 0, ++row, 6, 1);
             mEditorPane.add(new Label("Audio Playback Insert Tones"), 0, ++row, 2, 1);
+
             mEditorPane.add(getUseAudioSegmentStartToneSwitch(), 0, ++row);
             mEditorPane.add(new Label("Start Tone"), 1, row, 3, 1);
             Label startFrequencyLabel = new Label("Frequency:");
@@ -111,6 +116,7 @@ public class PlaybackPreferenceEditor extends HBox
             mEditorPane.add(startVolumeLabel, 3, row);
             mEditorPane.add(getStartToneVolumeComboBox(), 4, row);
             mEditorPane.add(getTestStartToneButton(), 5, row);
+
             mEditorPane.add(getUseAudioSegmentPreemptToneSwitch(), 0, ++row);
             mEditorPane.add(new Label("Priority Preempt Tone"), 1, row, 3, 1);
             Label preemptFrequencyLabel = new Label("Frequency:");
@@ -122,6 +128,18 @@ public class PlaybackPreferenceEditor extends HBox
             mEditorPane.add(preemptVolumeLabel, 3, row);
             mEditorPane.add(getPreemptToneVolumeComboBox(), 4, row);
             mEditorPane.add(getTestPreemptToneButton(), 5, row);
+
+            mEditorPane.add(getUseAudioSegmentDropToneSwitch(), 0, ++row);
+            mEditorPane.add(new Label("Drop Tone - Do Not Monitor"), 1, row, 3, 1);
+            Label dropFrequencyLabel = new Label("Frequency:");
+            GridPane.setHalignment(dropFrequencyLabel, HPos.RIGHT);
+            mEditorPane.add(dropFrequencyLabel, 1, ++row);
+            mEditorPane.add(getDropToneFrequencyComboBox(), 2, row);
+            Label dropVolumeLabel = new Label("Volume:");
+            GridPane.setHalignment(dropVolumeLabel, HPos.RIGHT);
+            mEditorPane.add(dropVolumeLabel, 3, row);
+            mEditorPane.add(getDropToneVolumeComboBox(), 4, row);
+            mEditorPane.add(getTestDropToneButton(), 5, row);
         }
 
         return mEditorPane;
@@ -194,6 +212,25 @@ public class PlaybackPreferenceEditor extends HBox
         return mUseAudioSegmentPreemptToneSwitch;
     }
 
+    private ToggleSwitch getUseAudioSegmentDropToneSwitch()
+    {
+        if(mUseAudioSegmentDropToneSwitch == null)
+        {
+            mUseAudioSegmentDropToneSwitch = new ToggleSwitch();
+            mUseAudioSegmentDropToneSwitch.setSelected(mPlaybackPreference.getUseAudioSegmentDropTone());
+            mUseAudioSegmentDropToneSwitch.selectedProperty().addListener(new ChangeListener<Boolean>()
+            {
+                @Override
+                public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue)
+                {
+                    mPlaybackPreference.setUseAudioSegmentDropTone(newValue);
+                }
+            });
+        }
+
+        return mUseAudioSegmentDropToneSwitch;
+    }
+
     public Button getTestStartToneButton()
     {
         if(mTestStartToneButton == null)
@@ -238,6 +275,59 @@ public class PlaybackPreferenceEditor extends HBox
         }
 
         return mTestPreemptToneButton;
+    }
+
+    public Button getTestDropToneButton()
+    {
+        if(mTestDropToneButton == null)
+        {
+            mTestDropToneButton = new Button("Test");
+            IconNode iconNode = new IconNode(FontAwesome.PLAY);
+            iconNode.setFill(Color.CORNFLOWERBLUE);
+            mTestDropToneButton.setGraphic(iconNode);
+            mTestDropToneButton.setOnAction(new EventHandler<ActionEvent>()
+            {
+                @Override
+                public void handle(ActionEvent event)
+                {
+                    play(mPlaybackPreference.getDropTone());
+                }
+            });
+
+            mTestDropToneButton.disableProperty().bind(getUseAudioSegmentDropToneSwitch().selectedProperty().not());
+        }
+
+        return mTestDropToneButton;
+    }
+
+    public ComboBox<ToneFrequency> getDropToneFrequencyComboBox()
+    {
+        if(mDropToneFrequencyComboBox == null)
+        {
+            mDropToneFrequencyComboBox = new ComboBox<>();
+            mDropToneFrequencyComboBox.getItems().addAll(ToneFrequency.values());
+            mDropToneFrequencyComboBox.getSelectionModel().select(mPlaybackPreference.getDropToneFrequency());
+            mDropToneFrequencyComboBox.getSelectionModel().selectedItemProperty()
+                .addListener((observable, oldValue, newValue) -> mPlaybackPreference.setDropToneFrequency(newValue));
+            mDropToneFrequencyComboBox.disableProperty().bind(getUseAudioSegmentDropToneSwitch().selectedProperty().not());
+        }
+
+        return mDropToneFrequencyComboBox;
+    }
+
+    public ComboBox<ToneVolume> getDropToneVolumeComboBox()
+    {
+        if(mDropToneVolumeComboBox == null)
+        {
+            mDropToneVolumeComboBox = new ComboBox<>();
+            mDropToneVolumeComboBox.getItems().addAll(ToneVolume.values());
+            mDropToneVolumeComboBox.getSelectionModel().select(mPlaybackPreference.getDropToneVolume());
+            mDropToneVolumeComboBox.getSelectionModel().selectedItemProperty()
+                .addListener((observable, oldValue, newValue) -> mPlaybackPreference.setDropToneVolume(newValue));
+            mDropToneVolumeComboBox.disableProperty().bind(getUseAudioSegmentDropToneSwitch().selectedProperty().not());
+        }
+
+        return mDropToneVolumeComboBox;
     }
 
     public ComboBox<ToneFrequency> getStartToneFrequencyComboBox()

--- a/src/main/java/io/github/dsheirer/preference/playback/PlaybackPreference.java
+++ b/src/main/java/io/github/dsheirer/preference/playback/PlaybackPreference.java
@@ -38,12 +38,18 @@ import java.util.prefs.Preferences;
  */
 public class PlaybackPreference extends Preference
 {
+    private static final String PREFERENCE_KEY_USE_AUDIO_SEGMENT_DROP_TONE = "audio.playback.segment.drop.tone";
+    private static final String PREFERENCE_KEY_DROP_TONE_FREQUENCY = "audio.playback.segment.drop.frequency";
+    private static final String PREFERENCE_KEY_DROP_TONE_VOLUME = "audio.playback.segment.drop.volume";
+
     private static final String PREFERENCE_KEY_USE_AUDIO_SEGMENT_PREEMPT_TONE = "audio.playback.segment.preempt.tone";
+    private static final String PREFERENCE_KEY_PREEMPT_TONE_FREQUENCY = "audio.playback.segment.preempt.frequency";
+    private static final String PREFERENCE_KEY_PREEMPT_TONE_VOLUME = "audio.playback.segment.preempt.volume";
+
     private static final String PREFERENCE_KEY_USE_AUDIO_SEGMENT_START_TONE = "audio.playback.segment.start.tone";
     private static final String PREFERENCE_KEY_START_TONE_FREQUENCY = "audio.playback.segment.start.frequency";
     private static final String PREFERENCE_KEY_START_TONE_VOLUME = "audio.playback.segment.start.volume";
-    private static final String PREFERENCE_KEY_PREEMPT_TONE_FREQUENCY = "audio.playback.segment.preempt.frequency";
-    private static final String PREFERENCE_KEY_PREEMPT_TONE_VOLUME = "audio.playback.segment.preempt.volume";
+
     private static final String PREFERENCE_KEY_MIXER_CHANNEL_CONFIG = "audio.playback.mixer.channel.configuration";
     private static final int TONE_LENGTH_SAMPLES = 180;
 
@@ -51,10 +57,13 @@ public class PlaybackPreference extends Preference
     private Preferences mPreferences = Preferences.userNodeForPackage(PlaybackPreference.class);
     private Boolean mUseAudioSegmentStartTone;
     private Boolean mUseAudioSegmentPreemptTone;
+    private Boolean mUseAudioSegmentDropTone;
     private ToneFrequency mStartToneFrequency;
     private ToneVolume mStartToneVolume;
     private ToneFrequency mPreemptToneFrequency;
     private ToneVolume mPreemptToneVolume;
+    private ToneFrequency mDropToneFrequency;
+    private ToneVolume mDropToneVolume;
     private MixerChannelConfiguration mMixerChannelConfiguration;
 
     /**
@@ -70,6 +79,29 @@ public class PlaybackPreference extends Preference
     public PreferenceType getPreferenceType()
     {
         return PreferenceType.PLAYBACK;
+    }
+
+    /**
+     * Indicates if an audio segment drop tone should be used.
+     */
+    public boolean getUseAudioSegmentDropTone()
+    {
+        if(mUseAudioSegmentDropTone == null)
+        {
+            mUseAudioSegmentDropTone = mPreferences.getBoolean(PREFERENCE_KEY_USE_AUDIO_SEGMENT_DROP_TONE, true);
+        }
+
+        return mUseAudioSegmentDropTone;
+    }
+
+    /**
+     * Sets the preference for using an audio segment drop tone
+     */
+    public void setUseAudioSegmentDropTone(boolean use)
+    {
+        mUseAudioSegmentDropTone = use;
+        mPreferences.putBoolean(PREFERENCE_KEY_USE_AUDIO_SEGMENT_DROP_TONE, use);
+        notifyPreferenceUpdated();
     }
 
     /**
@@ -119,6 +151,30 @@ public class PlaybackPreference extends Preference
     }
 
     /**
+     * Frequency for the drop tone
+     */
+    public ToneFrequency getDropToneFrequency()
+    {
+        if(mDropToneFrequency == null)
+        {
+            int frequency = mPreferences.getInt(PREFERENCE_KEY_DROP_TONE_FREQUENCY, ToneFrequency.F500.getValue());
+            mDropToneFrequency = ToneFrequency.fromValue(frequency);
+        }
+
+        return mDropToneFrequency;
+    }
+
+    /**
+     * Sets the frequency for the drop tone
+     */
+    public void setDropToneFrequency(ToneFrequency toneFrequency)
+    {
+        mDropToneFrequency = toneFrequency;
+        mPreferences.putInt(PREFERENCE_KEY_DROP_TONE_FREQUENCY, toneFrequency.getValue());
+        notifyPreferenceUpdated();
+    }
+
+    /**
      * Frequency for the start tone
      */
     public ToneFrequency getStartToneFrequency()
@@ -163,6 +219,30 @@ public class PlaybackPreference extends Preference
     {
         mPreemptToneFrequency = toneFrequency;
         mPreferences.putInt(PREFERENCE_KEY_PREEMPT_TONE_FREQUENCY, toneFrequency.getValue());
+        notifyPreferenceUpdated();
+    }
+
+    /**
+     * Drop tone volume
+     */
+    public ToneVolume getDropToneVolume()
+    {
+        if(mDropToneVolume == null)
+        {
+            int volume = mPreferences.getInt(PREFERENCE_KEY_DROP_TONE_VOLUME, ToneVolume.V3.getValue());
+            mDropToneVolume = ToneVolume.fromValue(volume);
+        }
+
+        return mDropToneVolume;
+    }
+
+    /**
+     * Sets the drop tone volume
+     */
+    public void setDropToneVolume(ToneVolume toneVolume)
+    {
+        mDropToneVolume = toneVolume;
+        mPreferences.putInt(PREFERENCE_KEY_DROP_TONE_VOLUME, toneVolume.getValue());
         notifyPreferenceUpdated();
     }
 
@@ -235,6 +315,19 @@ public class PlaybackPreference extends Preference
         if(getUseAudioSegmentPreemptTone())
         {
             return ToneUtil.getTone(getPreemptToneFrequency(), getPreemptToneVolume(), TONE_LENGTH_SAMPLES);
+        }
+
+        return null;
+    }
+
+    /**
+     * Buffer with samples for the audio segment drop tone
+     */
+    public float[] getDropTone()
+    {
+        if(getUseAudioSegmentDropTone())
+        {
+            return ToneUtil.getTone(getDropToneFrequency(), getDropToneVolume(), TONE_LENGTH_SAMPLES);
         }
 
         return null;


### PR DESCRIPTION
Resolves #680 Audio Do Not Monitor is not working.  

- Adds audio segment drop tone to indicate that an audio playback is dropped because the do not monitor setting was applied after the audio segment started.
- Resolves issue with audio playback panel gui occasionally showing stale talkgroup information