### PR TITLE
Mac/OSX M1 aarch64 Native Library for libusb/usb4java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     implementation 'org.usb4java:libusb4java:1.3.0'
     implementation 'org.usb4java:usb4java:1.3.0'
     implementation 'org.usb4java:usb4java-javax:1.3.0'
+    implementation 'io.github.dsheirer:libusb4java-darwin-aarch64:1.3.0' //usb4java native lib for OSX M1 cpu
     implementation 'pl.edu.icm:JLargeArrays:1.6'
 }
 
@@ -125,69 +126,83 @@ idea {
 }
 
 /**
- * Java Development Kit (JDK) locations.  In order to build OS-specific images, these paths must point to the parent
- * directory containing the 'bin' directory within a JDK for each of the specified architectures.  These JDKs are used
- * by the runtime and runtimeZip tasks to produce platform-specific builds.  If none of these paths exists, then an
- * image will be created for the host OS using the installed JDK.
+ * Java Development Kit (JDK) for each target platform can either be used from a local copy, or downloaded from a
+ * JDK vendor.  These locations are relative to the author's development workstation.
  */
 def jdk_base = '/home/denny/java_jdks/'
-
-def jdk_linux_arm64 = jdk_base + 'linux-arm64/jdk-17.0.2-full'
-def jdk_linux_x86_64 = jdk_base + 'linux-x64/jdk-17.0.2-full'
-def jdk_osx_x86_64 = jdk_base + 'osx-x64/jdk-17.0.2-full.jdk'
-def jdk_windows_x86_64 = jdk_base + 'windows-x64/jdk-17.0.2-full'
-
-def hasTargetJdk = file(jdk_linux_x86_64).exists() ||
-        file(jdk_linux_arm64).exists() ||
-        file(jdk_osx_x86_64).exists() ||
-        file(jdk_windows_x86_64).exists()
+def jdk_linux_aarch64 = file(jdk_base + 'linux-arm64/jdk-17.0.2-full')
+def jdk_linux_x86_64 = file(jdk_base + 'linux-x64/jdk-17.0.2-full')
+def jdk_osx_x86_64 = file(jdk_base + 'osx-x64/jdk-17.0.2-full.jdk')
+def jdk_osx_aarch64 = file(jdk_base + 'osx-arm64/jdk-17.0.2-full.jdk')
+def jdk_windows_x86_64 = file(jdk_base + 'windows-x64/jdk-17.0.2-full')
+def hasTargetJdk = jdk_linux_x86_64.exists() || jdk_linux_aarch64.exists() || jdk_osx_x86_64.exists() ||
+        jdk_osx_aarch64.exists() || jdk_windows_x86_64.exists()
 
 /**
- * Beryx Runtime plugin - adds operating system specific runtime build targets when the OS-specific JDK is
- * found on the local file system.  The runtime plugin enables you to optionally download these files,
- * however I normally have them installed locally and use those versions.
+ * Beryx Runtime plugin - adds operating system specific runtime build targets using either an OS-specific JDK
+ * found on the local file system or it downloads the JDK from the specified URLs.
+ *
+ * usage: gradle runtimeZip
  */
 runtime {
-    if(file(jdk_linux_arm64).exists())
-    {
-        targetPlatform('linux-arm64-v' + version, jdk_linux_arm64)
-    }
-    else
-    {
-        println("Skipping OS Image - Linux ARM 64-bit JDK was not found at " + jdk_linux_arm64)
-    }
-
-    if(file(jdk_linux_x86_64).exists())
-    {
-        targetPlatform('linux-x86_64-v' + version, jdk_linux_x86_64)
-    }
-    else
-    {
-        println("Skipping OS Image - Linux x86 64-bit JDK was not found at " + jdk_linux_x86_64)
+    targetPlatform('linux-aarch64-v' + version) {
+        if(jdk_linux_aarch64.exists())
+        {
+            jdkHome = jdk_linux_aarch64
+        }
+        else
+        {
+            jdkHome = jdkDownload("https://download.bell-sw.com/java/17.0.2+9/bellsoft-jdk17.0.2+9-linux-aarch64-full.tar.gz")
+        }
     }
 
-    if(file(jdk_osx_x86_64).exists())
-    {
-        targetPlatform('osx-x86_64-v' + version, jdk_osx_x86_64)
-    }
-    else
-    {
-        println("Skipping OS Image - OSX x86 64-bit JDK was not found at " + jdk_osx_x86_64);
+    targetPlatform('linux-x86_64-v' + version) {
+        if(file(jdk_linux_x86_64).exists())
+        {
+            jdkHome = jdk_linux_x86_64
+        }
+        else
+        {
+            jdkHome = jdkDownload("https://download.bell-sw.com/java/17.0.2+9/bellsoft-jdk17.0.2+9-linux-amd64-full.tar.gz")
+        }
     }
 
-    if(file(jdk_windows_x86_64).exists())
-    {
-        targetPlatform('windows-x86_64-v' + version, jdk_windows_x86_64)
+    targetPlatform('osx-x86_64-v' + version) {
+        if(file(jdk_osx_x86_64).exists())
+        {
+            jdkHome = jdk_osx_x86_64
+        }
+        else
+        {
+            jdkHome = jdkDownload("https://download.bell-sw.com/java/17.0.2+9/bellsoft-jdk17.0.2+9-macos-amd64-full.tar.gz")
+        }
     }
-    else
-    {
-        println("Skipping OS Image - Windows x86 64-bit JDK was not found at " + jdk_windows_x86_64)
+
+    targetPlatform('osx-aarch64-v' + version) {
+        if(file(jdk_osx_aarch64).exists())
+        {
+            jdkHome = jdk_osx_aarch64
+        }
+        else
+        {
+            jdkHome = jdkDownload("https://download.bell-sw.com/java/17.0.2+9/bellsoft-jdk17.0.2+9-macos-aarch64-full.tar.gz")
+        }
+    }
+
+    targetPlatform('windows-x86_64-v' + version) {
+        if(file(jdk_windows_x86_64).exists())
+        {
+            jdkHome = jdk_windows_x86_64
+        }
+        else
+        {
+            jdkHome = jdkDownload("https://download.bell-sw.com/java/17.0.2+9/bellsoft-jdk17.0.2+9-windows-amd64-full.zip")
+        }
     }
 
     //jdk.crypto.ec is needed for HTTPS connections (broadcastify calls & map tile server)
     modules = ['jdk.crypto.ec']
     additive = true
-
     options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
     imageZip = hasTargetJdk ? file("$buildDir/image/sdr-trunk.zip") : file("$buildDir/image/sdr-trunk-" + version + ".zip")
 }


### PR DESCRIPTION
Resolves #1160.  

Adds usb4java native library support for Mac/OSX M1 aarch64 processor.