### PR TITLE
1122 Adjacent Channel Signal Impacts NBFM Squelch Performance

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelSource.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelSource.java
@@ -1,7 +1,6 @@
 /*
- * ******************************************************************************
- * sdrtrunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- * *****************************************************************************
+ * ****************************************************************************
  */
 package io.github.dsheirer.dsp.filter.channelizer;
 
@@ -40,6 +39,7 @@ public class PolyphaseChannelSource extends TunerChannelSource
 {
 //    private final static Logger mLog = LoggerFactory.getLogger(PolyphaseChannelSource.class);
 
+    private static final int PROCESSED_BUFFER_SAMPLE_SIZE = 2048;
     private ReusableComplexBufferAssembler mReusableComplexBufferAssembler;
     private IPolyphaseChannelOutputProcessor mPolyphaseChannelOutputProcessor;
     private IPolyphaseChannelOutputProcessor mReplacementPolyphaseChannelOutputProcessor;
@@ -71,7 +71,7 @@ public class PolyphaseChannelSource extends TunerChannelSource
         super(producerSourceEventListener, tunerChannel);
         mPolyphaseChannelOutputProcessor = outputProcessor;
         mChannelSampleRate = channelSampleRate;
-        mReusableComplexBufferAssembler = new ReusableComplexBufferAssembler(2500, mChannelSampleRate);
+        mReusableComplexBufferAssembler = new ReusableComplexBufferAssembler(PROCESSED_BUFFER_SAMPLE_SIZE, mChannelSampleRate);
 
         float[] filterCoefficients = getLowPassFilter(channelSampleRate, channelSpecification.getPassFrequency(),
             channelSpecification.getStopFrequency());

--- a/src/main/java/io/github/dsheirer/dsp/filter/decimate/ComplexDecimateX0Filter.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/decimate/ComplexDecimateX0Filter.java
@@ -22,21 +22,19 @@ package io.github.dsheirer.dsp.filter.decimate;
 import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
 
 /**
- * Interface for a decimation filter for float array sample buffers
+ * No decimation filter.
  */
-public interface IComplexDecimationFilter
+public class ComplexDecimateX0Filter implements IComplexDecimationFilter
 {
-    /**
-     * Decimates an array of float complex samples
-     * @param samples to decimate
-     * @return decimated samples
-     */
-    float[] decimateComplex(float[] samples);
+    @Override
+    public float[] decimateComplex(float[] samples)
+    {
+        return samples;
+    }
 
-    /**
-     * Decimates an buffer of float complex samples
-     * @param buffer to decimate
-     * @return decimated samples
-     */
-    ReusableComplexBuffer decimate(ReusableComplexBuffer buffer);
+    @Override
+    public ReusableComplexBuffer decimate(ReusableComplexBuffer buffer)
+    {
+        return buffer;
+    }
 }

--- a/src/main/java/io/github/dsheirer/dsp/filter/decimate/DecimationFilterFactory.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/decimate/DecimationFilterFactory.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2021 Dennis Sheirer
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@ package io.github.dsheirer.dsp.filter.decimate;
  */
 public class DecimationFilterFactory
 {
-    private static final int[] SUPPORTED_RATES = new int[]{2,4,8,16,32,64,128,256,512,1024};
+    private static final int[] SUPPORTED_RATES = new int[]{0,2,4,8,16,32,64,128,256,512,1024};
 
     /**
      * Creates a real-valued decimation filter for float array sample buffers providing greater than 100 dB of
@@ -37,6 +37,8 @@ public class DecimationFilterFactory
     {
         switch(decimationRate)
         {
+            case 0:
+                return new RealDecimateX0Filter();
             case 2:
                 return new RealDecimateX2Filter();
             case 4:
@@ -74,6 +76,8 @@ public class DecimationFilterFactory
     {
         switch(decimationRate)
         {
+            case 0:
+                return new ComplexDecimateX0Filter();
             case 2:
                 return new ComplexDecimateX2Filter();
             case 4:

--- a/src/main/java/io/github/dsheirer/dsp/filter/decimate/RealDecimateX0Filter.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/decimate/RealDecimateX0Filter.java
@@ -19,24 +19,14 @@
 
 package io.github.dsheirer.dsp.filter.decimate;
 
-import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
-
 /**
- * Interface for a decimation filter for float array sample buffers
+ * No decimation filter.
  */
-public interface IComplexDecimationFilter
+public class RealDecimateX0Filter implements IRealDecimationFilter
 {
-    /**
-     * Decimates an array of float complex samples
-     * @param samples to decimate
-     * @return decimated samples
-     */
-    float[] decimateComplex(float[] samples);
-
-    /**
-     * Decimates an buffer of float complex samples
-     * @param buffer to decimate
-     * @return decimated samples
-     */
-    ReusableComplexBuffer decimate(ReusableComplexBuffer buffer);
+    @Override
+    public float[] decimateReal(float[] samples)
+    {
+        return samples;
+    }
 }

--- a/src/main/java/io/github/dsheirer/dsp/filter/halfband/complex/ComplexHalfBandDecimationFilter.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/halfband/complex/ComplexHalfBandDecimationFilter.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2021 Dennis Sheirer
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +20,8 @@
 package io.github.dsheirer.dsp.filter.halfband.complex;
 
 import io.github.dsheirer.dsp.filter.decimate.IComplexDecimationFilter;
+import io.github.dsheirer.sample.buffer.ReusableComplexBuffer;
+import io.github.dsheirer.sample.buffer.ReusableComplexBufferQueue;
 
 /**
  * Complex half-band filter that processes samples on a per-array basis, versus a per-sample basis.
@@ -35,6 +37,7 @@ public class ComplexHalfBandDecimationFilter implements IComplexDecimationFilter
     private int mCoefficientsLengthMinus2;
     private int mBufferPointer;
     private int mHalf;
+    private ReusableComplexBufferQueue mReusableComplexBufferQueue = new ReusableComplexBufferQueue("half-band decimation filter");
 
     /**
      * Constructs a complex sample half-band decimate x2 filter using the specified filter coefficients.
@@ -117,5 +120,18 @@ public class ComplexHalfBandDecimationFilter implements IComplexDecimationFilter
         }
 
         return filtered;
+    }
+
+    /**
+     * Decimates the complex samples and returns a buffer of decimated samples.
+     * @param buffer to decimate
+     * @return decimated buffer.
+     */
+    @Override
+    public ReusableComplexBuffer decimate(ReusableComplexBuffer buffer)
+    {
+        float[] decimated = decimateComplex(buffer.getSamples());
+        buffer.decrementUserCount();
+        return mReusableComplexBufferQueue.getBuffer(decimated, buffer.getTimestamp());
     }
 }

--- a/src/main/java/io/github/dsheirer/sample/buffer/AbstractReusableBufferQueue.java
+++ b/src/main/java/io/github/dsheirer/sample/buffer/AbstractReusableBufferQueue.java
@@ -1,18 +1,21 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
 package io.github.dsheirer.sample.buffer;
 
 import org.slf4j.Logger;
@@ -48,6 +51,14 @@ public abstract class AbstractReusableBufferQueue<T extends AbstractReusableBuff
      */
     public AbstractReusableBufferQueue()
     {
+    }
+
+    /**
+     * Turns on/off logging of buffer creation
+     */
+    public void setDebugLogging(boolean enabled)
+    {
+        mBufferCreationLoggingEnabled = enabled;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/sample/buffer/ReusableComplexBufferQueue.java
+++ b/src/main/java/io/github/dsheirer/sample/buffer/ReusableComplexBufferQueue.java
@@ -1,18 +1,21 @@
-/*******************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2018 Dennis Sheirer
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
 package io.github.dsheirer.sample.buffer;
 
 import org.slf4j.Logger;
@@ -57,6 +60,33 @@ public class ReusableComplexBufferQueue extends AbstractReusableBufferQueue<Reus
         }
 
         buffer.resize(size);
+        buffer.incrementUserCount();
+
+        return buffer;
+    }
+
+    /**
+     * Returns a buffer loaded with the samples.
+     * @param samples to load
+     * @param timestamp to apply
+     * @return buffer
+     */
+    public ReusableComplexBuffer getBuffer(float[] samples, long timestamp)
+    {
+        ReusableComplexBuffer buffer = getRecycledBuffer();
+
+        if(buffer == null)
+        {
+            buffer = new ReusableComplexBuffer(this, samples);
+            buffer.setTimestamp(timestamp);
+            buffer.setDebugName("Owner:" + getDebugName());
+            incrementBufferCount();
+        }
+        else
+        {
+            buffer.reloadFrom(samples, timestamp);
+        }
+
         buffer.incrementUserCount();
 
         return buffer;


### PR DESCRIPTION
Resolves #1122.  Adds decimation to NBFMDecoder so that channel bandwidth is reduced to min sample rate needed.  This reduces the impact on channel power measurement from adjacent channels.