### PR TITLE
Make Broadcastify Calls scheduled test configurable

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/broadcastify/BroadcastifyCallConfiguration.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/broadcastify/BroadcastifyCallConfiguration.java
@@ -24,7 +24,9 @@ import io.github.dsheirer.audio.broadcast.BroadcastConfiguration;
 import io.github.dsheirer.audio.broadcast.BroadcastFormat;
 import io.github.dsheirer.audio.broadcast.BroadcastServerType;
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -42,6 +44,8 @@ public class BroadcastifyCallConfiguration extends BroadcastConfiguration
 
     private IntegerProperty mSystemID = new SimpleIntegerProperty();
     private StringProperty mApiKey = new SimpleStringProperty();
+    private BooleanProperty mTestEnabled= new SimpleBooleanProperty(false);
+    private IntegerProperty mTestInterval = new SimpleIntegerProperty(15);
 
     /**
      * Constructor for faster jackson
@@ -126,6 +130,34 @@ public class BroadcastifyCallConfiguration extends BroadcastConfiguration
     public BroadcastServerType getBroadcastServerType()
     {
         return BroadcastServerType.BROADCASTIFY_CALL;
+    }
+
+    /**
+     * Indicates if this instance should schedule tests after connecting
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "test_enabled")
+    public boolean isTestEnabled()
+    {
+        return mTestEnabled.get();
+    }
+
+    public void setTestEnabled(boolean enabled)
+    {
+        mTestEnabled.set(enabled);
+    }
+
+    /**
+     * Indicates the interval at which tests should be performed while enabled
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "test_interval")
+    public int getTestInterval()
+    {
+        return mTestInterval.get();
+    }
+
+    public void setTestInterval(int interval)
+    {
+        mTestInterval.set(interval);
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/gui/playlist/streaming/BroadcastifyCallEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/streaming/BroadcastifyCallEditor.java
@@ -34,6 +34,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.controlsfx.control.ToggleSwitch;
 
 /**
  * Broadcastify calls API configuration editor
@@ -47,6 +48,8 @@ public class BroadcastifyCallEditor extends AbstractBroadcastEditor<Broadcastify
     private TextField mApiKeyTextField;
     private TextField mHostTextField;
     private GridPane mEditorPane;
+    private ToggleSwitch mTestEnabledToggleSwitch;
+    private IntegerTextField mTestIntervalTextField;
 
     /**
      * Constructs an instance
@@ -66,6 +69,8 @@ public class BroadcastifyCallEditor extends AbstractBroadcastEditor<Broadcastify
         getApiKeyTextField().setDisable(item == null);
         getHostTextField().setDisable(item == null);
         getMaxAgeTextField().setDisable(item == null);
+        getTestEnabledToggleSwitch().setDisable(item == null);
+        getTestIntervalTextField().setDisable(item == null);
 
         if(item != null)
         {
@@ -73,6 +78,8 @@ public class BroadcastifyCallEditor extends AbstractBroadcastEditor<Broadcastify
             getApiKeyTextField().setText(item.getApiKey());
             getHostTextField().setText(item.getHost());
             getMaxAgeTextField().set((int)(item.getMaximumRecordingAge() / 1000));
+            getTestEnabledToggleSwitch().setSelected(item.isTestEnabled());
+            getTestIntervalTextField().set(item.getTestInterval());
         }
         else
         {
@@ -80,6 +87,8 @@ public class BroadcastifyCallEditor extends AbstractBroadcastEditor<Broadcastify
             getApiKeyTextField().setText(null);
             getHostTextField().setText(null);
             getMaxAgeTextField().set(0);
+            getTestEnabledToggleSwitch().setSelected(false);
+            getTestIntervalTextField().set(15);
         }
 
         modifiedProperty().set(false);
@@ -100,6 +109,8 @@ public class BroadcastifyCallEditor extends AbstractBroadcastEditor<Broadcastify
             getItem().setHost(getHostTextField().getText());
             getItem().setApiKey(getApiKeyTextField().getText());
             getItem().setMaximumRecordingAge(getMaxAgeTextField().get() * 1000);
+            getItem().setTestEnabled(getTestEnabledToggleSwitch().isSelected());
+            getItem().setTestInterval(getTestIntervalTextField().get());
         }
 
         super.save();
@@ -177,6 +188,22 @@ public class BroadcastifyCallEditor extends AbstractBroadcastEditor<Broadcastify
             GridPane.setConstraints(getMaxAgeTextField(), 1, row);
             mEditorPane.getChildren().add(getMaxAgeTextField());
 
+            Label testEnabledLabel = new Label("Send Periodic Keep-Alive");
+            GridPane.setHalignment(testEnabledLabel, HPos.RIGHT);
+            GridPane.setConstraints(testEnabledLabel, 0, ++row);
+            mEditorPane.getChildren().add(testEnabledLabel);
+
+            GridPane.setConstraints(getTestEnabledToggleSwitch(), 1, row);
+            mEditorPane.getChildren().add(getTestEnabledToggleSwitch());
+
+            Label testIntervalLabel = new Label("Ping Interval (minutes)");
+            GridPane.setHalignment(testIntervalLabel, HPos.RIGHT);
+            GridPane.setConstraints(testIntervalLabel, 3, row);
+            mEditorPane.getChildren().add(testIntervalLabel);
+
+            GridPane.setConstraints(getTestIntervalTextField(), 4, row);
+            mEditorPane.getChildren().add(getTestIntervalTextField());
+
             GridPane.setConstraints(getTestButton(), 1, ++row);
             mEditorPane.getChildren().add(getTestButton());
         }
@@ -230,6 +257,31 @@ public class BroadcastifyCallEditor extends AbstractBroadcastEditor<Broadcastify
         }
 
         return mSystemIdTextField;
+    }
+
+    private ToggleSwitch getTestEnabledToggleSwitch()
+    {
+        if(mTestEnabledToggleSwitch == null)
+        {
+            mTestEnabledToggleSwitch = new ToggleSwitch();
+            mTestEnabledToggleSwitch.setDisable(true);
+            mTestEnabledToggleSwitch.selectedProperty()
+                .addListener((observable, oldValue, newValue) -> modifiedProperty().set(true));
+        }
+
+        return mTestEnabledToggleSwitch;
+    }
+
+    private IntegerTextField getTestIntervalTextField()
+    {
+        if(mTestIntervalTextField == null)
+        {
+            mTestIntervalTextField = new IntegerTextField();
+            mTestIntervalTextField.setDisable(true);
+            mTestIntervalTextField.textProperty().addListener(mEditorModificationListener);
+        }
+
+        return mTestIntervalTextField;
     }
 
     private Button getTestButton()


### PR DESCRIPTION
Adds a configuration toggle for the scheduled connection test, defaulting to off, as well as a configurable interval that defaults to 15 minutes.