### PR TITLE
#969 P25P2 Configuration Editor - NAC Value 

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P2ConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P2ConfigurationEditor.java
@@ -305,7 +305,7 @@ public class P25P2ConfigurationEditor extends ChannelConfigurationEditor
             config.setAutoDetectScrambleParameters(false);
             int wacn = getWacnTextField().get();
             int system = getSystemTextField().get();
-            int nac = getSystemTextField().get();
+            int nac = getNacTextField().get();
             config.setScrambleParameters(new ScrambleParameters(wacn, system, nac));
         }
         else


### PR DESCRIPTION
Resolves #969 

Resolves issue where P25P2 NAC value is saved incorrectly by configuration editor.
