### PR TITLE
Generate audio metadata with correct to/from

### DIFF
--- a/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
+++ b/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
@@ -278,29 +278,43 @@ public class IdentifierCollection
      */
     public Identifier getFromIdentifier()
     {
-        List<Identifier> fromIdentifiers = getIdentifiers(Role.FROM);
+        Identifier from = getIdentifier(IdentifierClass.USER, Form.RADIO, Role.FROM);
 
-        if(!fromIdentifiers.isEmpty())
+        if(from == null)
         {
-            return fromIdentifiers.get(0);
+            List<Identifier> fromIdentifiers = getIdentifiers(Role.FROM);
+
+            if(!fromIdentifiers.isEmpty())
+            {
+                from = fromIdentifiers.get(0);
+            }
         }
 
-        return null;
+        return from;
     }
 
     /**
-     * Returns the first identifier in this collection that is assigned a FROM role
+     * Returns the first identifier in this collection that is assigned a TO role
      */
     public Identifier getToIdentifier()
     {
-        List<Identifier> toIdentifiers = getIdentifiers(Role.TO);
+        Identifier to = getIdentifier(IdentifierClass.USER, Form.PATCH_GROUP, Role.TO);
 
-        if(!toIdentifiers.isEmpty())
+        if(to == null)
         {
-            return toIdentifiers.get(0);
+            to = getIdentifier(IdentifierClass.USER, Form.TALKGROUP, Role.TO);
         }
 
-        return null;
+        if(to == null)
+        {
+            List<Identifier> toIdentifiers = getIdentifiers(Role.TO);
+            if(!toIdentifiers.isEmpty())
+            {
+                to = toIdentifiers.get(0);
+            }
+        }
+
+        return to;
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/record/wave/AudioMetadataUtils.java
+++ b/src/main/java/io/github/dsheirer/record/wave/AudioMetadataUtils.java
@@ -89,37 +89,41 @@ public class AudioMetadataUtils
 
         if(identifierCollection != null)
         {
-            for(Identifier to: identifierCollection.getIdentifiers(Role.TO))
+            StringBuilder sb;
+
+            Identifier to = identifierCollection.getToIdentifier();
+            if(to != null)
             {
-                StringBuilder sb = new StringBuilder();
+                sb = new StringBuilder();
                 sb.append(to.toString());
 
-                List<Alias> aliases = aliasList.getAliases(to);
+                List<Alias> toAliases = aliasList.getAliases(to);
 
-                if(!aliases.isEmpty())
+                if(!toAliases.isEmpty())
                 {
-                    sb.append("\"").append(Joiner.on("\",\"").join(aliases)).append("\"");
+                    sb.append("\"").append(Joiner.on("\",\"").join(toAliases)).append("\"");
                 }
 
                 audioMetadata.put(AudioMetadata.TRACK_TITLE, sb.toString());
-                break;
             }
 
-            for(Identifier from: identifierCollection.getIdentifiers(Role.FROM))
+            Identifier from = identifierCollection.getFromIdentifier();
+            if(from != null)
             {
-                StringBuilder sb = new StringBuilder();
+                sb = new StringBuilder();
                 sb.append(from.toString());
 
-                List<Alias> aliases = aliasList.getAliases(from);
+                List<Alias> fromAliases = aliasList.getAliases(from);
 
-                for(Alias alias: aliases)
+                for(Alias alias: fromAliases)
                 {
                     sb.append(" ").append(alias.toString());
                 }
 
                 audioMetadata.put(AudioMetadata.ARTIST_NAME, sb.toString());
-                break;
             }
+            
+            sb = null;
 
             Identifier system = identifierCollection.getIdentifier(IdentifierClass.CONFIGURATION, Form.SYSTEM, Role.ANY);
             if(system instanceof SystemConfigurationIdentifier)


### PR DESCRIPTION
Modifies getToIdentifier() and getFromIdentifier() to return the most appropriate value, rather than the first, and then use them in AudioMetadataUtils for consistency.