### PR TITLE
973 Tuner Controller Concurrent Locking - Avoid USB Pipe Errors

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/FrequencyErrorCorrectionManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/FrequencyErrorCorrectionManager.java
@@ -19,6 +19,8 @@ import io.github.dsheirer.source.SourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.text.DecimalFormat;
+
 /**
  * Monitors measured frequency error PPM values from the tuner and (when enabled) applies the current
  * error measurement to the tuner controller to adjust the tuner's PPM and align the frequency value.
@@ -32,6 +34,7 @@ public class FrequencyErrorCorrectionManager
     private long mObservationPeriodStart;
     private double mPPMRequired;
     private boolean mEnabled = true;
+    private DecimalFormat mDecimalFormat = new DecimalFormat("0.0");
     private TunerController mTunerController;
 
     /**
@@ -72,7 +75,7 @@ public class FrequencyErrorCorrectionManager
 
             try
             {
-                mLog.info("Auto-Correcting Tuner PPM to [" + frequencyCorrection + "]");
+                mLog.info("Auto-Correcting Tuner PPM to [" + mDecimalFormat.format(frequencyCorrection) + "]");
 
                 mTunerController.setFrequencyCorrection(frequencyCorrection);
                 reset();

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
@@ -42,6 +42,7 @@ import javax.usb.UsbException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
+import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class FCDTunerController extends TunerController
 {
@@ -60,6 +61,7 @@ public abstract class FCDTunerController extends TunerController
 
     private FCDConfiguration mConfiguration = new FCDConfiguration();
     protected ComplexMixer mComplexMixer;
+    protected ReentrantLock mLock = new ReentrantLock();
 
 
     /**
@@ -302,6 +304,8 @@ public abstract class FCDTunerController extends TunerController
      */
     public void setTunedFrequency(long frequency) throws SourceException
     {
+        mLock.lock();
+
         try
         {
             send(FCDCommand.APP_SET_FREQUENCY_HZ, frequency);
@@ -310,6 +314,10 @@ public abstract class FCDTunerController extends TunerController
         {
             throw new SourceException("Couldn't set FCD Local " +
                 "Oscillator Frequency [" + frequency + "]", e);
+        }
+        finally
+        {
+            mLock.unlock();
         }
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerController.java
@@ -176,10 +176,18 @@ public class FCD1TunerController extends FCDTunerController
      * @throws UsbException
      * @throws UsbClaimException
      */
-    public void setLNAGain(LNAGain gain)
-        throws UsbException, UsbClaimException
+    public void setLNAGain(LNAGain gain) throws UsbException, UsbClaimException
     {
-        send(FCDCommand.APP_SET_LNA_GAIN, gain.getSetting());
+        mLock.lock();
+
+        try
+        {
+            send(FCDCommand.APP_SET_LNA_GAIN, gain.getSetting());
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     /**
@@ -269,7 +277,16 @@ public class FCD1TunerController extends FCDTunerController
         //Merge the results
         long correction = longGain | phase;
 
-        send(FCDCommand.APP_SET_IQ_CORRECTION, correction);
+        mLock.lock();
+
+        try
+        {
+            send(FCDCommand.APP_SET_IQ_CORRECTION, correction);
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     /**
@@ -402,15 +419,16 @@ public class FCD1TunerController extends FCDTunerController
         //Merge the results
         long correction = shiftedQuadrature | maskedInphase;
 
-//		Log.info( "FCD1: setting iq correction," +
-//				" inphase:" + inphase +
-//				" masked inphase:" + maskedInphase +
-//				" quad:" + quadrature +
-//				" masked quad:" + maskedQuadrature +
-//				" shifted quadrature:" + shiftedQuadrature +
-//				" correction:" + correction );
+        mLock.lock();
 
-        send(FCDCommand.APP_SET_DC_CORRECTION, correction);
+        try
+        {
+            send(FCDCommand.APP_SET_DC_CORRECTION, correction);
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     private void getDCIQCorrection() throws UsbClaimException,
@@ -464,10 +482,18 @@ public class FCD1TunerController extends FCDTunerController
         return mLNAEnhance;
     }
 
-    public void setLNAEnhance(LNAEnhance enhance)
-        throws UsbClaimException, UsbException
+    public void setLNAEnhance(LNAEnhance enhance) throws UsbClaimException, UsbException
     {
-        send(FCDCommand.APP_SET_LNA_ENHANCE, enhance.getSetting());
+        mLock.lock();
+
+        try
+        {
+            send(FCDCommand.APP_SET_LNA_ENHANCE, enhance.getSetting());
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     private void getMixerGainSetting() throws UsbClaimException, UsbException
@@ -488,7 +514,16 @@ public class FCD1TunerController extends FCDTunerController
 
     public void setMixerGain(MixerGain gain) throws UsbClaimException, UsbException
     {
-        send(FCDCommand.APP_SET_MIXER_GAIN, gain.getSetting());
+        mLock.lock();
+
+        try
+        {
+            send(FCDCommand.APP_SET_MIXER_GAIN, gain.getSetting());
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     public enum Block

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerController.java
@@ -83,6 +83,8 @@ public class FCD2TunerController extends FCDTunerController
 
     public void setLNAGain(boolean enabled) throws SourceException
     {
+        mLock.lock();
+
         try
         {
             send(FCDCommand.APP_SET_LNA_GAIN, enabled ? 1 : 0);
@@ -91,10 +93,16 @@ public class FCD2TunerController extends FCDTunerController
         {
             throw new SourceException("error while setting LNA Gain", e);
         }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     public void setMixerGain(boolean enabled) throws SourceException
     {
+        mLock.lock();
+
         try
         {
             send(FCDCommand.APP_SET_MIXER_GAIN, enabled ? 1 : 0);
@@ -102,6 +110,10 @@ public class FCD2TunerController extends FCDTunerController
         catch(Exception e)
         {
             throw new SourceException("error while setting Mixer Gain", e);
+        }
+        finally
+        {
+            mLock.unlock();
         }
     }
 
@@ -159,6 +171,8 @@ public class FCD2TunerController extends FCDTunerController
 
     public void setDCCorrection(int value)
     {
+        mLock.lock();
+
         try
         {
             send(FCDCommand.APP_SET_DC_CORRECTION, value);
@@ -166,6 +180,10 @@ public class FCD2TunerController extends FCDTunerController
         catch(Exception e)
         {
             mLog.error("error setting dc correction to [" + value + "]", e);
+        }
+        finally
+        {
+            mLock.unlock();
         }
     }
 
@@ -191,6 +209,8 @@ public class FCD2TunerController extends FCDTunerController
 
     public void setIQCorrection(int value)
     {
+        mLock.lock();
+
         try
         {
             send(FCDCommand.APP_SET_IQ_CORRECTION, value);
@@ -198,6 +218,10 @@ public class FCD2TunerController extends FCDTunerController
         catch(Exception e)
         {
             mLog.error("error setting IQ correction to [" + value + "]", e);
+        }
+        finally
+        {
+            mLock.unlock();
         }
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -46,6 +46,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class RTL2832TunerController extends USBTunerController
 {
@@ -60,6 +61,7 @@ public abstract class RTL2832TunerController extends USBTunerController
     public final static long TIMEOUT_US = 1000000l; //uSeconds
     public final static byte REQUEST_ZERO = (byte) 0;
     public final static byte EEPROM_ADDRESS = (byte) 0xA0;
+    protected ReentrantLock mLock = new ReentrantLock();
 
     public final static byte[] sFIR_COEFFICIENTS =
         {

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerController.java
@@ -384,6 +384,8 @@ public class E4KTunerController extends RTL2832TunerController
             actualFrequency = calculateActualFrequency(pll, z, x);
         }
 
+        mLock.lock();
+
         /* Apply the actual frequency */
         try
         {
@@ -427,6 +429,10 @@ public class E4KTunerController extends RTL2832TunerController
         {
             throw new SourceException("E4K tuner controller - error tuning "
                 + "frequency [" + frequency + "]", e);
+        }
+        finally
+        {
+            mLock.unlock();
         }
     }
 
@@ -657,38 +663,46 @@ public class E4KTunerController extends RTL2832TunerController
      * @param gain
      * @throws UsbException
      */
-    public void setLNAGain(E4KLNAGain gain, boolean controlI2CRepeater)
-        throws UsbException
+    public void setLNAGain(E4KLNAGain gain, boolean controlI2CRepeater) throws UsbException
     {
-        if(controlI2CRepeater)
+        mLock.lock();
+
+        try
         {
-            enableI2CRepeater(mDeviceHandle, true);
+            if(controlI2CRepeater)
+            {
+                enableI2CRepeater(mDeviceHandle, true);
+            }
+
+            if(gain == E4KLNAGain.AUTOMATIC)
+            {
+                writeMaskedE4KRegister(Register.AGC1,
+                    AGC1_MOD_MASK,
+                    AGCMode.IF_SERIAL_LNA_AUTON.getValue(),
+                    false);
+            }
+            else
+            {
+                writeMaskedE4KRegister(Register.AGC1,
+                    AGC1_MOD_MASK,
+                    AGCMode.SERIAL.getValue(),
+                    false);
+
+
+                writeMaskedE4KRegister(E4KLNAGain.getRegister(),
+                    E4KLNAGain.getMask(),
+                    gain.getValue(),
+                    false);
+            }
+
+            if(controlI2CRepeater)
+            {
+                enableI2CRepeater(mDeviceHandle, false);
+            }
         }
-
-        if(gain == E4KLNAGain.AUTOMATIC)
+        finally
         {
-            writeMaskedE4KRegister(Register.AGC1,
-                AGC1_MOD_MASK,
-                AGCMode.IF_SERIAL_LNA_AUTON.getValue(),
-                false);
-        }
-        else
-        {
-            writeMaskedE4KRegister(Register.AGC1,
-                AGC1_MOD_MASK,
-                AGCMode.SERIAL.getValue(),
-                false);
-
-
-            writeMaskedE4KRegister(E4KLNAGain.getRegister(),
-                E4KLNAGain.getMask(),
-                gain.getValue(),
-                false);
-        }
-
-        if(controlI2CRepeater)
-        {
-            enableI2CRepeater(mDeviceHandle, false);
+            mLock.unlock();
         }
     }
 
@@ -699,8 +713,16 @@ public class E4KTunerController extends RTL2832TunerController
      */
     public E4KLNAGain getLNAGain(boolean controlI2CRepeater) throws UsbException
     {
-        return E4KLNAGain.fromRegisterValue(
-            readE4KRegister(E4KLNAGain.getRegister(), controlI2CRepeater));
+        mLock.lock();
+
+        try
+        {
+            return E4KLNAGain.fromRegisterValue(readE4KRegister(E4KLNAGain.getRegister(), controlI2CRepeater));
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     /**
@@ -711,13 +733,18 @@ public class E4KTunerController extends RTL2832TunerController
      * @param gain
      * @throws UsbException
      */
-    public void setEnhanceGain(E4KEnhanceGain gain, boolean controlI2CRepeater)
-        throws UsbException
+    public void setEnhanceGain(E4KEnhanceGain gain, boolean controlI2CRepeater) throws UsbException
     {
-        writeMaskedE4KRegister(E4KEnhanceGain.getRegister(),
-            E4KEnhanceGain.getMask(),
-            gain.getValue(),
-            controlI2CRepeater);
+        mLock.lock();
+
+        try
+        {
+            writeMaskedE4KRegister(E4KEnhanceGain.getRegister(), E4KEnhanceGain.getMask(), gain.getValue(), controlI2CRepeater);
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     /**
@@ -728,72 +755,90 @@ public class E4KTunerController extends RTL2832TunerController
      * @return
      * @throws UsbException
      */
-    public E4KEnhanceGain getEnhanceGain(boolean controlI2CRepeater)
-        throws UsbException
+    public E4KEnhanceGain getEnhanceGain(boolean controlI2CRepeater) throws UsbException
     {
-        return E4KEnhanceGain.fromRegisterValue(
-            readE4KRegister(E4KEnhanceGain.getRegister(), controlI2CRepeater));
-    }
+        mLock.lock();
 
-    public void setMixerGain(E4KMixerGain gain, boolean controlI2CRepeater)
-        throws UsbException
-    {
-        if(controlI2CRepeater)
+        try
         {
-            enableI2CRepeater(mDeviceHandle, true);
+            return E4KEnhanceGain.fromRegisterValue(readE4KRegister(E4KEnhanceGain.getRegister(), controlI2CRepeater));
         }
-
-        boolean localI2CRepeaterControl = false;
-
-        if(gain == E4KMixerGain.AUTOMATIC)
+        finally
         {
-            writeMaskedE4KRegister(Register.AGC7,
-                AGC7_MIXER_GAIN_MASK,
-                AGC7_MIX_GAIN_AUTO,
-                localI2CRepeaterControl);
-        }
-        else
-        {
-            writeMaskedE4KRegister(Register.AGC7,
-                AGC7_MIXER_GAIN_MASK,
-                AGC7_MIX_GAIN_MANUAL,
-                localI2CRepeaterControl);
-
-            /* Set the desired manual gain setting */
-            writeMaskedE4KRegister(E4KMixerGain.getRegister(),
-                E4KMixerGain.getMask(),
-                gain.getValue(),
-                localI2CRepeaterControl);
-        }
-
-        if(controlI2CRepeater)
-        {
-            enableI2CRepeater(mDeviceHandle, false);
+            mLock.unlock();
         }
     }
 
-    public E4KMixerGain getMixerGain(boolean controlI2CRepeater)
-        throws UsbException
+    public void setMixerGain(E4KMixerGain gain, boolean controlI2CRepeater) throws UsbException
     {
-        byte autoOrManual = readMaskedE4KRegister(Register.AGC7,
-            AGC7_MIXER_GAIN_MASK,
-            controlI2CRepeater);
+        mLock.lock();
 
-        if(autoOrManual == AGC7_MIX_GAIN_AUTO)
+        try
         {
-            return E4KMixerGain.AUTOMATIC;
+            if(controlI2CRepeater)
+            {
+                enableI2CRepeater(mDeviceHandle, true);
+            }
+
+            boolean localI2CRepeaterControl = false;
+
+            if(gain == E4KMixerGain.AUTOMATIC)
+            {
+                writeMaskedE4KRegister(Register.AGC7,
+                    AGC7_MIXER_GAIN_MASK,
+                    AGC7_MIX_GAIN_AUTO,
+                    localI2CRepeaterControl);
+            }
+            else
+            {
+                writeMaskedE4KRegister(Register.AGC7,
+                    AGC7_MIXER_GAIN_MASK,
+                    AGC7_MIX_GAIN_MANUAL,
+                    localI2CRepeaterControl);
+
+                /* Set the desired manual gain setting */
+                writeMaskedE4KRegister(E4KMixerGain.getRegister(),
+                    E4KMixerGain.getMask(),
+                    gain.getValue(),
+                    localI2CRepeaterControl);
+            }
+
+            if(controlI2CRepeater)
+            {
+                enableI2CRepeater(mDeviceHandle, false);
+            }
         }
-        else
+        finally
         {
-            int register = readE4KRegister(E4KMixerGain.getRegister(),
-                controlI2CRepeater);
-
-            return E4KMixerGain.fromRegisterValue(register);
+            mLock.unlock();
         }
     }
 
-    public void setIFStage1Gain(IFStage1Gain gain,
-                                boolean controlI2CRepeater) throws UsbException
+    public E4KMixerGain getMixerGain(boolean controlI2CRepeater) throws UsbException
+    {
+        mLock.lock();
+
+        try
+        {
+            byte autoOrManual = readMaskedE4KRegister(Register.AGC7, AGC7_MIXER_GAIN_MASK, controlI2CRepeater);
+
+            if(autoOrManual == AGC7_MIX_GAIN_AUTO)
+            {
+                return E4KMixerGain.AUTOMATIC;
+            }
+            else
+            {
+                int register = readE4KRegister(E4KMixerGain.getRegister(), controlI2CRepeater);
+                return E4KMixerGain.fromRegisterValue(register);
+            }
+        }
+        finally
+        {
+            mLock.unlock();
+        }
+    }
+
+    public void setIFStage1Gain(IFStage1Gain gain, boolean controlI2CRepeater) throws UsbException
     {
         writeMaskedE4KRegister(IFStage1Gain.getRegister(),
             IFStage1Gain.getMask(),
@@ -959,8 +1004,7 @@ public class E4KTunerController extends RTL2832TunerController
         }
     }
 
-    public void setBand(long frequency,
-                        boolean controlI2CRepeater) throws UsbException
+    public void setBand(long frequency, boolean controlI2CRepeater) throws UsbException
     {
         if(controlI2CRepeater)
         {
@@ -997,8 +1041,7 @@ public class E4KTunerController extends RTL2832TunerController
         }
     }
 
-    private void setRFFilter(long frequency,
-                             boolean controlI2CRepeater) throws UsbException
+    private void setRFFilter(long frequency, boolean controlI2CRepeater) throws UsbException
     {
         RFFilter filter = RFFilter.fromFrequency(frequency);
 

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerController.java
@@ -180,6 +180,8 @@ public class R820TTunerController extends RTL2832TunerController
     @Override
     public void setTunedFrequency(long frequency) throws SourceException
     {
+        mLock.lock();
+
         try
         {
             enableI2CRepeater(mDeviceHandle, true);
@@ -199,6 +201,10 @@ public class R820TTunerController extends RTL2832TunerController
             throw new SourceException("R820TTunerController - exception "
                 + "while setting frequency [" + frequency + "] - " +
                 e.getLocalizedMessage());
+        }
+        finally
+        {
+            mLock.unlock();
         }
     }
 
@@ -693,7 +699,16 @@ public class R820TTunerController extends RTL2832TunerController
      */
     public void setLNAGain(R820TLNAGain gain, boolean controlI2C) throws UsbException
     {
-        writeR820TRegister(Register.LNA_GAIN, gain.getSetting(), controlI2C);
+        mLock.lock();
+
+        try
+        {
+            writeR820TRegister(Register.LNA_GAIN, gain.getSetting(), controlI2C);
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     /**
@@ -701,7 +716,16 @@ public class R820TTunerController extends RTL2832TunerController
      */
     public void setMixerGain(R820TMixerGain gain, boolean controlI2C) throws UsbException
     {
-        writeR820TRegister(Register.MIXER_GAIN, gain.getSetting(), controlI2C);
+        mLock.lock();
+
+        try
+        {
+            writeR820TRegister(Register.MIXER_GAIN, gain.getSetting(), controlI2C);
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     /**
@@ -709,7 +733,16 @@ public class R820TTunerController extends RTL2832TunerController
      */
     public void setVGAGain(R820TVGAGain gain, boolean controlI2C) throws UsbException
     {
-        writeR820TRegister(Register.VGA_GAIN, gain.getSetting(), controlI2C);
+        mLock.lock();
+
+        try
+        {
+            writeR820TRegister(Register.VGA_GAIN, gain.getSetting(), controlI2C);
+        }
+        finally
+        {
+            mLock.unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
Resolves #973.  Adds concurrent locking to primary tuner controller methods to avoid concurrent access to USB methods.