### PR TITLE
#1223 Airspy and HackRF Editor NPE on Enable

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
@@ -110,8 +110,12 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
         {
             List<AirspySampleRate> rates = getTuner().getController().getSampleRates();
             getSampleRateCombo().setModel(new DefaultComboBoxModel<>(rates.toArray(new AirspySampleRate[rates.size()])));
-            AirspySampleRate sampleRate = getSampleRate(getConfiguration().getSampleRate());
-            getSampleRateCombo().setSelectedItem(sampleRate);
+
+            if(hasConfiguration())
+            {
+                AirspySampleRate sampleRate = getSampleRate(getConfiguration().getSampleRate());
+                getSampleRateCombo().setSelectedItem(sampleRate);
+            }
         }
         else
         {
@@ -508,9 +512,9 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
      */
     private void updateGainComponents(Gain gain)
     {
-        if(hasTuner())
+        if(hasTuner() && gain != null)
         {
-            boolean isCustom = gain == Gain.CUSTOM;
+            boolean isCustom = gain.equals(Gain.CUSTOM);
 
             getGainModeCombo().setEnabled(true);
             getGainModeCombo().setSelectedItem(gain.getGainMode());

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
@@ -121,16 +121,21 @@ public class HackRFTunerEditor extends TunerEditor<HackRFTuner,HackRFTunerConfig
         getButtonPanel().updateControls();
         getFrequencyPanel().updateControls();
         getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLocked());
-        getSampleRateCombo().setSelectedItem(getConfiguration().getSampleRate());
         updateSampleRateToolTip();
         getTunerInfoButton().setEnabled(hasTuner());
 
         getAmplifierToggle().setEnabled(hasTuner());
-        getAmplifierToggle().setSelected(getConfiguration().getAmplifierEnabled());
         getLnaGainCombo().setEnabled(hasTuner());
-        getLnaGainCombo().setSelectedItem(getConfiguration().getLNAGain());
         getVgaGainCombo().setEnabled(hasTuner());
-        getVgaGainCombo().setSelectedItem(getConfiguration().getVGAGain());
+
+        if(hasConfiguration())
+        {
+            getSampleRateCombo().setSelectedItem(getConfiguration().getSampleRate());
+            getAmplifierToggle().setSelected(getConfiguration().getAmplifierEnabled());
+            getLnaGainCombo().setSelectedItem(getConfiguration().getLNAGain());
+            getVgaGainCombo().setSelectedItem(getConfiguration().getVGAGain());
+        }
+
         setLoading(false);
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
@@ -156,6 +156,12 @@ public abstract class USBTunerController extends TunerController
         }
 
         mDevice = findDevice();
+
+        if(mDevice == null)
+        {
+            throw new SourceException("Couldn't find USB device at bus [" + mBus + "] port [" + mPort + "]");
+        }
+
         mDeviceDescriptor = new DeviceDescriptor();
         status = LibUsb.getDeviceDescriptor(mDevice, mDeviceDescriptor);
 
@@ -167,6 +173,10 @@ public abstract class USBTunerController extends TunerController
 
         mDeviceHandle = new DeviceHandle();
         status = LibUsb.open(mDevice, mDeviceHandle);
+
+        //Now that we have opened the device and added an additional reference, remove the original reference placed on
+        // the device during the findDevice() operation
+        LibUsb.unrefDevice(mDevice);
 
         if(status == LibUsb.ERROR_ACCESS)
         {


### PR DESCRIPTION
Resolves #1223 NPE when Airspy and HackRF tuners are re-enabled after startup.  Slight tweaks to TunerManager to change when discovered USB device startup takes place to potentially address intermittent fail on start for some tuners that users are seeing.  Resolves issue where a started device was not unreferenced in LibUsb on shutdown.