### PR TITLE
Don't sort Alias TableView while bulk changes are applied

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasBulkEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasBulkEditor.java
@@ -19,12 +19,16 @@
 
 package io.github.dsheirer.gui.playlist.alias;
 
+import java.util.List;
+
+import org.controlsfx.control.ToggleSwitch;
+
 import com.google.common.collect.Ordering;
+
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.gui.playlist.Editor;
 import io.github.dsheirer.icon.Icon;
 import io.github.dsheirer.playlist.PlaylistManager;
-import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -45,9 +49,6 @@ import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.paint.Color;
 import javafx.util.Callback;
-import org.controlsfx.control.ToggleSwitch;
-
-import java.util.List;
 
 /**
  * Editor for multiple selected aliases providing limited options for changing attributes of multiple aliases

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasBulkEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasBulkEditor.java
@@ -24,6 +24,10 @@ import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.gui.playlist.Editor;
 import io.github.dsheirer.icon.Icon;
 import io.github.dsheirer.playlist.PlaylistManager;
+import javafx.application.Platform;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.transformation.SortedList;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -60,6 +64,9 @@ public class AliasBulkEditor extends Editor<List<Alias>>
     private ToggleSwitch mMonitorAudioToggleSwitch;
     private ComboBox<Integer> mMonitorPriorityComboBox;
     private Button mApplyMonitorButton;
+    
+    private BooleanProperty mChangeInProgressProperty;
+    private ReadOnlyBooleanProperty mChangeInProgressROProperty;
 
     /**
      * Constructs an instance
@@ -68,6 +75,8 @@ public class AliasBulkEditor extends Editor<List<Alias>>
     public AliasBulkEditor(PlaylistManager playlistManager)
     {
         mPlaylistManager = playlistManager;
+        
+        mChangeInProgressProperty = new SimpleBooleanProperty();
 
         GridPane gridPane = new GridPane();
         gridPane.setPadding(new Insets(10,10,10,10));
@@ -160,6 +169,29 @@ public class AliasBulkEditor extends Editor<List<Alias>>
     {
         //no-op
     }
+    
+    /**
+     * Property indicating whether a bulk change is in progress.  Bulk changes may cause drastic
+     * slow downs in some UI components.  
+     * @return changeInProgressProperty
+     */
+    public ReadOnlyBooleanProperty changeInProgressProperty()
+    {
+    	if(mChangeInProgressROProperty == null)
+    		mChangeInProgressROProperty = BooleanProperty.readOnlyBooleanProperty(mChangeInProgressProperty);
+    	
+    	return mChangeInProgressROProperty;
+    }
+    
+    private void startChange()
+    {
+    	mChangeInProgressProperty.set(true);
+    }
+    
+    private void endChange()
+    {
+    	mChangeInProgressProperty.set(false);
+    }
 
     private Label getEditingLabel()
     {
@@ -189,12 +221,16 @@ public class AliasBulkEditor extends Editor<List<Alias>>
         {
             mApplyColorButton = new Button("Apply");
             mApplyColorButton.setOnAction(event -> {
+            	startChange();
+            	
                 int colorValue = ColorUtil.toInteger(getColorPicker().getValue());
 
                 for(Alias alias: getItem())
                 {
                     alias.setColor(colorValue);
                 }
+                
+                endChange();
             });
         }
 
@@ -207,10 +243,14 @@ public class AliasBulkEditor extends Editor<List<Alias>>
         {
             mResetColorButton = new Button("Reset Color");
             mResetColorButton.setOnAction(event -> {
+            	startChange();
+            	
                 for(Alias alias: getItem())
                 {
                     alias.setColor(0);
                 }
+                
+                endChange();
             });
         }
 
@@ -246,6 +286,8 @@ public class AliasBulkEditor extends Editor<List<Alias>>
                 @Override
                 public void handle(ActionEvent event)
                 {
+                	startChange();
+                	
                     Icon icon = getIconNodeComboBox().getSelectionModel().getSelectedItem();
 
                     if(icon != null)
@@ -255,6 +297,8 @@ public class AliasBulkEditor extends Editor<List<Alias>>
                             alias.setIconName(icon.getName());
                         }
                     }
+                    
+                    endChange();
                 }
             });
         }
@@ -295,6 +339,7 @@ public class AliasBulkEditor extends Editor<List<Alias>>
         return mMonitorPriorityComboBox;
     }
 
+    private static int setCount = 0;
     private Button getApplyMonitorButton()
     {
         if(mApplyMonitorButton == null)
@@ -305,6 +350,8 @@ public class AliasBulkEditor extends Editor<List<Alias>>
                 @Override
                 public void handle(ActionEvent event)
                 {
+                	startChange();
+                	
                     boolean canMonitor = getMonitorAudioToggleSwitch().isSelected();
                     Integer priority = getMonitorPriorityComboBox().getSelectionModel().getSelectedItem();
                     if(canMonitor)
@@ -318,11 +365,15 @@ public class AliasBulkEditor extends Editor<List<Alias>>
                     {
                         priority = io.github.dsheirer.alias.id.priority.Priority.DO_NOT_MONITOR;
                     }
-
+                    
+                    final Integer pri = priority;
                     for(Alias alias: getItem())
                     {
-                        alias.setCallPriority(priority);
+                    	alias.setCallPriority(pri);
+                    	//System.out.println(++setCount);
                     }
+                    
+                    endChange();
                 }
             });
         }

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasConfigurationEditor.java
@@ -32,7 +32,13 @@ import io.github.dsheirer.icon.Icon;
 import io.github.dsheirer.playlist.PlaylistManager;
 import io.github.dsheirer.preference.UserPreferences;
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.ObjectBinding;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.transformation.FilteredList;
@@ -73,6 +79,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -445,6 +452,19 @@ public class AliasConfigurationEditor extends SplitPane
         {
             mAliasSortedList = new SortedList<>(getAliasFilteredList());
             mAliasSortedList.comparatorProperty().bind(getAliasTableView().comparatorProperty());
+            
+            //Don't re-sort while the bulk editor is still applying changes to aliases
+            getAliasBulkEditor().changeInProgressProperty().addListener((observable, oldValue, newValue) -> {
+            	if(newValue)
+            	{
+            		mAliasSortedList.comparatorProperty().unbind();
+            		mAliasSortedList.setComparator(null);
+            	}
+            	else
+            	{
+            		mAliasSortedList.comparatorProperty().bind(getAliasTableView().comparatorProperty());
+            	}
+            });
         }
 
         return mAliasSortedList;

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasConfigurationEditor.java
@@ -22,6 +22,15 @@
 
 package io.github.dsheirer.gui.playlist.alias;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.controlsfx.control.textfield.TextFields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasFactory;
 import io.github.dsheirer.alias.AliasList;
@@ -32,13 +41,7 @@ import io.github.dsheirer.icon.Icon;
 import io.github.dsheirer.playlist.PlaylistManager;
 import io.github.dsheirer.preference.UserPreferences;
 import javafx.application.Platform;
-import javafx.beans.binding.Bindings;
-import javafx.beans.binding.ObjectBinding;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.transformation.FilteredList;
@@ -74,15 +77,6 @@ import javafx.util.Callback;
 import jiconfont.IconCode;
 import jiconfont.icons.font_awesome.FontAwesome;
 import jiconfont.javafx.IconNode;
-import org.controlsfx.control.textfield.TextFields;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 /**
  * Editor for aliases


### PR DESCRIPTION
When the user has selected a column to sort by on the TableView in the Alias editor, the table's backing SortedList will resort every time an ObservableProperty of an Alias is modified.  This can cause the UI to lock up for minutes at a time if many Aliases are modified at once using the AliasBulkEditor.

This change works around this issue by simply resetting the SortedList's ComparatorProperty while the AliasBulkEditor is applying changes, and rebinding it back to the TableView's ComparatorProperty once AliasBulkEditor has finished.

This change seems a bit hacky to me but it's the cleanest thing I could come up with.  I couldn't find a way to set a property's value to null via a binding, so unbinding and rebinding had to do.  I hope that I'm missing a simple solution to this problem because this isn't the only instance of UI updates slowing stuff down when many changes are being made at once, and manually pausing slow elements while changes are made is annoying and a maintenance nightmare.  Regardless, in the meantime this change makes the Alias editor a lot more usable and it is easily reversible should a better solution be proposed later.