### PR TITLE
#815 - Change usable bandwidth percentage based on Airspy samplerate

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerController.java
@@ -276,6 +276,14 @@ public abstract class TunerController implements Tunable, ISourceEventProcessor,
     }
 
     /**
+     * Sets the usable bandwidth percentage -- this can change based on samplerate for some tuners
+     */
+    public void setUsableBandwidthPercentage(double usableBandwidthPercentage)
+    {
+        mUsableBandwidthPercentage = usableBandwidthPercentage;
+    }
+
+    /**
      * Usable half bandwidth - total bandwidth minus unusable space at either end of the spectrum.
      *
      * Note: this does not account for any DC spike protected frequency region at the center of the tuner

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
@@ -406,6 +406,25 @@ public class AirspyTunerController extends USBTunerController
             {
                 mSampleRate = rate.getRate();
                 mFrequencyController.setSampleRate(mSampleRate);
+
+                // Update the Usable Bandwidth Percentage, as the usable range varies with the sample rate.
+                // Values below are from https://github.com/DSheirer/sdrtrunk/issues/815#issuecomment-699859590
+                switch(mSampleRate)
+                {
+                    default:
+                    case 10000000:
+                        super.setUsableBandwidthPercentage(0.90);
+                        break;
+                    case 6000000:
+                        super.setUsableBandwidthPercentage(0.83);
+                        break;
+                    case 3000000:
+                        super.setUsableBandwidthPercentage(0.66);
+                        break;
+                    case 2500000:
+                        super.setUsableBandwidthPercentage(0.60);
+                        break;
+                }
             }
         }
     }


### PR DESCRIPTION
Percentages based on @DSheirer's percentages given in the bug report.

Tested with the Airspy Mini, and the percentages seem to be good. The usable bandwidth with Airspy Mini at 3MHz is asymmetric, but probably close enough to be fine as it is.

Fixes #815 .