### PR TITLE
#956 Identifier Collection NPE On Channel Start

### DIFF
--- a/src/main/java/io/github/dsheirer/controller/channel/event/ChannelStartProcessingRequest.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/event/ChannelStartProcessingRequest.java
@@ -56,7 +56,7 @@ public class ChannelStartProcessingRequest extends ModuleEventBusMessage
     {
         mChannel = channel;
         mChannelDescriptor = channelDescriptor;
-        mIdentifierCollection = identifierCollection;
+        mIdentifierCollection = (identifierCollection != null ? identifierCollection : new IdentifierCollection());
         mTrafficChannelManager = trafficChannelManager;
     }
 


### PR DESCRIPTION
Resolves #956 issue with null pointer in identifier collection on channel start.

