### PR TITLE
#864 Radio Reference System Bandplan Error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation 'com.miglayout:miglayout-swing:5.2'
     implementation 'com.mpatric:mp3agic:0.9.1'
     implementation 'eu.hansolo:charts:1.0.5'
-    implementation 'io.github.dsheirer:radio-reference-api:15.1.4'
+    implementation 'io.github.dsheirer:radio-reference-api:15.1.6'
     implementation 'javax.usb:usb-api:1.0.2'
     implementation 'net.coderazzi:tablefilter-swing:5.4.0'
     implementation 'org.apache.commons:commons-compress:1.20'

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/EnrichedSite.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/EnrichedSite.java
@@ -1,0 +1,131 @@
+/*
+ * *****************************************************************************
+ *  Copyright (C) 2014-2020 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.playlist.radioreference;
+
+import io.github.dsheirer.rrapi.type.CountyInfo;
+import io.github.dsheirer.rrapi.type.Site;
+
+/**
+ * Wrapper class to join a Site and a corresponding County Info
+ */
+public class EnrichedSite
+{
+    private Site mSite;
+    private CountyInfo mCountyInfo;
+
+    /**
+     * Constructs an instance
+     * @param site object
+     * @param countyInfo optional
+     */
+    public EnrichedSite(Site site, CountyInfo countyInfo)
+    {
+        mSite = site;
+        mCountyInfo = countyInfo;
+    }
+
+    /**
+     * Site instance
+     * @return site or null
+     */
+    public Site getSite()
+    {
+        return mSite;
+    }
+
+    /**
+     * Sets the site instance
+     * @param site or null
+     */
+    public void setSite(Site site)
+    {
+        mSite = site;
+    }
+
+    /**
+     * County information
+     * @return county info or null
+     */
+    public CountyInfo getCountyInfo()
+    {
+        return mCountyInfo;
+    }
+
+    /**
+     * Sets the county info
+     * @param countyInfo or null
+     */
+    public void setCountyInfo(CountyInfo countyInfo)
+    {
+        mCountyInfo = countyInfo;
+    }
+
+    /**
+     * Optional site number
+     */
+    public Integer getSiteNumber()
+    {
+        if(mSite != null)
+        {
+            return mSite.getSiteNumber();
+        }
+
+        return null;
+    }
+
+    /**
+     * Optional site RFSS value
+     */
+    public Integer getRfss()
+    {
+        if(mSite != null)
+        {
+            return mSite.getRfss();
+        }
+
+        return null;
+    }
+
+    /**
+     * Optional county name
+     */
+    public String getCountyName()
+    {
+        if(mCountyInfo != null)
+        {
+            return mCountyInfo.getName();
+        }
+
+        return null;
+    }
+
+    /**
+     * Optional description of the site
+     */
+    public String getDescription()
+    {
+        if(mSite != null)
+        {
+            return mSite.getDescription();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceDecoder.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceDecoder.java
@@ -204,7 +204,7 @@ public class RadioReferenceDecoder
     {
         List<Tag> tags = new ArrayList<>();
 
-        if(talkgroup.getTags() != null)
+        if(talkgroup != null && talkgroup.getTags() != null)
         {
             for(Tag tag: talkgroup.getTags())
             {
@@ -220,7 +220,12 @@ public class RadioReferenceDecoder
      */
     public Type getType(System system)
     {
-        return mTypeMap.get(system.getTypeId());
+        if(system != null)
+        {
+            return mTypeMap.get(system.getTypeId());
+        }
+
+        return null;
     }
 
     /**
@@ -228,7 +233,12 @@ public class RadioReferenceDecoder
      */
     public Flavor getFlavor(System system)
     {
-        return mFlavorMap.get(system.getFlavorId());
+        if(system != null)
+        {
+            return mFlavorMap.get(system.getFlavorId());
+        }
+
+        return null;
     }
 
     /**
@@ -236,7 +246,12 @@ public class RadioReferenceDecoder
      */
     public Voice getVoice(System system)
     {
-        return mVoiceMap.get(system.getVoiceId());
+        if(system != null)
+        {
+            return mVoiceMap.get(system.getVoiceId());
+        }
+
+        return null;
     }
 
     /**
@@ -340,51 +355,54 @@ public class RadioReferenceDecoder
         Flavor flavor = getFlavor(system);
         Voice voice = getVoice(system);
 
-        switch(type.getName())
+        if(type != null && flavor != null && voice != null)
         {
-            case "LTR":
-                if(flavor.getName().contentEquals("Net"))
-                {
-                    return DecoderType.LTR_NET;
-                }
-                else if(flavor.getName().contentEquals("Passport"))
-                {
-                    return DecoderType.PASSPORT;
-                }
-                else
-                {
-                    return DecoderType.LTR;
-                }
-            case "MPT-1327":
-                return DecoderType.MPT1327;
-            case "Project 25":
-                if(flavor.getName().contentEquals("Phase II"))
-                {
-                    return DecoderType.P25_PHASE2;
-                }
-                else if(flavor.getName().contentEquals("Phase I"))
-                {
-                    return DecoderType.P25_PHASE1;
-                }
-                break;
-            case "Motorola":
-                if(voice.getName().contentEquals("Analog and APCO-25 Common Air Interface") ||
-                   voice.getName().contentEquals("APCO-25 Common Air Interface Exclusive"))
-                {
-                    return DecoderType.P25_PHASE1;
-                }
-                break;
-            case "DMR":
-            case "NXDN":
+            switch(type.getName())
+            {
+                case "LTR":
+                    if(flavor.getName().contentEquals("Net"))
+                    {
+                        return DecoderType.LTR_NET;
+                    }
+                    else if(flavor.getName().contentEquals("Passport"))
+                    {
+                        return DecoderType.PASSPORT;
+                    }
+                    else
+                    {
+                        return DecoderType.LTR;
+                    }
+                case "MPT-1327":
+                    return DecoderType.MPT1327;
+                case "Project 25":
+                    if(flavor.getName().contentEquals("Phase II"))
+                    {
+                        return DecoderType.P25_PHASE2;
+                    }
+                    else if(flavor.getName().contentEquals("Phase I"))
+                    {
+                        return DecoderType.P25_PHASE1;
+                    }
+                    break;
+                case "Motorola":
+                    if(voice.getName().contentEquals("Analog and APCO-25 Common Air Interface") ||
+                        voice.getName().contentEquals("APCO-25 Common Air Interface Exclusive"))
+                    {
+                        return DecoderType.P25_PHASE1;
+                    }
+                    break;
+                case "DMR":
+                case "NXDN":
 
-            case "EDACS":
-            case "TETRA":
-            case "Midland CMS":
-            case "OpenSky":
-            case "iDEN":
-            case "SmarTrunk":
-            case "Other":
-            default:
+                case "EDACS":
+                case "TETRA":
+                case "Midland CMS":
+                case "OpenSky":
+                case "iDEN":
+                case "SmarTrunk":
+                case "Other":
+                default:
+            }
         }
 
         return null;

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceUnavailableAlert.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceUnavailableAlert.java
@@ -30,10 +30,13 @@ public class RadioReferenceUnavailableAlert extends Alert
 {
     public RadioReferenceUnavailableAlert(Node ownerNode)
     {
-        super(AlertType.INFORMATION, "Check network connection or see details in sdrtrunk log.", ButtonType.OK);
+        super(AlertType.INFORMATION, "This may be caused by a network outage or there was an error " +
+            "accessing the service.  If this problem occurs each time you attempt to access a " +
+            "specific system or agency, please notify the developer.  Details for this issue " +
+            "are located in the sdrtrunk application log.", ButtonType.OK);
 
         setTitle("Service Unavailable");
-        setHeaderText("Radio Reference Is Currently Unavailable");
+        setHeaderText("Radio Reference Error or Service Is Currently Unavailable");
         initOwner(ownerNode.getScene().getWindow());
     }
 }

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SiteEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SiteEditor.java
@@ -108,7 +108,7 @@ public class SiteEditor extends GridPane
     private CheckBox mGoToChannelEditorCheckBox;
     private Label mProtocolNotSupportedLabel;
     private RadioReferenceDecoder mRadioReferenceDecoder;
-    private Site mCurrentSite;
+    private EnrichedSite mCurrentSite;
     private System mCurrentSystem;
     private SystemInformation mCurrentSystemInformation;
     private ComboBox mAliasListNameComboBox;
@@ -290,7 +290,7 @@ public class SiteEditor extends GridPane
         }
     }
 
-    public void setSite(Site site, System system, SystemInformation systemInformation, RadioReferenceDecoder decoder)
+    public void setSite(EnrichedSite site, System system, SystemInformation systemInformation, RadioReferenceDecoder decoder)
     {
         mCurrentSite = site;
         mCurrentSystem = system;
@@ -299,7 +299,7 @@ public class SiteEditor extends GridPane
 
         getSiteFrequencyTableView().getItems().clear();
 
-        boolean disable = site == null || site.getSiteFrequencies().isEmpty();
+        boolean disable = site == null || site.getSite().getSiteFrequencies().isEmpty();
         boolean supported = decoder.hasSupportedProtocol(system);
 
         getFrequenciesSegmentedButton().setDisable(disable || !supported);
@@ -318,7 +318,7 @@ public class SiteEditor extends GridPane
 
         if(site != null)
         {
-            List<SiteFrequency> siteFrequencies = site.getSiteFrequencies();
+            List<SiteFrequency> siteFrequencies = site.getSite().getSiteFrequencies();
             for(SiteFrequency siteFrequency: siteFrequencies)
             {
                 if(siteFrequency.getFrequency() > 0.01)
@@ -340,7 +340,7 @@ public class SiteEditor extends GridPane
                 getCreateChannelConfigurationButton().setVisible(true);
                 getGoToChannelEditorCheckBox().setVisible(true);
                 getSystemTextField().setText(system.getName());
-                getSiteTextField().setText(site.getCountyName());
+                getSiteTextField().setText(mCurrentSite.getCountyName());
                 getNameTextField().setText("Control");
 
                 if(!siteFrequencies.isEmpty())
@@ -456,7 +456,8 @@ public class SiteEditor extends GridPane
                 Channel channel = getChannelTemplate();
                 channel.setName("LCN " + siteFrequency.getLogicalChannelNumber());
                 DecoderType decoderType = mRadioReferenceDecoder.getDecoderType(mCurrentSystem);
-                channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite, mCurrentSystemInformation));
+                channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite.getSite(),
+                    mCurrentSystemInformation));
                 SourceConfigTuner sourceConfigTuner = new SourceConfigTuner();
                 sourceConfigTuner.setFrequency(getFrequency(siteFrequency));
                 channel.setSourceConfiguration(sourceConfigTuner);
@@ -511,7 +512,7 @@ public class SiteEditor extends GridPane
                 decoderType = DecoderType.P25_PHASE1;
             }
 
-            channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite, mCurrentSystemInformation));
+            channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite.getSite(), mCurrentSystemInformation));
 
             SourceConfigTuner sourceConfigTuner = new SourceConfigTuner();
             sourceConfigTuner.setFrequency((long)(control.getFrequency() * 1E6));
@@ -569,7 +570,8 @@ public class SiteEditor extends GridPane
                     decoderType = DecoderType.P25_PHASE1;
                 }
 
-                channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite, mCurrentSystemInformation));
+                channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite.getSite(),
+                    mCurrentSystemInformation));
 
                 if(siteFrequencies.size() == 1)
                 {
@@ -605,7 +607,8 @@ public class SiteEditor extends GridPane
                     Channel channel = getChannelTemplate();
                     channel.setName("LCN " + siteFrequency.getLogicalChannelNumber());
                     DecoderType decoderType = mRadioReferenceDecoder.getDecoderType(mCurrentSystem);
-                    channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite, mCurrentSystemInformation));
+                    channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite.getSite(),
+                        mCurrentSystemInformation));
                     SourceConfigTuner sourceConfigTuner = new SourceConfigTuner();
                     sourceConfigTuner.setFrequency(getFrequency(siteFrequency));
                     channel.setSourceConfiguration(sourceConfigTuner);
@@ -659,7 +662,8 @@ public class SiteEditor extends GridPane
                 Channel channel = getChannelTemplate();
 
                 DecoderType decoderType = mRadioReferenceDecoder.getDecoderType(mCurrentSystem);
-                channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite, mCurrentSystemInformation));
+                channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite.getSite(),
+                    mCurrentSystemInformation));
 
                 if(siteFrequencies.size() == 1)
                 {
@@ -695,7 +699,8 @@ public class SiteEditor extends GridPane
                     Channel channel = getChannelTemplate();
                     channel.setName("LCN " + siteFrequency.getLogicalChannelNumber());
                     DecoderType decoderType = mRadioReferenceDecoder.getDecoderType(mCurrentSystem);
-                    channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite, mCurrentSystemInformation));
+                    channel.setDecodeConfiguration(getDecodeConfiguration(decoderType, mCurrentSite.getSite(),
+                        mCurrentSystemInformation));
 
                     SourceConfigTuner sourceConfigTuner = new SourceConfigTuner();
                     sourceConfigTuner.setFrequency(getFrequency(siteFrequency));

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemEditor.java
@@ -54,6 +54,7 @@ import jiconfont.javafx.IconNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -281,13 +282,14 @@ public class SystemEditor extends VBox
                     List<Site> sites = mRadioReference.getService().getSites(system.getSystemId());
 
                     //The service api doesn't provide the county name, so we run a separate query to update each value
+                    List<EnrichedSite> enrichedSites = new ArrayList<>();
                     for(Site site: sites)
                     {
                         CountyInfo countyInfo = mRadioReference.getService().getCountyInfo(site.getCountyId());
-                        site.setCountyName(countyInfo.getName());
+                        enrichedSites.add(new EnrichedSite(site, countyInfo));
                     }
 
-                    Platform.runLater(() -> getSystemSiteSelectionEditor().setSystem(system, sites, mRadioReferenceDecoder,
+                    Platform.runLater(() -> getSystemSiteSelectionEditor().setSystem(system, enrichedSites, mRadioReferenceDecoder,
                         systemInformation));
 
                     //Query and load the talkgroup view second

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemSiteSelectionEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemSiteSelectionEditor.java
@@ -25,7 +25,6 @@ package io.github.dsheirer.gui.playlist.radioreference;
 import io.github.dsheirer.playlist.PlaylistManager;
 import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.rrapi.type.Flavor;
-import io.github.dsheirer.rrapi.type.Site;
 import io.github.dsheirer.rrapi.type.System;
 import io.github.dsheirer.rrapi.type.SystemInformation;
 import io.github.dsheirer.rrapi.type.Type;
@@ -60,7 +59,7 @@ public class SystemSiteSelectionEditor extends GridPane
     private Label mProtocolLabel;
     private Label mFlavorLabel;
     private Label mVoiceLabel;
-    private TableView<Site> mSiteTableView;
+    private TableView<EnrichedSite> mSiteTableView;
     private SiteEditor mSiteEditor;
     private RadioReferenceDecoder mRadioReferenceDecoder;
     private System mCurrentSystem;
@@ -113,7 +112,8 @@ public class SystemSiteSelectionEditor extends GridPane
      * Updates this view with the specified system
      * @param system to view
      */
-    public void setSystem(System system, List<Site> sites, RadioReferenceDecoder decoder, SystemInformation systemInformation)
+    public void setSystem(System system, List<EnrichedSite> sites, RadioReferenceDecoder decoder,
+                          SystemInformation systemInformation)
     {
         mCurrentSystem = system;
         mCurrentSystemInformation = systemInformation;
@@ -205,7 +205,7 @@ public class SystemSiteSelectionEditor extends GridPane
         return mPlaceholderLabel;
     }
 
-    private TableView<Site> getSiteTableView()
+    private TableView<EnrichedSite> getSiteTableView()
     {
         if(mSiteTableView == null)
         {
@@ -235,8 +235,11 @@ public class SystemSiteSelectionEditor extends GridPane
             mSiteTableView.getColumns().addAll(numberColumn, rfssColumn, countyColumn, descriptionColumn);
             mSiteTableView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
             mSiteTableView.getSelectionModel().selectedItemProperty()
-                .addListener((observable, oldValue, selected) -> getSiteEditor()
-                    .setSite(selected, mCurrentSystem, mCurrentSystemInformation, mRadioReferenceDecoder));
+                .addListener((observable, oldValue, selected) ->
+                {
+                    getSiteEditor().setSite(selected, mCurrentSystem, mCurrentSystemInformation,
+                        mRadioReferenceDecoder);
+                });
         }
 
         return mSiteTableView;


### PR DESCRIPTION
Resolves #864 

Updates radio reference service library to resolve issue where the library wasn't parsing the system information object correctly and was assuming a singular bandplan object versus an array of bandplans.

Updating the service library prompted some minor changes with the way that county info objects are handled for each site.