### PR TITLE
#837 Sorted list ArrayIndexOutOfBoundsException during alias save.

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
@@ -330,11 +330,8 @@ public class AliasItemEditor extends Editor<Alias>
 
             if(alias != null)
             {
-                alias.setName(getNameField().getText());
-                alias.setGroup(getGroupField().getText());
                 alias.setRecordable(getRecordAudioToggleSwitch().isSelected());
                 alias.setColor(ColorUtil.toInteger(getColorPicker().getValue()));
-
 
                 Icon icon = getIconNodeComboBox().getSelectionModel().getSelectedItem();
                 alias.setIconName(icon != null ? icon.getName() : null);
@@ -376,6 +373,27 @@ public class AliasItemEditor extends Editor<Alias>
                 for(AliasAction aliasAction: getActionsList().getItems())
                 {
                     alias.addAliasAction(aliasAction);
+                }
+
+                //Hack: because we're using a sorted list for the alias editor, sometimes setting
+                //name and or group can cause list errors.  So, we wrap each of these in a try/catch
+                //block to mitigate the error and effect the changes.
+                try
+                {
+                    alias.setName(getNameField().getText());
+                }
+                catch(Exception e)
+                {
+                    mLog.error("Error while updating alias name.", e);
+                }
+
+                try
+                {
+                    alias.setGroup(getGroupField().getText());
+                }
+                catch(Exception e)
+                {
+                    mLog.error("Error while updating alias group value", e);
                 }
             }
 


### PR DESCRIPTION
Resolves #837 

There's an ArrayIndexOutOfBoundsException rarely being thrown from within the JavaFX SortedLIst code whenever saving an alias and updating the alias name or alias group values.  

I don't see where the code is doing anything incorrectly.  I updated the save operation to wrap each of the calls to update the alias name and group in try/catch blocks to ensure the save operation completes for all alias attributes.