### PR TITLE
#1219 resolves issues with NPE and restarting an error tuner.

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -251,7 +251,7 @@ public class RTL2832TunerController extends USBTunerController
         }
         catch(UsbException ue)
         {
-            throw new SourceException("Unable to initialize " + getEmbeddedTuner().getTunerType(), ue);
+            throw new SourceException("Unable to initialize " + tunerType, ue);
         }
 
         setMinimumFrequency(mEmbeddedTuner.getMinimumFrequencySupported());
@@ -366,7 +366,12 @@ public class RTL2832TunerController extends USBTunerController
      */
     public TunerType getTunerType()
     {
-        return getEmbeddedTuner().getTunerType();
+        if(getEmbeddedTuner() != null)
+        {
+            return getEmbeddedTuner().getTunerType();
+        }
+
+        return TunerType.UNKNOWN;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
@@ -33,6 +33,7 @@ import io.github.dsheirer.source.tuner.manager.IDiscoveredTunerStatusListener;
 import io.github.dsheirer.source.tuner.manager.TunerManager;
 import io.github.dsheirer.source.tuner.manager.TunerStatus;
 import io.github.dsheirer.util.SwingUtils;
+import io.github.dsheirer.util.ThreadPool;
 import net.miginfocom.swing.MigLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -370,11 +371,11 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
             {
                 if(!hasTuner() && getDiscoveredTuner().getTunerStatus() == TunerStatus.ERROR)
                 {
-                    mLog.info("Resetting " + getDiscoveredTuner().getTunerClass() + " tuner");
+                    mLog.info("Restarting " + getDiscoveredTuner().getTunerClass() + " tuner");
                     getDiscoveredTuner().reset();
                     if(getDiscoveredTuner().isEnabled())
                     {
-                        getDiscoveredTuner().start();
+                        ThreadPool.CACHED.submit(() -> getDiscoveredTuner().start());
                     }
                 }
             });


### PR DESCRIPTION
Resolves #1219 

Resolves issue with restarting error tuner causing UI thread lockup and an NPE when accessing the embedded tuner type of an error RTL2832 tuner where the embedded tuner was not initialized.