### PR TITLE
#1163 Airspy Buffer Iterator Calibrations Hang

### DIFF
--- a/src/main/java/io/github/dsheirer/vector/calibrate/airspy/AirspyUnpackedCalibration.java
+++ b/src/main/java/io/github/dsheirer/vector/calibrate/airspy/AirspyUnpackedCalibration.java
@@ -57,6 +57,8 @@ public class AirspyUnpackedCalibration extends Calibration
         short[] residualI = getShortSamples(AirspyBufferIterator.I_OVERLAP);
         short[] residualQ = getShortSamples(AirspyBufferIterator.Q_OVERLAP);
 
+        mLog.info("AIRSPY UNPACKED - VECTOR SIMD LANES PREFERRED: " + FloatVector.SPECIES_PREFERRED.length());
+
         //Warm-Up Phase ....
         Mean scalarMean = new Mean();
 
@@ -214,7 +216,7 @@ public class AirspyUnpackedCalibration extends Calibration
             AirspyBufferIteratorScalar iterator = new AirspyBufferIteratorScalar(samples, residualI,
                     residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().i()[2];
                 count++;
@@ -235,7 +237,7 @@ public class AirspyUnpackedCalibration extends Calibration
             AirspyBufferIteratorVector64Bits iterator = new AirspyBufferIteratorVector64Bits(samples, residualI,
                     residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().i()[2];
                 count++;
@@ -255,7 +257,7 @@ public class AirspyUnpackedCalibration extends Calibration
             AirspyBufferIteratorVector128Bits iterator = new AirspyBufferIteratorVector128Bits(samples, residualI,
                     residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().i()[2];
                 count++;
@@ -276,7 +278,7 @@ public class AirspyUnpackedCalibration extends Calibration
             AirspyBufferIteratorVector256Bits iterator =
                     new AirspyBufferIteratorVector256Bits(samples, residualI, residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().i()[2];
                 count++;
@@ -297,7 +299,7 @@ public class AirspyUnpackedCalibration extends Calibration
             AirspyBufferIteratorVector512Bits iterator =
                     new AirspyBufferIteratorVector512Bits(samples, residualI, residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().i()[2];
                 count++;

--- a/src/main/java/io/github/dsheirer/vector/calibrate/airspy/AirspyUnpackedInterleavedCalibration.java
+++ b/src/main/java/io/github/dsheirer/vector/calibrate/airspy/AirspyUnpackedInterleavedCalibration.java
@@ -58,6 +58,8 @@ public class AirspyUnpackedInterleavedCalibration extends Calibration
         short[] residualQ = getShortSamples(AirspyBufferIterator.Q_OVERLAP);
 
         //Warm-Up Phase ....
+        mLog.info("AIRSPY UNPACKED INTERLEAVED - VECTOR SIMD LANES PREFERRED: " + FloatVector.SPECIES_PREFERRED.length());
+
         Mean scalarMean = new Mean();
 
         for(int x = 0; x < WARMUP_ITERATIONS; x++)
@@ -225,7 +227,7 @@ public class AirspyUnpackedInterleavedCalibration extends Calibration
             AirspyInterleavedBufferIteratorScalar iterator = new AirspyInterleavedBufferIteratorScalar(samples, residualI,
                     residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().samples()[2];
                 count++;
@@ -246,7 +248,7 @@ public class AirspyUnpackedInterleavedCalibration extends Calibration
             AirspyInterleavedBufferIteratorVector64Bits iterator = new AirspyInterleavedBufferIteratorVector64Bits(samples, residualI,
                     residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().samples()[2];
                 count++;
@@ -267,7 +269,7 @@ public class AirspyUnpackedInterleavedCalibration extends Calibration
             AirspyInterleavedBufferIteratorVector128Bits iterator = new AirspyInterleavedBufferIteratorVector128Bits(samples, residualI,
                     residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().samples()[2];
                 count++;
@@ -288,7 +290,7 @@ public class AirspyUnpackedInterleavedCalibration extends Calibration
             AirspyInterleavedBufferIteratorVector256Bits iterator =
                     new AirspyInterleavedBufferIteratorVector256Bits(samples, residualI, residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().samples()[2];
                 count++;
@@ -309,7 +311,7 @@ public class AirspyUnpackedInterleavedCalibration extends Calibration
             AirspyInterleavedBufferIteratorVector512Bits iterator =
                     new AirspyInterleavedBufferIteratorVector512Bits(samples, residualI, residualQ, 0.0f, System.currentTimeMillis());
 
-            while(iterator.hasNext())
+            while(iterator.hasNext() && ((System.currentTimeMillis() - start) < ITERATION_DURATION_MS))
             {
                 accumulator += iterator.next().samples()[2];
                 count++;


### PR DESCRIPTION
Resolves #1163 

Resolves issue with airspy unpacked calibrations hanging.  Updates each test to check elapsed timer on a more granular scale on the theory that the SIMD vector implementation is horribly slow on some systems.
