### PR TITLE
#724 USB Transfer Processor Potential Memory Leaks

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/usb/USBTransferProcessor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/usb/USBTransferProcessor.java
@@ -162,7 +162,7 @@ public class USBTransferProcessor implements TransferCallback
         {
             if(mBufferDispatcherFuture != null)
             {
-                mBufferDispatcherFuture.cancel(true);
+                mBufferDispatcherFuture.cancel(false);
                 mBufferDispatcherFuture = null;
             }
 
@@ -174,7 +174,7 @@ public class USBTransferProcessor implements TransferCallback
 
             //Await completion of all in-progress transfers
             int waitCycleCount = 0;
-            while(!mInProgressTransfers.isEmpty() && waitCycleCount < 10)
+            while(!mInProgressTransfers.isEmpty() && waitCycleCount < 30)
             {
                 waitCycleCount++;
 


### PR DESCRIPTION
Resolves #724 issue with usb transfer buffer(s) memory leak.  Changes shutdown process to allow the completed buffer processor thread to finish, avoiding possible orphaned transfer(s).  Extends the shutdown wait cycle to allow libusb event processor more time to fully cancel transfers.
