### PR TITLE
#1221 Tuner Editor NPE On Restart

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerClass.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerClass.java
@@ -54,12 +54,22 @@ public enum TunerClass
 	public static final EnumSet<TunerClass> SUPPORTED_USB_TUNERS = EnumSet.of(AIRSPY, HACKRF, RTL2832,
 			FUNCUBE_DONGLE_PRO, FUNCUBE_DONGLE_PRO_PLUS);
 
+	public static final EnumSet<TunerClass> FUNCUBE_TUNERS = EnumSet.of(FUNCUBE_DONGLE_PRO, FUNCUBE_DONGLE_PRO_PLUS);
+
 	/**
 	 * Indicates if this tuner class entry is a supported USB tuner class.
 	 */
 	public boolean isSupportedUsbTuner()
 	{
 		return SUPPORTED_USB_TUNERS.contains(this);
+	}
+
+	/**
+	 * Indicates if the tuner class is a funcube dongle with a matching sound card interface
+	 */
+	public boolean isFuncubeTuner()
+	{
+		return FUNCUBE_TUNERS.contains(this);
 	}
 
 	/**

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
@@ -104,7 +104,7 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
         getFrequencyPanel().updateControls();
         getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLocked());
         getTunerInfoButton().setEnabled(hasTuner());
-        updateGainComponents(hasTuner() ? getConfiguration().getGain() : null);
+        updateGainComponents((hasTuner() && hasConfiguration()) ? getConfiguration().getGain() : null);
 
         if(hasTuner())
         {

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredTuner.java
@@ -60,11 +60,28 @@ public abstract class DiscoveredTuner implements ITunerErrorListener
      * Sets the status of the discovered tuner and notifies registered listeners of the status change.
      * @param tunerStatus to set
      */
-    protected void setTunerStatus(TunerStatus tunerStatus)
+    private void setTunerStatus(TunerStatus tunerStatus)
     {
-        TunerStatus previous = mTunerStatus;
-        mTunerStatus = tunerStatus;
-        broadcast(this, previous, mTunerStatus);
+        setTunerStatus(tunerStatus, true);
+    }
+
+    /**
+     * Sets the status of the discovered tuner and optionally notifies registered listeners of the status change.
+     * @param tunerStatus to set
+     * @param notifyListeners true to notify and false to not notify
+     */
+    private void setTunerStatus(TunerStatus tunerStatus, boolean notifyListeners)
+    {
+        if(mTunerStatus != tunerStatus)
+        {
+            TunerStatus previous = mTunerStatus;
+            mTunerStatus = tunerStatus;
+
+            if(notifyListeners)
+            {
+                broadcast(this, previous, mTunerStatus);
+            }
+        }
     }
 
     /**
@@ -215,8 +232,9 @@ public abstract class DiscoveredTuner implements ITunerErrorListener
     public void setErrorMessage(String errorMessage)
     {
         mErrorMessage = errorMessage;
-        setTunerStatus(TunerStatus.ERROR);
+        mLog.info("Tuner Error - Stopping - " + getId() + " Error: " + errorMessage);
         stop();
+        setTunerStatus(TunerStatus.ERROR);
     }
 
     /**
@@ -246,7 +264,7 @@ public abstract class DiscoveredTuner implements ITunerErrorListener
     /**
      * Attempts to restart a tuner that's currently in an error state
      */
-    public void reset()
+    public void restart()
     {
         if(getTunerStatus() == TunerStatus.ERROR)
         {
@@ -254,7 +272,9 @@ public abstract class DiscoveredTuner implements ITunerErrorListener
 
             if(isEnabled())
             {
+                //Change status to enabled so that we can attempt to start, but don't notify listeners yet.
                 setTunerStatus(TunerStatus.ENABLED);
+                start();
             }
             else
             {

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredUSBTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredUSBTuner.java
@@ -109,20 +109,9 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
             }
             catch(SourceException se)
             {
-
                 //Set error message to flag this tuner with error status and invoke stop()
                 setErrorMessage(se.getMessage());
-
                 mLog.error("Unable to start tuner [" + getTunerClass() + "] - error: " + getErrorMessage());
-
-                try
-                {
-                    stop();
-                }
-                catch(Exception e)
-                {
-                    //No-op on attempted cleanup
-                }
             }
         }
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
@@ -246,8 +246,10 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
      * @param bus usb
      * @param port usb
      */
-    public void removeUsbTuner(int bus, int port)
+    public DiscoveredTuner removeUsbTuner(int bus, int port)
     {
+        DiscoveredTuner removed = null;
+
         mLock.lock();
 
         try
@@ -259,12 +261,15 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
             if(discoveredTuner != null)
             {
                 removeDiscoveredTuner(discoveredTuner);
+                removed = discoveredTuner;
             }
         }
         finally
         {
             mLock.unlock();
         }
+
+        return removed;
     }
 
     /**


### PR DESCRIPTION
#1221 resolves null pointer exception in tuner editor when attempting to restart an error tuner.

Closes #1221