### PR TITLE
Hackrf Changes

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerConfiguration.java
@@ -27,10 +27,10 @@ import io.github.dsheirer.source.tuner.hackrf.HackRFTunerController.HackRFVGAGai
 
 public class HackRFTunerConfiguration extends TunerConfiguration
 {
-    private HackRFSampleRate mSampleRate = HackRFSampleRate.RATE2_016MHZ;
-    private HackRFLNAGain mLNAGain = HackRFLNAGain.GAIN_16;
-    private HackRFVGAGain mVGAGain = HackRFVGAGain.GAIN_10;
-    private boolean mAmplifierEnabled = true;
+    private HackRFSampleRate mSampleRate = HackRFSampleRate.RATE_5_0;
+    private HackRFLNAGain mLNAGain = HackRFLNAGain.GAIN_16;  // We can see some signal at this gain
+    private HackRFVGAGain mVGAGain = HackRFVGAGain.GAIN_16;  // We can see some signal at this gain
+    private boolean mAmplifierEnabled = false;  //Probably should start off disabled
     private double mFrequencyCorrection = 0.0d;
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
@@ -57,13 +57,13 @@ public class HackRFTunerController extends USBTunerController
     public static final long MIN_FREQUENCY = 10000000l;
     public static final long MAX_FREQUENCY = 6000000000l;
     public static final long DEFAULT_FREQUENCY = 101100000;
-    public static final double USABLE_BANDWIDTH_PERCENT = 0.75;
+    public static final double USABLE_BANDWIDTH_PERCENT = 0.90;
     public static final int DC_SPIKE_AVOID_BUFFER = 5000;
 
     private NativeBufferConverter mNativeBufferConverter = new SignedByteSampleConverter();
     private USBTransferProcessor mUSBTransferProcessor;
 
-    private HackRFSampleRate mSampleRate = HackRFSampleRate.RATE2_016MHZ;
+    private HackRFSampleRate mSampleRate = HackRFSampleRate.RATE_5_0;
     private boolean mAmplifierEnabled = false;
 
     private Device mDevice;
@@ -344,7 +344,7 @@ public class HackRFTunerController extends USBTunerController
             if(!hackRFConfig.getSampleRate().isValidSampleRate())
             {
                 mLog.warn("Changing legacy HackRF Sample Rates Setting [" + hackRFConfig.getSampleRate().name() + "] to current valid setting");
-                hackRFConfig.setSampleRate(HackRFSampleRate.RATE_2_3);
+                hackRFConfig.setSampleRate(HackRFSampleRate.RATE_5_0);
             }
 
             try
@@ -508,7 +508,7 @@ public class HackRFTunerController extends USBTunerController
     {
         if(!rate.isValidSampleRate())
         {
-            rate = HackRFSampleRate.RATE_2_3;
+            rate = HackRFSampleRate.RATE_5_0;
         }
 
         setSampleRateManual(rate.getRate(), 1);
@@ -578,19 +578,22 @@ public class HackRFTunerController extends USBTunerController
 
     public enum HackRFSampleRate
     {
-        RATE_2_3(2300000, "2.300 MHz", BasebandFilter.F1_75),
-        RATE_3_3(3300000, "3.300 MHz", BasebandFilter.F2_50),
-        RATE_4_6(4600000, "4.600 MHz", BasebandFilter.F3_50),
-        RATE_6_6(6600000, "6.600 MHz", BasebandFilter.F5_00),
-        RATE_7_3(7300000, "7.300 MHz", BasebandFilter.F5_50),
-        RATE_8_0(8000000, "8.000 MHz", BasebandFilter.F6_00),
-        RATE_9_3(9300000, "9.300 MHz", BasebandFilter.F7_00),
-        RATE_10_6(10600000, "10.600 MHz", BasebandFilter.F8_00),
-        RATE_12_0(12000000, "12.000 MHz", BasebandFilter.F9_00),
-        RATE_13_3(13300000, "13.300 MHz", BasebandFilter.F10_00),
-        RATE_16_0(16000000, "16.000 MHz", BasebandFilter.F12_00),
-        RATE_18_6(18600000, "18.600 MHz", BasebandFilter.F14_00),
-        RATE_20_0(20000000, "20.000 MHz", BasebandFilter.F15_00),
+		//Changes to enumerate correct rates
+        RATE_1_75(1750000, "1.750 MHz", BasebandFilter.F1_75),
+        RATE_2_5(2500000, "2.500 MHz", BasebandFilter.F2_50),
+        RATE_3_5(3500000, "3.500 MHz", BasebandFilter.F3_50),
+		 RATE_5_0(5000000, "5.000 MHz", BasebandFilter.F5_00),
+		 RATE_5_5(5500000, "5.500 MHz", BasebandFilter.F5_50),
+        RATE_6_0(6000000, "6.000 MHz", BasebandFilter.F6_00),
+        RATE_7_0(7000000, "7.000 MHz", BasebandFilter.F7_00),
+        RATE_8_0(8000000, "8.000 MHz", BasebandFilter.F8_00),
+        RATE_9_0(9000000, "9.000 MHz", BasebandFilter.F9_00),
+        RATE_10_0(10000000, "10.000 MHz", BasebandFilter.F10_00),
+        RATE_12_0(12000000, "12.000 MHz", BasebandFilter.F12_00),
+        RATE_14_0(14000000, "14.000 MHz", BasebandFilter.F14_00),
+        RATE_15_0(15000000, "15.000 MHz", BasebandFilter.F15_00),
+        RATE_20_0(20000000, "20.000 MHz", BasebandFilter.F20_00),
+        RATE_24_0(24000000, "24.000 MHz", BasebandFilter.F24_00),
 
         //These sample rates are deprecated.  They're maintained here for backward compatibility with user settings
         RATE2_016MHZ(2016000, "*2.016 MHz", BasebandFilter.F3_50),
@@ -615,7 +618,7 @@ public class HackRFTunerController extends USBTunerController
             mFilter = filter;
         }
 
-        public static EnumSet<HackRFSampleRate> VALID_SAMPLE_RATES = EnumSet.range(RATE_2_3, RATE_20_0);
+        public static EnumSet<HackRFSampleRate> VALID_SAMPLE_RATES = EnumSet.range(RATE_1_75, RATE_24_0);
 
         public int getRate()
         {

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
@@ -236,7 +236,7 @@ public class HackRFTunerEditor extends TunerConfigurationEditor
 
                     if(lnaGain == null)
                     {
-                        lnaGain = HackRFLNAGain.GAIN_0;
+                        lnaGain = HackRFLNAGain.GAIN_16;
                     }
 
                     mController.setLNAGain(lnaGain);
@@ -267,7 +267,7 @@ public class HackRFTunerEditor extends TunerConfigurationEditor
 
                     if(vgaGain == null)
                     {
-                        vgaGain = HackRFVGAGain.GAIN_4;
+                        vgaGain = HackRFVGAGain.GAIN_16;
                     }
 
                     mController.setVGAGain(vgaGain);


### PR DESCRIPTION
These fix the hackrf bandwidth/sample rate selection in sdrt. many might not know if they don't have the portapak installed. it shows the selected bandwidth onscreen. Most of the settings were rounding down to the next lower setting. I notices they were mapped (don't know official term yet) to the BasebandFilter table below.

I tested all the modes and they worked fine except 24 MHz (looks pretty tho) i couldn't find what i missed. It displays properly but isn't getting initialized and decoding. I didn't add the 28 MHz since it probably wont work reliably. seems to be too much data to look at. sdrtrunk crashes in just a few seconds randomly using it. 

I tested the bandwidth at 90% and cant see any problems but if you let me know why it was set down to 75% i probably can understand.

let me know if you have an hackrf if not just let me know what and how to test anything you want. after i learn a lot more i want to try and help with the project or add features. that's a long ways off.

let me know if these help or create any problems. I'm learning slowly with a lot of free time but java seems slow to learn for me. Jumping into a big project isn't best way to learn i know. i can handle constructive criticism fine.