### PR TITLE
#954 Channel Rotation Delay Minimums - P25 and MPT1327

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/AMConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/AMConfigurationEditor.java
@@ -138,7 +138,7 @@ public class AMConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), false);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel());
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/DMRConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/DMRConfigurationEditor.java
@@ -231,7 +231,9 @@ public class DMRConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), true);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(),
+                DecodeConfigDMR.CHANNEL_ROTATION_DELAY_MINIMUM_MS,
+                DecodeConfigDMR.CHANNEL_ROTATION_DELAY_MAXIMUM_MS);
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/LTRConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/LTRConfigurationEditor.java
@@ -210,7 +210,7 @@ public class LTRConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), false);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel());
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/LTRNetConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/LTRNetConfigurationEditor.java
@@ -210,7 +210,7 @@ public class LTRNetConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), false);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel());
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/MPT1327ConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/MPT1327ConfigurationEditor.java
@@ -195,7 +195,9 @@ public class MPT1327ConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), true);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(),
+                DecodeConfigMPT1327.CHANNEL_ROTATION_DELAY_MINIMUM_MS,
+                DecodeConfigMPT1327.CHANNEL_ROTATION_DELAY_MAXIMUM_MS);
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/NBFMConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/NBFMConfigurationEditor.java
@@ -200,7 +200,7 @@ public class NBFMConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), false);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel());
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P1ConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P1ConfigurationEditor.java
@@ -191,7 +191,9 @@ public class P25P1ConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), true);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(),
+                DecodeConfigP25Phase1.CHANNEL_ROTATION_DELAY_MINIMUM_MS,
+                DecodeConfigP25Phase1.CHANNEL_ROTATION_DELAY_MAXIMUM_MS);
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P2ConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P2ConfigurationEditor.java
@@ -179,7 +179,7 @@ public class P25P2ConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), false);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel());
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/PassportConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/PassportConfigurationEditor.java
@@ -155,7 +155,7 @@ public class PassportConfigurationEditor extends ChannelConfigurationEditor
     {
         if(mSourceConfigurationEditor == null)
         {
-            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel(), false);
+            mSourceConfigurationEditor = new FrequencyEditor(getTunerModel());
 
             //Add a listener so that we can push change notifications up to this editor
             mSourceConfigurationEditor.modifiedProperty()

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DecodeConfigDMR.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DecodeConfigDMR.java
@@ -34,6 +34,8 @@ import java.util.List;
  */
 public class DecodeConfigDMR extends DecodeConfiguration
 {
+    public static final int CHANNEL_ROTATION_DELAY_MINIMUM_MS = 200;
+    public static final int CHANNEL_ROTATION_DELAY_MAXIMUM_MS = 2000;
     private int mTrafficChannelPoolSize = TRAFFIC_CHANNEL_LIMIT_DEFAULT;
     private boolean mIgnoreDataCalls = true;
     private List<TimeslotFrequency> mTimeslotMap = new ArrayList<>();

--- a/src/main/java/io/github/dsheirer/module/decode/mpt1327/DecodeConfigMPT1327.java
+++ b/src/main/java/io/github/dsheirer/module/decode/mpt1327/DecodeConfigMPT1327.java
@@ -30,6 +30,9 @@ import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigMPT1327 extends DecodeConfiguration implements WithCallTimeout
 {
+    public static final int CHANNEL_ROTATION_DELAY_MINIMUM_MS = 500;
+    public static final int CHANNEL_ROTATION_DELAY_MAXIMUM_MS = 2000;
+
     private String mChannelMapName;
     private Sync mSync = Sync.NORMAL;
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/DecodeConfigP25Phase1.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/DecodeConfigP25Phase1.java
@@ -30,6 +30,9 @@ import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
 
 public class DecodeConfigP25Phase1 extends DecodeConfiguration
 {
+    public static final int CHANNEL_ROTATION_DELAY_MINIMUM_MS = 500;
+    public static final int CHANNEL_ROTATION_DELAY_MAXIMUM_MS = 2000;
+
     private P25P1Decoder.Modulation mModulation = P25P1Decoder.Modulation.C4FM;
 
     private int mTrafficChannelPoolSize = TRAFFIC_CHANNEL_LIMIT_DEFAULT;


### PR DESCRIPTION
Resolves #954.  Updates channel editors to use custom min/max channel rotation values on a per-protocol basis.
