### PR TITLE
#1210 Tuner Instance Memory Leak

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/AudioSegmentBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/AudioSegmentBroadcaster.java
@@ -39,7 +39,7 @@ public class AudioSegmentBroadcaster<T extends AudioSegment> extends Broadcaster
     @Override
     public void broadcast(T audioSegment)
     {
-        for(Listener<T> listener : mListeners)
+        for(Listener<T> listener : getListeners())
         {
             audioSegment.incrementConsumerCount();
             listener.receive(audioSegment);

--- a/src/main/java/io/github/dsheirer/gui/control/JFrequencyControl.java
+++ b/src/main/java/io/github/dsheirer/gui/control/JFrequencyControl.java
@@ -194,7 +194,10 @@ public class JFrequencyControl extends JPanel implements ISourceEventProcessor
      */
     public void addListener(ISourceEventProcessor processor)
     {
-        mProcessors.add(processor);
+        if(!mProcessors.contains(processor))
+        {
+            mProcessors.add(processor);
+        }
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/Tuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/Tuner.java
@@ -110,10 +110,17 @@ public abstract class Tuner implements ISourceEventProcessor, ITunerErrorListene
         if(getChannelSourceManager() != null)
         {
             getChannelSourceManager().stopAllChannels();
+            getChannelSourceManager().dispose();
+            mChannelSourceManager = null;
         }
 
         broadcast(new TunerEvent(this, Event.NOTIFICATION_SHUTTING_DOWN));
         getTunerController().stop();
+        getTunerController().dispose();
+
+        mTunerEventBroadcaster.clear();
+        mTunerFrequencyErrorMonitor = null;
+        mTunerErrorListener = null;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerController.java
@@ -49,13 +49,13 @@ public abstract class TunerController implements Tunable, ISourceEventProcessor,
     protected Broadcaster<INativeBuffer> mNativeBufferBroadcaster = new Broadcaster();
     protected FrequencyController mFrequencyController;
     private int mMiddleUnusableHalfBandwidth;
-    private double mUsableBandwidthPercentage;
-    private Listener<SourceEvent> mSourceEventListener;
     private int mMeasuredFrequencyError;
+    private double mUsableBandwidthPercentage;
+    private SourceEventListenerToProcessorAdapter mSourceEventListener;
     private NativeBufferWaveRecorder mRecorder;
     private ITunerErrorListener mTunerErrorListener;
-    public FrequencyErrorCorrectionManager mFrequencyErrorCorrectionManager;
     private DecimalFormat mFrequencyErrorPPMFormat = new DecimalFormat("0.0");
+    private FrequencyErrorCorrectionManager mFrequencyErrorCorrectionManager;
 
     /**
      * Abstract tuner controller class.  The tuner controller manages frequency bandwidth and currently tuned channels
@@ -76,6 +76,15 @@ public abstract class TunerController implements Tunable, ISourceEventProcessor,
     public FrequencyErrorCorrectionManager getFrequencyErrorCorrectionManager()
     {
         return mFrequencyErrorCorrectionManager;
+    }
+
+    protected void dispose()
+    {
+        getFrequencyErrorCorrectionManager().dispose();
+        mNativeBufferBroadcaster.clear();
+        mFrequencyController.dispose();
+        mSourceEventListener.dispose();
+        mTunerErrorListener = null;
     }
 
     /**
@@ -141,7 +150,6 @@ public abstract class TunerController implements Tunable, ISourceEventProcessor,
         setFrequency(config.getFrequency());
         setFrequencyCorrection(config.getFrequencyCorrection());
         getFrequencyErrorCorrectionManager().setEnabled(config.getAutoPPMCorrectionEnabled());
-
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
@@ -37,6 +37,14 @@ public abstract class ChannelSourceManager implements ISourceEventProcessor
     private Broadcaster<SourceEvent> mSourceEventBroadcaster = new Broadcaster<>();
 
     /**
+     * Prepare for disposal
+     */
+    public void dispose()
+    {
+        mSourceEventBroadcaster.clear();
+    }
+
+    /**
      * Sorted set of tuner channels being sourced by this source manager.  Set is ordered by frequency lowest to highest
      */
     public abstract SortedSet<TunerChannel> getTunerChannels();

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/FrequencyErrorCorrectionManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/FrequencyErrorCorrectionManager.java
@@ -50,6 +50,15 @@ public class FrequencyErrorCorrectionManager
     }
 
     /**
+     * Dispose of this manager instance and nullify references.
+     */
+    public void dispose()
+    {
+        setEnabled(false);
+        mTunerController = null;
+    }
+
+    /**
      * Enables or disables automatic frequency PPM correction.
      * @param enabled to true to turn on automatic PPM adjustments.
      */
@@ -80,7 +89,7 @@ public class FrequencyErrorCorrectionManager
      */
     private void applyCorrection()
     {
-        if(mEnabled && mTunerController.hasMeasuredFrequencyError())
+        if(mEnabled && mTunerController != null && mTunerController.hasMeasuredFrequencyError())
         {
             double frequencyCorrection = mTunerController.getFrequencyCorrection();
             frequencyCorrection -= mTunerController.getPPMFrequencyError();

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -26,7 +26,6 @@ import io.github.dsheirer.source.tuner.TunerClass;
 import io.github.dsheirer.source.tuner.TunerFactory;
 import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
-import io.github.dsheirer.source.tuner.manager.FrequencyErrorCorrectionManager;
 import io.github.dsheirer.source.tuner.usb.USBTunerController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -301,16 +300,6 @@ public class RTL2832TunerController extends USBTunerController
     }
 
     /**
-     * Manager for applying automatic frequency error PPM adjustments to the tuner controller based on
-     * frequency error measurements received from certain downstream decoders (e.g. P25).
-     * @return manager
-     */
-    public FrequencyErrorCorrectionManager getFrequencyErrorCorrectionManager()
-    {
-        return mFrequencyErrorCorrectionManager;
-    }
-
-    /**
      * Overrides updates for measured frequency error so that the updates can also be applied to the
      * frequency error correction manager for automatic PPM updating.
      * @param measuredFrequencyError in hertz averaged over a 5 second interval.
@@ -348,11 +337,11 @@ public class RTL2832TunerController extends USBTunerController
         {
             if(hasEmbeddedTuner())
             {
-                return TunerClass.RTL2832.toString() + "/" + getTunerType().getLabel() + " " + mDescriptor.getSerial();
+                return TunerClass.RTL2832 + "/" + getTunerType().getLabel() + " " + mDescriptor.getSerial();
             }
             else
             {
-                return TunerClass.RTL2832.toString() + " " + mDescriptor.getSerial();
+                return TunerClass.RTL2832 + " " + mDescriptor.getSerial();
             }
         }
         else

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerEditor.java
@@ -99,6 +99,8 @@ public class DiscoveredTunerEditor extends Editor<DiscoveredTuner> implements ID
 
         super.setItem(tuner);
 
+        mEditorScroller.remove(mEditor);
+
         if(hasItem())
         {
             mEditor = TunerFactory.getEditor(mUserPreferences, getItem(), mTunerManager);

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
@@ -116,7 +116,7 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         }
     }
 
-    /**
+    /**r
      * Indicates if the controls are currently being loaded with values.
      */
     protected boolean isLoading()
@@ -337,7 +337,7 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mEnabledButton == null)
         {
             mEnabledButton = new JButton(BUTTON_STATUS_ENABLE);
-            mEnabledButton.setToolTipText("Enable or disable the tuner for use by sdrtrunk, or attempt to reset a tuner error");
+            mEnabledButton.setToolTipText("Enable or disable the tuner for use by sdrtrunk");
             mEnabledButton.addActionListener(e ->
             {
                 switch(getEnabledButton().getText())
@@ -493,6 +493,11 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
      */
     public void dispose()
     {
+        turnOffRecorder();
+
+        getFrequencyControl().clearListeners();
+        getFrequencyCorrectionSpinner().removeChangeListener(mFrequencyAndCorrectionChangeListener);
+
         if(mDiscoveredTuner != null)
         {
             mDiscoveredTuner.removeTunerStatusListener(this);
@@ -501,9 +506,12 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
             {
                 mDiscoveredTuner.getTuner().removeTunerEventListener(this);
             }
+
+            mDiscoveredTuner = null;
         }
 
-        turnOffRecorder();
+        mUserPreferences = null;
+        mTunerManager = null;
     }
 
     /**


### PR DESCRIPTION
Resolves #1210 

Tuner instances can't be garbage collected due to retained references.  Updates several of the tuner controller and tuner editor classes to add/invoke dispose() methods to clear retained instance references.