### PR TITLE
Only update ViewByIdentifierEditor's list when the editor is selected

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasEditor.java
@@ -124,7 +124,7 @@ public class AliasEditor extends TabPane
     {
         if(mAliasViewByIdentifierEditor == null)
         {
-            mAliasViewByIdentifierEditor = new AliasViewByIdentifierEditor(mPlaylistManager);
+            mAliasViewByIdentifierEditor = new AliasViewByIdentifierEditor(mPlaylistManager, getAliasIdentifierTab().selectedProperty());
         }
 
         return mAliasViewByIdentifierEditor;

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasViewByIdentifierEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasViewByIdentifierEditor.java
@@ -190,22 +190,22 @@ public class AliasViewByIdentifierEditor extends VBox
     {
         if(mAliasAndIdentifierTableView == null)
         {
-            mAliasAndIdentifierTableView = new TableView(FXCollections.observableArrayList(AliasAndIdentifier.extractor()));
+            mAliasAndIdentifierTableView = new TableView<>(FXCollections.observableArrayList(AliasAndIdentifier.extractor()));
             mAliasAndIdentifierTableView.setPlaceholder(new Label("No aliases or identifiers available"));
             mIdentifierColumn = new TableColumn<>("Identifier");
             mIdentifierColumn.setCellValueFactory(new PropertyValueFactory<>("identifier"));
             mIdentifierColumn.setPrefWidth(350);
 
-            TableColumn aliasColumn = new TableColumn();
+            TableColumn<AliasAndIdentifier, String> aliasColumn = new TableColumn<>();
             aliasColumn.setText("Alias");
             aliasColumn.setCellValueFactory(new PropertyValueFactory<>("alias"));
             aliasColumn.setPrefWidth(200);
 
-            TableColumn groupColumn = new TableColumn();
+            TableColumn<AliasAndIdentifier, String> groupColumn = new TableColumn<>();
             groupColumn.setText("Group");
             groupColumn.setCellValueFactory(new PropertyValueFactory<>("group"));
             groupColumn.setPrefWidth(200);
-
+            
             mAliasAndIdentifierTableView.getColumns().addAll(mIdentifierColumn, aliasColumn, groupColumn);
             mAliasAndIdentifierTableView.setMaxHeight(Double.MAX_VALUE);
 


### PR DESCRIPTION
Editing many aliases with the AliasBulkEditor becomes very slow when modifying more than just a few aliases.  When applying a change to 1000 aliases, the PlaylistEditor freezes for over a minute.  It turns out most of the processing time came down to running the updateList() method in the ViewByIdentifierEditor class, as it was called multiple times per modified alias.  By changing the editor to only update its list when it is selected updateList() is no longer called in the background unnecessarily.  The same bulk edits take seconds instead of minutes.

I can't help but feel like the way I implemented the change is a bit ugly but it's the best I could come up with without making a lot of changes to AliasViewByIdentifierEditor.  I wanted to change how the list worked so it wouldn't have to be rebuilt every time an alias was added or removed but I wasn't sure what future plans there may be for this class so I settled on something less invasive and easy to change in the future.