### PR TITLE
RR User Interface Improvements, including Premium notices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,17 @@ sourceSets {
     test.java.srcDirs 'src/test'
 }
 
+test {
+    useJUnitPlatform()
+}
+
 dependencies {
+
+    // JUnit Tests
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.8.0'
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     //Jitpack imports
     implementation 'com.github.nwaldispuehl:java-lame:v3.98.4'

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/LoginDialog.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/LoginDialog.java
@@ -360,6 +360,12 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
                             }
                             catch(RadioReferenceException rre)
                             {
+
+                                // Set an error state
+                                getTestPassIcon().setVisible(false);
+                                getTestFailIcon().setVisible(true);
+                                getTestExpiredIcon().setVisible(false);
+
                                 if(rre.getCause() instanceof ConnectException)
                                 {
                                     Alert alert = new Alert(Alert.AlertType.ERROR, "Please check network or radio reference availability", ButtonType.OK);
@@ -391,10 +397,7 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
                                 }
                             }
 
-                            // Set an error state
-                            getTestPassIcon().setVisible(false);
-                            getTestFailIcon().setVisible(true);
-                            getTestExpiredIcon().setVisible(false);
+
                             getTestConnectionButton().setDisable(false);
                         }
                     });

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/LoginDialog.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/LoginDialog.java
@@ -49,6 +49,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.ConnectException;
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
 
 /**
  * Login dialog for radioreference.com with support for testing connection to the service.
@@ -66,6 +69,7 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
     private Button mTestConnectionButton;
     private IconNode mTestPassIcon;
     private IconNode mTestFailIcon;
+    private IconNode mTextExpiredIcon;
 
     /**
      * Constructs an instance.
@@ -166,6 +170,10 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
             getTestFailIcon().setVisible(false);
             GridPane.setConstraints(getTestFailIcon(), 2, 4);
             mGridPane.getChildren().add(getTestFailIcon());
+
+            getTestExpiredIcon().setVisible(false);
+            GridPane.setConstraints(getTestExpiredIcon(), 2, 4);
+            mGridPane.getChildren().add(getTestExpiredIcon());
         }
 
         return mGridPane;
@@ -275,6 +283,7 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
                     getTestConnectionButton().setDisable(true);
                     getTestPassIcon().setVisible(false);
                     getTestFailIcon().setVisible(false);
+                    getTestExpiredIcon().setVisible(false);
 
                     String userName = getUserNameText().getText();
                     String password = getPasswordField().isVisible() ? getPasswordField().getText() : getPasswordText().getText();
@@ -307,10 +316,47 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
                         public void run()
                         {
                             boolean success = false;
+                            RadioReference.LoginStatus loginStatus;
 
                             try
                             {
-                                success = RadioReference.testConnection(userName, password);
+                                loginStatus = RadioReference.testConnectionWithExp(userName, password);
+
+                                if(loginStatus == RadioReference.LoginStatus.VALID_PREMIUM)
+                                {
+                                    getTestPassIcon().setVisible(true);
+                                    getTestFailIcon().setVisible(false);
+                                    getTestExpiredIcon().setVisible(false);
+                                }
+                                else if (loginStatus == RadioReference.LoginStatus.EXPIRED_PREMIUM)
+                                {
+                                    getTestPassIcon().setVisible(false);
+                                    getTestFailIcon().setVisible(false);
+                                    getTestExpiredIcon().setVisible(true);
+
+                                    Alert alert = new Alert(Alert.AlertType.WARNING, "You do not have a valid Radio Reference Premium Subscription (it may have expired).", ButtonType.OK);
+                                    alert.setHeaderText("Expired Premium Account");
+                                    alert.setTitle("Radio Reference Account issue");
+                                    alert.initOwner(((Node)getTestConnectionButton()).getScene().getWindow());
+                                    alert.showAndWait();
+                                }
+                                else if (loginStatus == RadioReference.LoginStatus.INVALID_LOGIN)
+                                {
+                                    getTestPassIcon().setVisible(false);
+                                    getTestFailIcon().setVisible(true);
+                                    getTestExpiredIcon().setVisible(false);
+
+                                    Alert alert = new Alert(Alert.AlertType.ERROR, "Please verify username and password", ButtonType.OK);
+                                    alert.setHeaderText("Login Failed");
+                                    alert.setTitle("Test Failed");
+                                    alert.initOwner(((Node)getTestConnectionButton()).getScene().getWindow());
+                                    alert.showAndWait();
+                                    mLog.error("Login failed. Invalid username or password.  Can't login to radioreference.com");
+                                }
+                                else
+                                {
+                                    // Only way to get here is via an exception
+                                }
                             }
                             catch(RadioReferenceException rre)
                             {
@@ -327,24 +373,12 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
                                 {
                                     Fault fault = rre.getFault();
 
-                                    if(fault.getFaultCode() != null && fault.getFaultCode().contentEquals("AUTH"))
-                                    {
-                                        Alert alert = new Alert(Alert.AlertType.ERROR, "Please verify username and password", ButtonType.OK);
-                                        alert.setHeaderText("Login Failed");
-                                        alert.setTitle("Test Failed");
-                                        alert.initOwner(((Node)getTestConnectionButton()).getScene().getWindow());
-                                        alert.showAndWait();
-                                        mLog.error("Login failed. Invalid username or password.  Can't login to radioreference.com");
-                                    }
-                                    else
-                                    {
-                                        Alert alert = new Alert(Alert.AlertType.ERROR, fault.getFaultString(), ButtonType.OK);
-                                        alert.setHeaderText(fault.getFaultCode());
-                                        alert.setTitle("Test Failed");
-                                        alert.initOwner(((Node)getTestConnectionButton()).getScene().getWindow());
-                                        alert.showAndWait();
-                                        mLog.error("Test failed.  Fault [" + fault.toString() + "] Can't login to radioreference.com");
-                                    }
+                                    Alert alert = new Alert(Alert.AlertType.ERROR, fault.getFaultString(), ButtonType.OK);
+                                    alert.setHeaderText(fault.getFaultCode());
+                                    alert.setTitle("Test Failed");
+                                    alert.initOwner(((Node)getTestConnectionButton()).getScene().getWindow());
+                                    alert.showAndWait();
+                                    mLog.error("Test failed.  Fault [" + fault.toString() + "] Can't login to radioreference.com");
                                 }
                                 else
                                 {
@@ -357,8 +391,10 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
                                 }
                             }
 
-                            getTestPassIcon().setVisible(success);
-                            getTestFailIcon().setVisible(!success);
+                            // Set an error state
+                            getTestPassIcon().setVisible(false);
+                            getTestFailIcon().setVisible(true);
+                            getTestExpiredIcon().setVisible(false);
                             getTestConnectionButton().setDisable(false);
                         }
                     });
@@ -391,5 +427,17 @@ public class LoginDialog extends Dialog<AuthorizationInformation>
         }
 
         return mTestFailIcon;
+    }
+
+    private IconNode getTestExpiredIcon()
+    {
+        if(mTextExpiredIcon == null)
+        {
+            mTextExpiredIcon = new IconNode(FontAwesome.EXCLAMATION_TRIANGLE);
+            mTextExpiredIcon.setIconSize(32);
+            mTextExpiredIcon.setFill(Color.ORANGERED);
+        }
+
+        return mTextExpiredIcon;
     }
 }

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemEditor.java
@@ -21,6 +21,7 @@ package io.github.dsheirer.gui.playlist.radioreference;
 
 import io.github.dsheirer.playlist.PlaylistManager;
 import io.github.dsheirer.preference.UserPreferences;
+import io.github.dsheirer.rrapi.RadioReferenceException;
 import io.github.dsheirer.rrapi.type.CountyInfo;
 import io.github.dsheirer.rrapi.type.Flavor;
 import io.github.dsheirer.rrapi.type.Site;
@@ -229,6 +230,18 @@ public class SystemEditor extends VBox
 
     private String getType(System system)
     {
+        if(mRadioReferenceDecoder == null)
+        {
+            try
+            {
+                initRadioReferenceDecoder();
+            }
+            catch (Throwable t)
+            {
+                mLog.error("Error retrieving system information", t);
+            }
+        }
+
         if(mRadioReferenceDecoder != null)
         {
             Type type = mRadioReferenceDecoder.getType(system);
@@ -268,12 +281,7 @@ public class SystemEditor extends VBox
                 {
                     if(mRadioReferenceDecoder == null)
                     {
-                        Map<Integer,Type> typeMap = mRadioReference.getService().getTypesMap();
-                        Map<Integer,Flavor> flavorMap = mRadioReference.getService().getFlavorsMap();
-                        Map<Integer,Voice> voiceMap = mRadioReference.getService().getVoicesMap();
-                        Map<Integer,Tag> tagMap = mRadioReference.getService().getTagsMap();
-                        mRadioReferenceDecoder = new RadioReferenceDecoder(mUserPreferences, typeMap, flavorMap,
-                            voiceMap, tagMap);
+                        initRadioReferenceDecoder();
                     }
 
                     //Query and load the system view editor first
@@ -318,6 +326,20 @@ public class SystemEditor extends VBox
             getSystemSiteSelectionEditor().clear();
             getSystemTalkgroupSelectionEditor().clear();
         }
+    }
+
+    /**
+     * Initializes the Radio Reference Decoder
+     * @throws RadioReferenceException
+     */
+    private void initRadioReferenceDecoder() throws RadioReferenceException
+    {
+        Map<Integer, Type> typeMap = mRadioReference.getService().getTypesMap();
+        Map<Integer, Flavor> flavorMap = mRadioReference.getService().getFlavorsMap();
+        Map<Integer, Voice> voiceMap = mRadioReference.getService().getVoicesMap();
+        Map<Integer, Tag> tagMap = mRadioReference.getService().getTagsMap();
+        mRadioReferenceDecoder = new RadioReferenceDecoder(mUserPreferences, typeMap, flavorMap,
+                voiceMap, tagMap);
     }
 
     public class SystemListCell extends ListCell<System>

--- a/src/test/java/io/github/dsheirer/service/radioreference/RadioReferenceTest.java
+++ b/src/test/java/io/github/dsheirer/service/radioreference/RadioReferenceTest.java
@@ -1,0 +1,54 @@
+package io.github.dsheirer.service.radioreference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import static io.github.dsheirer.service.radioreference.RadioReference.CheckExpDate;
+import static org.junit.Assert.*;
+
+public class RadioReferenceTest
+{
+
+    /**
+     * Tests the handling of Radio Reference's Premium Expiration date to Account Statuses
+     * Necessary because DateTime math gets easy to do incorrectly, and we don't want to
+     * lock a user out of access due to an off-by-one Date issue.
+     */
+    @Test
+    void checkExpDate()
+    {
+        SimpleDateFormat RRDateFormatter = new SimpleDateFormat("MM-dd-yyyy");
+        Date now = new Date();
+
+        Calendar c = Calendar.getInstance();
+        c.setTime(now);
+
+        // Never had premium (expired)
+        Assertions.assertEquals(RadioReference.LoginStatus.EXPIRED_PREMIUM, CheckExpDate("12-31-1969"));
+
+        // Expiring today (valid)
+        Assertions.assertEquals(RadioReference.LoginStatus.VALID_PREMIUM, CheckExpDate(RRDateFormatter.format(c.getTime())));
+
+        // Expiring next week (valid)
+        c.add(Calendar.DAY_OF_MONTH, 7);
+        Assertions.assertEquals(RadioReference.LoginStatus.VALID_PREMIUM, CheckExpDate(RRDateFormatter.format(c.getTime())));
+
+        // Expired yesterday (valid)
+        c.setTime(now);
+        c.add(Calendar.DAY_OF_MONTH, -1);
+        Assertions.assertEquals(RadioReference.LoginStatus.VALID_PREMIUM, CheckExpDate(RRDateFormatter.format(c.getTime())));
+
+        // Expired last week (expired)
+        c.setTime(now);
+        c.add(Calendar.DAY_OF_MONTH, -7);
+        Assertions.assertEquals(RadioReference.LoginStatus.EXPIRED_PREMIUM, CheckExpDate(RRDateFormatter.format(c.getTime())));
+
+        // Broadcastify user? Admin? Any string that's not a Date is considered valid (valid)
+        Assertions.assertEquals(RadioReference.LoginStatus.VALID_PREMIUM, CheckExpDate("Not a date"));
+
+    }
+}


### PR DESCRIPTION
This PR has some improvements around Radio Reference, Premium Accounts, and the Playlist Import system.

# Overview
- The Login pane now lets you know if you're logging in with a valid RR account, but that is _not_ a Premium account. This should help with issues like #888, where users don't realize that a Premium account is required for import.
![no_premium login slash test](https://user-images.githubusercontent.com/176014/97520740-459fd180-1972-11eb-82f0-106cfd743766.png)

- The Radio Reference Playlist Importer locks out the UI elements if the account doesn't have a valid, premium account, or isn't logged in. Additionally, an error message is displayed if the account isn't Premium.
![no_premium rr import v2](https://user-images.githubusercontent.com/176014/97520741-46386800-1972-11eb-891c-f6134ec7db87.png)

- The UI is enabled with a valid, Premium account.
![premium_acct import](https://user-images.githubusercontent.com/176014/97520742-46386800-1972-11eb-9a63-5dba44ca883e.png)

# Notes
- I added a new `SimpleBooleanProperty` for the Premium Status, as I think (?) the user can be logged in with a non-Premium account, but should still have access to Broadcastify upload.
- The PR considers an account expired if the expiration date is more than a day in the past, as I am not sure how RadioReference's timezones work. I wanted to err on the side of caution rather than locking a user out of a valid, but shortly expiring account.
- I added a JUnit test to test parsing various possible Premium Expiration values returned by the API, to ensure that my Date comparison math worked. I believe that a text string can also be returned from RR's API as the expiration date (for Admins or Broadcastify Streamers), so any API Expiration value that throws a `ParseException` is treated as a Valid Premium Subscription. The test can be run by  executing `gradle test`, or by adding the tests to IntelliJ as a Run Configuration, and probably other IDEs as well.
- If RR ever returns a "has Premium" flag in the `getUserInfo` response in a future API update, a decent part of this code can be removed, and I will be glad to remove it.
- `initRadioReferenceDecoder` is called sooner when loading systems from RR, which fixes the issue where the first time loading of a System after startup showed "Unknown" for the type of every System.

