### PR TITLE
#1169 P25 C4FM Interpolator - ArrayIndexOutOfBounds Exception

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/psk/InterpolatingSampleBuffer.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/InterpolatingSampleBuffer.java
@@ -1,23 +1,20 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 package io.github.dsheirer.dsp.psk;
 
@@ -185,7 +182,11 @@ public class InterpolatingSampleBuffer
      */
     public float getInphase(float interpolation)
     {
-        if(interpolation < 1.0f)
+        if(interpolation < 0.0f)
+        {
+            return mInterpolator.filter(mDelayLineInphase, mDelayLinePointer, 0.0f);
+        }
+        else if(interpolation < 1.0f)
         {
             return mInterpolator.filter(mDelayLineInphase, mDelayLinePointer, interpolation);
         }
@@ -203,7 +204,11 @@ public class InterpolatingSampleBuffer
      */
     public float getQuadrature(float interpolation)
     {
-        if(interpolation < 1.0f)
+        if(interpolation < 0.0f)
+        {
+            return mInterpolator.filter(mDelayLineQuadrature, mDelayLinePointer, 0.0f);
+        }
+        else if(interpolation < 1.0f)
         {
             return mInterpolator.filter(mDelayLineQuadrature, mDelayLinePointer, interpolation);
         }


### PR DESCRIPTION
Closes #1169 

Resolves issue where P25 C4FM decoder can request an interpolated sample value that is less than 0.  Not sure why or what is causing this but this change guards against an ArrayIndexOutOfBounds exception when it does happen.