### PR TITLE
MPT1327: Fix decoding of calls to past talkgroups

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/mpt1327/MPT1327TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/mpt1327/MPT1327TrafficChannelManager.java
@@ -332,13 +332,14 @@ public class MPT1327TrafficChannelManager extends Module implements IDecodeEvent
                             if(entry.getValue() == channel)
                             {
                                 toRemove = entry.getKey();
-                                continue;
+                                break;
                             }
                         }
 
                         if(toRemove != null)
                         {
                             mAllocatedTrafficChannelMap.remove(toRemove);
+                            mChannelGrantEventMap.remove(toRemove);
                             mAvailableTrafficChannelQueue.add(channel);
 
                             MPT1327ChannelGrantEvent event = mChannelGrantEventMap.get(toRemove);
@@ -358,13 +359,14 @@ public class MPT1327TrafficChannelManager extends Module implements IDecodeEvent
                             if(entry.getValue() == channel)
                             {
                                 rejected = entry.getKey();
-                                continue;
+                                break;
                             }
                         }
 
                         if(rejected != null)
                         {
                             mAllocatedTrafficChannelMap.remove(rejected);
+                            mChannelGrantEventMap.remove(rejected);
                             mAvailableTrafficChannelQueue.add(channel);
 
                             MPT1327ChannelGrantEvent event = mChannelGrantEventMap.get(rejected);

--- a/src/main/java/io/github/dsheirer/module/decode/mpt1327/MPT1327TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/mpt1327/MPT1327TrafficChannelManager.java
@@ -325,24 +325,14 @@ public class MPT1327TrafficChannelManager extends Module implements IDecodeEvent
                 switch(channelEvent.getEvent())
                 {
                     case NOTIFICATION_PROCESSING_STOP:
-                        MPT1327Channel toRemove = null;
-
-                        for(Map.Entry<MPT1327Channel,Channel> entry : mAllocatedTrafficChannelMap.entrySet())
-                        {
-                            if(entry.getValue() == channel)
-                            {
-                                toRemove = entry.getKey();
-                                break;
-                            }
-                        }
+                        final var toRemove = mptChannelForChannel(channel);
 
                         if(toRemove != null)
                         {
                             mAllocatedTrafficChannelMap.remove(toRemove);
-                            mChannelGrantEventMap.remove(toRemove);
                             mAvailableTrafficChannelQueue.add(channel);
 
-                            MPT1327ChannelGrantEvent event = mChannelGrantEventMap.get(toRemove);
+                            final var event = mChannelGrantEventMap.remove(toRemove);
 
                             if(event != null)
                             {
@@ -352,24 +342,14 @@ public class MPT1327TrafficChannelManager extends Module implements IDecodeEvent
                         }
                         break;
                     case NOTIFICATION_PROCESSING_START_REJECTED:
-                        MPT1327Channel rejected = null;
-
-                        for(Map.Entry<MPT1327Channel,Channel> entry : mAllocatedTrafficChannelMap.entrySet())
-                        {
-                            if(entry.getValue() == channel)
-                            {
-                                rejected = entry.getKey();
-                                break;
-                            }
-                        }
+                        final var rejected = mptChannelForChannel(channel);
 
                         if(rejected != null)
                         {
                             mAllocatedTrafficChannelMap.remove(rejected);
-                            mChannelGrantEventMap.remove(rejected);
                             mAvailableTrafficChannelQueue.add(channel);
 
-                            MPT1327ChannelGrantEvent event = mChannelGrantEventMap.get(rejected);
+                            final var event = mChannelGrantEventMap.remove(rejected);
 
                             if(event != null)
                             {
@@ -387,6 +367,18 @@ public class MPT1327TrafficChannelManager extends Module implements IDecodeEvent
                         break;
                 }
             }
+        }
+
+        private MPT1327Channel mptChannelForChannel(final Channel channel)
+        {
+            for (final var entry : mAllocatedTrafficChannelMap.entrySet())
+            {
+                if (entry.getValue() == channel)
+                {
+                    return entry.getKey();
+                }
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
This PR tries to fix something that I have observed for MPT1327 which seems like a bug to me.

Specifically, all calls after the first one to the same talkgroup on the same traffic channel are not decoded - the decoder for the traffic channel is not created nor initialized. Instead, the _past event for the channel_ is updated with new "end" timestamps from subsequent MPT messages. This can be seen here:

![mpt1327-before-past-talkgroups-fix](https://user-images.githubusercontent.com/41550889/82468335-fbf9b380-9ac2-11ea-8ef3-ac9f8c8734b1.jpg)

I've marked weird call durations which are a consequence of the "end" timestamp being updated for past events.

After short debugging it seems that this is the offending line:

https://github.com/DSheirer/sdrtrunk/blob/8167e9e9f2c07480a45fd417653e419b4ae016a0/src/main/java/io/github/dsheirer/module/decode/mpt1327/MPT1327TrafficChannelManager.java#L100

in case a go-to-channel event is already associated with a channel in question we just update it's "end" timestamp. This is fine. The problem is that we never remove those associated go-to-channel events - even when decoding of the traffic channel stops.

This fix is just removing memorized go-to-channel events whenever associated channel (managed by us) is stopped/start-rejected. This is done in `TrafficChannelTeardownMonitor`.

After the fix sample event log for the same system looks like this:

![mpt1327-after-past-talkgroups-fix](https://user-images.githubusercontent.com/41550889/82469484-60694280-9ac4-11ea-8bf0-8859e94cb03b.jpg)

As a result subsequent go-to-channel messages targeting the same talkgroup and referencing the same channel are correctly handled and decoded. Instead of updating old "channel grant" events they get their own, freshly created "channel grant" events.