### PR TITLE
#740 - Adds Encrypted state to the Status column for P25 Phase 1 Voice Calls

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -823,15 +823,20 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
         }
         else
         {
+            mCurrentCallEvent.setIdentifierCollection(getIdentifierCollection().copyOf());
+            mCurrentCallEvent.end(timestamp);
+            broadcast(mCurrentCallEvent);
+
             if(type == DecodeEventType.CALL_ENCRYPTED)
             {
                 mCurrentCallEvent.setEventDescription(type.toString());
                 mCurrentCallEvent.setDetails(details);
+                broadcast(new DecoderStateEvent(this, Event.CONTINUATION, State.ENCRYPTED));
             }
-            mCurrentCallEvent.setIdentifierCollection(getIdentifierCollection().copyOf());
-            mCurrentCallEvent.end(timestamp);
-            broadcast(mCurrentCallEvent);
-            broadcast(new DecoderStateEvent(this, Event.CONTINUATION, State.CALL));
+            else
+            {
+                broadcast(new DecoderStateEvent(this, Event.CONTINUATION, State.CALL));
+            }
         }
     }
 


### PR DESCRIPTION
This adds the **Encrypted** state to the Status column for P25 Phase 1 Voice Calls, and fixes issue #740.

I am fairly sure that this is the right way/place to fix this, and it seems to work correctly on a test recording I have.

Fixes #740 .