### PR TITLE
981 Channel Short Title Serialization

### DIFF
--- a/src/main/java/io/github/dsheirer/controller/channel/Channel.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/Channel.java
@@ -186,6 +186,7 @@ public class Channel extends Configuration implements Listener<SourceEvent>
      * ten characters each.
      * @return short title
      */
+    @JsonIgnore
     public String getShortTitle()
     {
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Resolves #981 sets channel short title as ignore for serialization.
