### PR TITLE
#893 Improved Cellocator Packet Detection

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/ip/PacketMessageFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/ip/PacketMessageFactory.java
@@ -84,12 +84,13 @@ public class PacketMessageFactory
     /**
      * Creates a UDP/IP packet payload parser
      *
+     * @param sourcePort for the packet (to identify the protocol/format)
      * @param destinationPort for the packet (to identify the protocol/format)
      * @param binaryMessage containing the IP/UDP payload
      * @param offset in the message to the start of the payload
      * @return constructed packet messge parser
      */
-    public static IPacket createUDPPayload(int destinationPort, BinaryMessage binaryMessage, int offset)
+    public static IPacket createUDPPayload(int sourcePort, int destinationPort, BinaryMessage binaryMessage, int offset)
     {
         switch(destinationPort)
         {
@@ -110,6 +111,23 @@ public class PacketMessageFactory
                 break;
             case 4008: //Telemetry Service
                 break;
+        }
+
+        switch(sourcePort)
+        {
+            case 231:
+                //Cellocator
+                if(MCGPHeader.isCellocatorMessage(binaryMessage, offset))
+                {
+                    return MCGPMessageFactory.create(binaryMessage, offset);
+                }
+                break;
+        }
+
+        //This is normally source or destination port 231, but can be on other ports as well.
+        if(MCGPHeader.isCellocatorMessage(binaryMessage, offset))
+        {
+            return MCGPMessageFactory.create(binaryMessage, offset);
         }
 
         return new UnknownPacket(binaryMessage, offset);

--- a/src/main/java/io/github/dsheirer/module/decode/ip/udp/UDPPacket.java
+++ b/src/main/java/io/github/dsheirer/module/decode/ip/udp/UDPPacket.java
@@ -26,6 +26,7 @@ import io.github.dsheirer.module.decode.ip.IPacket;
 import io.github.dsheirer.module.decode.ip.Packet;
 import io.github.dsheirer.module.decode.ip.PacketMessageFactory;
 import io.github.dsheirer.module.decode.ip.UnknownPacket;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -80,7 +81,8 @@ public class UDPPacket extends Packet
         {
             if(getHeader().isValid())
             {
-                mPayload = PacketMessageFactory.createUDPPayload(getHeader().getDestinationPort(), getMessage(), getOffset() + getHeader().getLength());
+                mPayload = PacketMessageFactory.createUDPPayload(getHeader().getSourcePort(),
+                    getHeader().getDestinationPort(), getMessage(), getOffset() + getHeader().getLength());
             }
             else
             {

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -962,7 +962,7 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
 
                         DecodeEvent cellocatorEvent = P25DecodeEvent.builder(message.getTimestamp())
                                 .channel(getCurrentChannel())
-                                .eventDescription("CELLOCATOR")
+                                .eventDescription("Cellocator")
                                 .identifiers(ic)
                                 .details(mcgpPacket.toString() + " " + ipv4.toString())
                                 .build();


### PR DESCRIPTION
Resolves #893 
Updates UDP packet to construct a Cellocator packet payload when the source or destination UDP port is 231 and any time the packet contains the correct start packet identifier.  Updates the decode event type label.