### PR TITLE
#1152 Broadcastify Calls - Patch Groups Not Formatted Correctly

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/broadcastify/BroadcastifyCallBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/broadcastify/BroadcastifyCallBroadcaster.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- *  Copyright (C) 2014-2020 Dennis Sheirer
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -417,36 +417,46 @@ public class BroadcastifyCallBroadcaster extends AbstractAudioBroadcaster<Broadc
     {
         List<Identifier> toIdentifiers = audioRecording.getIdentifierCollection().getIdentifiers(Role.TO);
 
-        if(toIdentifiers.size() >= 1)
+        //Format a patch group first, if there are multiples
+        for(Identifier identifier: toIdentifiers)
         {
-            Identifier to = toIdentifiers.get(0);
-
-            if(to instanceof TalkgroupIdentifier)
+            if(identifier instanceof PatchGroupIdentifier patchGroupIdentifier)
             {
-                TalkgroupIdentifier talkgroupIdentifier = (TalkgroupIdentifier)to;
+                return format(patchGroupIdentifier);
+            }
+        }
+
+        for(Identifier identifier: toIdentifiers)
+        {
+            if(identifier instanceof TalkgroupIdentifier talkgroupIdentifier)
+            {
                 return String.valueOf(RadioReferenceDecoder.convertToRadioReferenceTalkgroup(talkgroupIdentifier.getValue(),
-                    talkgroupIdentifier.getProtocol()));
+                        talkgroupIdentifier.getProtocol()));
             }
-            else if(to instanceof PatchGroupIdentifier)
+            else if(identifier instanceof RadioIdentifier radioIdentifier)
             {
-                PatchGroup patchGroup = ((PatchGroupIdentifier)to).getValue();
-
-                StringBuilder sb = new StringBuilder();
-                sb.append(patchGroup.getPatchGroup().getValue().toString());
-                for(TalkgroupIdentifier patched: patchGroup.getPatchedGroupIdentifiers())
-                {
-                    sb.append(",").append(patched.getValue());
-                }
-
-                return sb.toString();
-            }
-            else if(to instanceof RadioIdentifier)
-            {
-                return ((RadioIdentifier)to).getValue().toString();
+                return radioIdentifier.getValue().toString();
             }
         }
 
         return "0";
+    }
+
+    /**
+     * Formats a patch group
+     */
+    public static String format(PatchGroupIdentifier patchGroupIdentifier)
+    {
+        PatchGroup patchGroup = patchGroupIdentifier.getValue();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(patchGroup.getPatchGroup().getValue().toString());
+        for(TalkgroupIdentifier patched: patchGroup.getPatchedGroupIdentifiers())
+        {
+            sb.append(",").append(patched.getValue());
+        }
+
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/identifier/patch/PatchGroupManager.java
+++ b/src/main/java/io/github/dsheirer/identifier/patch/PatchGroupManager.java
@@ -1,7 +1,6 @@
 /*
- * ******************************************************************************
- * sdrtrunk
- * Copyright (C) 2014-2019 Dennis Sheirer
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- * *****************************************************************************
+ * ****************************************************************************
  */
 
 package io.github.dsheirer.identifier.patch;
@@ -46,8 +45,20 @@ public class PatchGroupManager
     private Map<Integer,Long> mPatchGroupLastUpdatedMap = new HashMap<>();
     private Map<Integer,PatchGroupIdentifier> mPatchGroupMap = new HashMap<>();
 
+    /**
+     * Constructs an instance
+     */
     public PatchGroupManager()
     {
+    }
+
+    /**
+     * Clears any existing patch groups
+     */
+    public void clear()
+    {
+        mPatchGroupMap.clear();
+        mPatchGroupLastUpdatedMap.clear();
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/identifier/patch/PatchGroupPreLoadDataContent.java
+++ b/src/main/java/io/github/dsheirer/identifier/patch/PatchGroupPreLoadDataContent.java
@@ -1,0 +1,39 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.identifier.patch;
+
+import io.github.dsheirer.controller.channel.event.PreloadDataContent;
+import io.github.dsheirer.identifier.IdentifierCollection;
+
+/**
+ * Preload patch group data content carrying the current list of identifiers in an identifier collection.
+ */
+public class PatchGroupPreLoadDataContent extends PreloadDataContent<IdentifierCollection>
+{
+    /**
+     * Constructs an instance
+     *
+     * @param data to preload
+     */
+    public PatchGroupPreLoadDataContent(IdentifierCollection data)
+    {
+        super(data);
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -1,23 +1,20 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 package io.github.dsheirer.module.decode.p25;
 
@@ -32,6 +29,7 @@ import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.identifier.IdentifierCollection;
 import io.github.dsheirer.identifier.MutableIdentifierCollection;
 import io.github.dsheirer.identifier.Role;
+import io.github.dsheirer.identifier.patch.PatchGroupPreLoadDataContent;
 import io.github.dsheirer.identifier.scramble.ScrambleParameterIdentifier;
 import io.github.dsheirer.message.IMessage;
 import io.github.dsheirer.message.IMessageListener;
@@ -315,7 +313,11 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
                     sourceConfig.setFrequency(frequency);
                     trafficChannel.setSourceConfiguration(sourceConfig);
                     mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
-                    getInterModuleEventBus().post(new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection));
+
+                    ChannelStartProcessingRequest startChannelRequest =
+                            new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection);
+                    startChannelRequest.addPreloadDataContent(new PatchGroupPreLoadDataContent(identifierCollection));
+                    getInterModuleEventBus().post(startChannelRequest);
                 }
             }
 
@@ -361,7 +363,11 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
             sourceConfig.setFrequency(frequency);
             trafficChannel.setSourceConfiguration(sourceConfig);
             mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
-            getInterModuleEventBus().post(new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection));
+
+            ChannelStartProcessingRequest startChannelRequest =
+                    new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection);
+            startChannelRequest.addPreloadDataContent(new PatchGroupPreLoadDataContent(identifierCollection));
+            getInterModuleEventBus().post(startChannelRequest);
         }
 
         broadcast(channelGrantEvent);
@@ -465,7 +471,10 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
                         decodeConfig.setScrambleParameters(mPhase2ScrambleParameters.copy());
                     }
 
-                    getInterModuleEventBus().post(new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection));
+                    ChannelStartProcessingRequest startChannelRequest =
+                            new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection);
+                    startChannelRequest.addPreloadDataContent(new PatchGroupPreLoadDataContent(identifierCollection));
+                    getInterModuleEventBus().post(startChannelRequest);
                 }
             }
 
@@ -519,7 +528,11 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
             sourceConfig.setFrequency(frequency);
             trafficChannel.setSourceConfiguration(sourceConfig);
             mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
-            getInterModuleEventBus().post(new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection));
+
+            ChannelStartProcessingRequest startChannelRequest =
+                    new ChannelStartProcessingRequest(trafficChannel, apco25Channel, identifierCollection);
+            startChannelRequest.addPreloadDataContent(new PatchGroupPreLoadDataContent(identifierCollection));
+            getInterModuleEventBus().post(startChannelRequest);
         }
 
         broadcast(channelGrantEvent);

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
@@ -1,26 +1,24 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 package io.github.dsheirer.module.decode.p25.phase2;
 
+import com.google.common.eventbus.Subscribe;
 import io.github.dsheirer.channel.IChannelDescriptor;
 import io.github.dsheirer.channel.state.ChangeChannelTimeoutEvent;
 import io.github.dsheirer.channel.state.DecoderStateEvent;
@@ -36,7 +34,9 @@ import io.github.dsheirer.identifier.IdentifierUpdateListener;
 import io.github.dsheirer.identifier.MutableIdentifierCollection;
 import io.github.dsheirer.identifier.Role;
 import io.github.dsheirer.identifier.encryption.EncryptionKey;
+import io.github.dsheirer.identifier.patch.PatchGroupIdentifier;
 import io.github.dsheirer.identifier.patch.PatchGroupManager;
+import io.github.dsheirer.identifier.patch.PatchGroupPreLoadDataContent;
 import io.github.dsheirer.message.IMessage;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.event.DecodeEvent;
@@ -143,6 +143,22 @@ public class P25P2DecoderState extends TimeslotDecoderState implements Identifie
         super.resetState();
         closeCurrentCallEvent(System.currentTimeMillis(), true, MacPduType.MAC_3_IDLE);
         mEndPttOnFacchCounter = 0;
+    }
+
+    /**
+     * Processes an identifier collection to harvest Patch Groups to preload when this channel is first starting up.
+     * @param preLoadDataContent containing an identifier collection with optional patch group identifier(s).
+     */
+    @Subscribe
+    public void process(PatchGroupPreLoadDataContent preLoadDataContent)
+    {
+        for(Identifier identifier: preLoadDataContent.getData().getIdentifiers(Role.TO))
+        {
+            if(identifier instanceof PatchGroupIdentifier patchGroupIdentifier)
+            {
+                mPatchGroupManager.addPatchGroup(patchGroupIdentifier);
+            }
+        }
     }
 
     /**
@@ -1242,6 +1258,8 @@ public class P25P2DecoderState extends TimeslotDecoderState implements Identifie
     @Override
     public void start()
     {
+        mPatchGroupManager.clear();
+
         //Change the default (45-second) traffic channel timeout to 1 second
         if(mChannelType == ChannelType.TRAFFIC)
         {
@@ -1257,5 +1275,6 @@ public class P25P2DecoderState extends TimeslotDecoderState implements Identifie
     @Override
     public void stop()
     {
+        mPatchGroupManager.clear();
     }
 }


### PR DESCRIPTION
Closes #1152 

Resolves issue where patch groups were not being properly formatted when uploading to broadcastify calls api.

Identified issue where the patch group manager for the control channel had the correct patch group details, but was not passing the patch group to the traffic channel on startup, so any call audio generated on the traffic channel had a good chance that it was missing the patch group details.