### PR TITLE
Properly format and safely escape to CSV in DecodeEventLogger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:3.8.0'
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
+    testImplementation 'org.mockito:mockito-core:3.+'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     //Jitpack imports

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.7'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
     implementation 'org.apache.commons:commons-math3:3.6.1'
+    implementation 'org.apache.commons:commons-text:1.9'
     implementation 'org.apache.mina:mina-core:2.1.3'
     implementation 'org.apache.mina:mina-http:2.1.3'
     implementation 'org.controlsfx:controlsfx:11.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.7'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
     implementation 'org.apache.commons:commons-math3:3.6.1'
-    implementation 'org.apache.commons:commons-text:1.9'
+    implementation 'org.apache.commons:commons-csv:1.9.0'
     implementation 'org.apache.mina:mina-core:2.1.3'
     implementation 'org.apache.mina:mina-http:2.1.3'
     implementation 'org.controlsfx:controlsfx:11.0.2'

--- a/src/main/java/io/github/dsheirer/module/log/DecodeEventLogger.java
+++ b/src/main/java/io/github/dsheirer/module/log/DecodeEventLogger.java
@@ -99,9 +99,11 @@ public class DecodeEventLogger extends EventLogger implements IDecodeEventListen
         List<Object> cells = new ArrayList<>();
 
         cells.add(mTimestampFormat.format(new Date(event.getTimeStart())));
-        cells.add(event.getDuration() > 0 ? event.getDuration() : null);
+        cells.add(event.getDuration() > 0 ? event.getDuration() : "");
         cells.add(event.getProtocol());
-        cells.add(event.getEventDescription());
+
+        String description = event.getEventDescription();
+        cells.add(description != null ? description : "");
 
         List<Identifier> fromIdentifiers = event.getIdentifierCollection().getIdentifiers(Role.FROM);
         if(fromIdentifiers != null && !fromIdentifiers.isEmpty())
@@ -110,7 +112,7 @@ public class DecodeEventLogger extends EventLogger implements IDecodeEventListen
         }
         else
         {
-            cells.add(null);
+            cells.add("");
         }
 
         List<Identifier> toIdentifiers = event.getIdentifierCollection().getIdentifiers(Role.TO);
@@ -129,15 +131,16 @@ public class DecodeEventLogger extends EventLogger implements IDecodeEventListen
             }
             else
             {
-                cells.add(null);
+                cells.add("");
             }
         }
         else
         {
-            cells.add(null);
+            cells.add("");
         }
 
-        cells.add(event.getChannelDescriptor());
+        IChannelDescriptor descriptor = event.getChannelDescriptor();
+        cells.add(descriptor != null ? descriptor : "");
 
         Identifier frequency = event.getIdentifierCollection()
             .getIdentifier(IdentifierClass.CONFIGURATION, Form.CHANNEL_FREQUENCY, Role.ANY);
@@ -150,7 +153,7 @@ public class DecodeEventLogger extends EventLogger implements IDecodeEventListen
         }
         else
         {
-            cells.add(null);
+            cells.add("");
         }
 
         if(event.hasTimeslot())
@@ -159,7 +162,7 @@ public class DecodeEventLogger extends EventLogger implements IDecodeEventListen
         }
         else
         {
-            cells.add(null);
+            cells.add("");
         }
 
         String details = event.getDetails();

--- a/src/main/java/io/github/dsheirer/module/log/DecodeEventLogger.java
+++ b/src/main/java/io/github/dsheirer/module/log/DecodeEventLogger.java
@@ -147,7 +147,7 @@ public class DecodeEventLogger extends EventLogger implements IDecodeEventListen
 
         if(event.hasTimeslot())
         {
-            sb.append(",\"TS:").append(event.getTimeslot());
+            sb.append(",\"TS:").append(event.getTimeslot()).append("\"");
         }
         else
         {

--- a/src/test/java/io/github/dsheirer/module/log/DecodeEventLoggerTest.java
+++ b/src/test/java/io/github/dsheirer/module/log/DecodeEventLoggerTest.java
@@ -84,9 +84,9 @@ class DecodeEventLoggerTest {
     }
 
     @Test
-    void test_receive_withQuotesAndCommasInDetails_writesToCsv() {
+    void test_receive_withQuotesInDetails_writesToCsv() {
         IDecodeEvent decodeEvent = decodeEventBuilder()
-                .details("Some details now with \"quotes\" and, to an extent, commas!")
+                .details("Some details now with \"quotes\"!")
                 .build();
 
         DecodeEventLogger decodeEventLogger = new DecodeEventLogger(aliasModel, logDirectory, "_foo.txt", 859562500);
@@ -97,7 +97,25 @@ class DecodeEventLoggerTest {
         spy.receive(decodeEvent);
 
         String expectedToCsvString =
-                "\"2021:10:16:20:03:14\",\"111\",\"APCO-25\",\"DATA_PACKET\",\"123\",\" (456)\",\"98765-1\",\"859.562500\",\"TS:2\",\"Some details\"";
+                "\"2021:10:16:20:03:14\",\"111\",\"APCO-25\",\"DATA_PACKET\",\"123\",\" (456)\",\"98765-1\",\"859.562500\",\"TS:2\",\"Some details now with \"\"quotes\"\"!\"";
+        verify(spy).write(expectedToCsvString);
+    }
+
+    @Test
+    void test_receive_withCommasInDetails_writesToCsv() {
+        IDecodeEvent decodeEvent = decodeEventBuilder()
+                .details("Some details now with, to an extent, commas!")
+                .build();
+
+        DecodeEventLogger decodeEventLogger = new DecodeEventLogger(aliasModel, logDirectory, "_foo.txt", 859562500);
+        DecodeEventLogger spy = spy(decodeEventLogger);
+
+        doNothing().when(spy).write(anyString());
+
+        spy.receive(decodeEvent);
+
+        String expectedToCsvString =
+                "\"2021:10:16:20:03:14\",\"111\",\"APCO-25\",\"DATA_PACKET\",\"123\",\" (456)\",\"98765-1\",\"859.562500\",\"TS:2\",\"Some details now with, to an extent, commas!\"";
         verify(spy).write(expectedToCsvString);
     }
 }

--- a/src/test/java/io/github/dsheirer/module/log/DecodeEventLoggerTest.java
+++ b/src/test/java/io/github/dsheirer/module/log/DecodeEventLoggerTest.java
@@ -26,46 +26,68 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class DecodeEventLoggerTest {
+    IChannelDescriptor channelDescriptor = APCO25Channel.create(98765, 1);
+
+    APCO25Talkgroup fromIdentifier = new APCO25Talkgroup(123, Role.FROM);
+    APCO25Talkgroup toIdentifier = new APCO25Talkgroup(456, Role.TO);
+    FrequencyConfigurationIdentifier freqIdentifier = new FrequencyConfigurationIdentifier(859562500L);
+    DecoderTypeConfigurationIdentifier decoderIdentifier = new DecoderTypeConfigurationIdentifier(DecoderType.P25_PHASE1);
+    AliasListConfigurationIdentifier aliasListIdentifier = new AliasListConfigurationIdentifier("My Alias List");
+    AliasModel aliasModel = new AliasModel();
+
+    Path logDirectory = Paths.get(System.getProperty("java.io.tmpdir"), "sdr_trunk_tests");
 
     @BeforeEach
     void setUp() {
+        aliasModel.addAliasList(aliasListIdentifier.getValue());
     }
 
     @AfterEach
     void tearDown() {
     }
 
-    @Test
-    void test_receive_writesToCsv() {
-        IChannelDescriptor channelDescriptor = APCO25Channel.create(98765, 1);
-
-        APCO25Talkgroup fromIdentifier = new APCO25Talkgroup(123, Role.FROM);
-        APCO25Talkgroup toIdentifier = new APCO25Talkgroup(456, Role.TO);
-        FrequencyConfigurationIdentifier freqIdentifier = new FrequencyConfigurationIdentifier(859562500L);
-        DecoderTypeConfigurationIdentifier decoderIdentifier = new DecoderTypeConfigurationIdentifier(DecoderType.P25_PHASE1);
-        AliasListConfigurationIdentifier aliasListIdentifier = new AliasListConfigurationIdentifier("My Alias List");
-        IdentifierCollection identifierCollection = new IdentifierCollection(Arrays.asList(
+    IdentifierCollection buildIdentifierCollection() {
+        return new IdentifierCollection(Arrays.asList(
                 fromIdentifier,
                 toIdentifier,
                 decoderIdentifier,
                 freqIdentifier,
                 aliasListIdentifier
         ));
+    }
 
-        IDecodeEvent decodeEvent = DecodeEvent.builder(1634428994000L)
+    DecodeEvent.DecodeEventBuilder decodeEventBuilder() {
+        return DecodeEvent.builder(1634428994000L)
                 .channel(channelDescriptor)
-                .identifiers(identifierCollection)
+                .identifiers(buildIdentifierCollection())
                 .duration(111)
                 .protocol(Protocol.APCO25)
                 .eventDescription("DATA_PACKET")
                 .timeslot(2)
-                .details("Some details")
+                .details("Some details");
+    }
+
+    @Test
+    void test_receive_writesToCsv() {
+        IDecodeEvent decodeEvent = decodeEventBuilder().build();
+
+        DecodeEventLogger decodeEventLogger = new DecodeEventLogger(aliasModel, logDirectory, "_foo.txt", 859562500);
+        DecodeEventLogger spy = spy(decodeEventLogger);
+
+        doNothing().when(spy).write(anyString());
+
+        spy.receive(decodeEvent);
+
+        String expectedToCsvString =
+                "\"2021:10:16:20:03:14\",\"111\",\"APCO-25\",\"DATA_PACKET\",\"123\",\" (456)\",\"98765-1\",\"859.562500\",\"TS:2\",\"Some details\"";
+        verify(spy).write(expectedToCsvString);
+    }
+
+    @Test
+    void test_receive_withQuotesAndCommasInDetails_writesToCsv() {
+        IDecodeEvent decodeEvent = decodeEventBuilder()
+                .details("Some details now with \"quotes\" and, to an extent, commas!")
                 .build();
-
-        AliasModel aliasModel = new AliasModel();
-        aliasModel.addAliasList(aliasListIdentifier.getValue());
-
-        Path logDirectory = Paths.get(System.getProperty("java.io.tmpdir"), "sdr_trunk_tests");
 
         DecodeEventLogger decodeEventLogger = new DecodeEventLogger(aliasModel, logDirectory, "_foo.txt", 859562500);
         DecodeEventLogger spy = spy(decodeEventLogger);


### PR DESCRIPTION
Fixes #1038.

Hand-crafting a serialized format will always be a losing proposition. Brings in Apache's Commons CSV to provide a bulletproof CSV-formatted string to be written into the log. This has an additional benefit of making aliases and details safe to use quotes and commas (as well as other "reserved" CSV characters). 

To preserve the existing behaviour of SDR Trunk's CSV logging, every value/cell is wrapped in quotes, even if it isn't explicitly needed.

Adds tests to ensure the strings are as we expect.