### PR TITLE
#751 Audio Recording - TRACK Metadata

### DIFF
--- a/src/main/java/io/github/dsheirer/record/wave/AudioMetadataUtils.java
+++ b/src/main/java/io/github/dsheirer/record/wave/AudioMetadataUtils.java
@@ -20,6 +20,7 @@
 
 package io.github.dsheirer.record.wave;
 
+import com.google.common.base.Joiner;
 import com.mpatric.mp3agic.ID3v24Tag;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasList;
@@ -96,9 +97,9 @@ public class AudioMetadataUtils
 
                 List<Alias> aliases = aliasList.getAliases(to);
 
-                for(Alias alias: aliases)
+                if(!aliases.isEmpty())
                 {
-                    sb.append(" ").append(alias.toString());
+                    sb.append("\"").append(Joiner.on("\",\"").join(aliases)).append("\"");
                 }
 
                 audioMetadata.put(AudioMetadata.TRACK_TITLE, sb.toString());


### PR DESCRIPTION
Resolves #751

Adds quoted, comma-separated aliases to TRACK_TITLE metadata tag.
