### PR TITLE
#1229 Use Port Address for USB Tuners

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
@@ -69,25 +69,25 @@ public class TunerFactory
     /**
      * Create a USB tuner
      * @param tunerClass to instantiate
-     * @param port usb
+     * @param portAddress usb
      * @param bus usb
      * @param tunerErrorListener to listen for errors from the tuner
      * @param channelizerType for the tuner
      * @return instantiated tuner
      * @throws SourceException if the tuner class is unrecognized
      */
-    public static Tuner getUsbTuner(TunerClass tunerClass, int port, int bus, ITunerErrorListener tunerErrorListener,
+    public static Tuner getUsbTuner(TunerClass tunerClass, String portAddress, int bus, ITunerErrorListener tunerErrorListener,
                                     ChannelizerType channelizerType) throws SourceException
     {
         switch(tunerClass)
         {
             case AIRSPY:
-                return new AirspyTuner(new AirspyTunerController(bus, port, tunerErrorListener), tunerErrorListener, channelizerType);
+                return new AirspyTuner(new AirspyTunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
             case FUNCUBE_DONGLE_PRO:
                 TargetDataLine tdl1 = MixerManager.getTunerTargetDataLine(MixerTunerType.FUNCUBE_DONGLE_PRO);
                 if(tdl1 != null)
                 {
-                    FCD1TunerController controller = new FCD1TunerController(tdl1, bus, port, tunerErrorListener);
+                    FCD1TunerController controller = new FCD1TunerController(tdl1, bus, portAddress, tunerErrorListener);
                     return new FCDTuner(controller, tunerErrorListener);
                 }
                 throw new SourceException("Unable to find matching tuner sound card mixer");
@@ -95,14 +95,14 @@ public class TunerFactory
                 TargetDataLine tdl2 = MixerManager.getTunerTargetDataLine(MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS);
                 if(tdl2 != null)
                 {
-                    FCD2TunerController controller = new FCD2TunerController(tdl2, bus, port, tunerErrorListener);
+                    FCD2TunerController controller = new FCD2TunerController(tdl2, bus, portAddress, tunerErrorListener);
                     return new FCDTuner(controller, tunerErrorListener);
                 }
                 throw new SourceException("Unable to find matching tuner sound card mixer");
             case HACKRF:
-                return new HackRFTuner(new HackRFTunerController(bus, port, tunerErrorListener), tunerErrorListener, channelizerType);
+                return new HackRFTuner(new HackRFTunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
             case RTL2832:
-                return new RTL2832Tuner(new RTL2832TunerController(bus, port, tunerErrorListener), tunerErrorListener, channelizerType);
+                return new RTL2832Tuner(new RTL2832TunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
             default:
                 throw new SourceException("Unrecognized tuner class [" + tunerClass + "]");
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
@@ -77,12 +77,12 @@ public class AirspyTunerController extends USBTunerController
     /**
      * Constructs an instance
      * @param bus usb
-     * @param port usb
+     * @param portAddress usb
      * @param tunerErrorListener to receive error notifications from this controller
      */
-    public AirspyTunerController(int bus, int port, ITunerErrorListener tunerErrorListener)
+    public AirspyTunerController(int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(bus, port, FREQUENCY_MIN, FREQUENCY_MAX, 0, USABLE_BANDWIDTH_PERCENT, tunerErrorListener);
+        super(bus, portAddress, FREQUENCY_MIN, FREQUENCY_MAX, 0, USABLE_BANDWIDTH_PERCENT, tunerErrorListener);
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerController.java
@@ -56,12 +56,12 @@ public class FCD1TunerController extends FCDTunerController
      * Constructs an instance
      * @param mixerTDL for the audio/data interface
      * @param bus usb
-     * @param port usb
+     * @param portAddress usb
      * @param tunerErrorListener to receive tuner errors
      */
-    public FCD1TunerController(TargetDataLine mixerTDL, int bus, int port, ITunerErrorListener tunerErrorListener)
+    public FCD1TunerController(TargetDataLine mixerTDL, int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(MixerTunerType.FUNCUBE_DONGLE_PRO, mixerTDL, bus, port, MINIMUM_TUNABLE_FREQUENCY,
+        super(MixerTunerType.FUNCUBE_DONGLE_PRO, mixerTDL, bus, portAddress, MINIMUM_TUNABLE_FREQUENCY,
                 MAXIMUM_TUNABLE_FREQUENCY, tunerErrorListener);
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerController.java
@@ -48,12 +48,12 @@ public class FCD2TunerController extends FCDTunerController
      * Constructs an instance
      * @param mixerTDL for the sample stream
      * @param bus usb
-     * @param port usb
+     * @param portAddress usb
      * @param tunerErrorListener to receive errors from this tuner
      */
-    public FCD2TunerController(TargetDataLine mixerTDL, int bus, int port, ITunerErrorListener tunerErrorListener)
+    public FCD2TunerController(TargetDataLine mixerTDL, int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS, mixerTDL, bus, port, MINIMUM_TUNABLE_FREQUENCY,
+        super(MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS, mixerTDL, bus, portAddress, MINIMUM_TUNABLE_FREQUENCY,
                 MAXIMUM_TUNABLE_FREQUENCY, tunerErrorListener);
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
@@ -60,11 +60,11 @@ public class HackRFTunerController extends USBTunerController
     /**
      * Constructs an instance
      * @param bus usb
-     * @param port usb
+     * @param portAddress usb
      */
-    public HackRFTunerController(int bus, int port, ITunerErrorListener tunerErrorListener)
+    public HackRFTunerController(int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(bus, port, MINIMUM_TUNABLE_FREQUENCY, MAXIMUM_TUNABLE_FREQUENCY, DC_HALF_BANDWIDTH, USABLE_BANDWIDTH,
+        super(bus, portAddress, MINIMUM_TUNABLE_FREQUENCY, MAXIMUM_TUNABLE_FREQUENCY, DC_HALF_BANDWIDTH, USABLE_BANDWIDTH,
                 tunerErrorListener);
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredUSBTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredUSBTuner.java
@@ -35,32 +35,32 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
     private Logger mLog = LoggerFactory.getLogger(DiscoveredUSBTuner.class);
     private TunerClass mTunerClass;
     private int mBus;
-    private int mPort;
+    private String mPortAddress;
     private ChannelizerType mChannelizerType;
 
     /**
      * Constructs an instance
      * @param bus (USB) number
-     * @param port (USB) number
+     * @param portAddress (USB)
      * @param channelizerType to use with the tuner
      */
-    public DiscoveredUSBTuner(TunerClass tunerClass, int bus, int port, ChannelizerType channelizerType)
+    public DiscoveredUSBTuner(TunerClass tunerClass, int bus, String portAddress, ChannelizerType channelizerType)
     {
         mTunerClass = tunerClass;
         mBus = bus;
-        mPort = port;
+        mPortAddress = portAddress;
         mChannelizerType = channelizerType;
     }
 
     /**
      * Indicates if this USB tuner is plugged into the specified bus and port.
      * @param bus number
-     * @param port number
+     * @param port address
      * @return true if there is a match
      */
-    public boolean isAt(int bus, int port)
+    public boolean isAt(int bus, String port)
     {
-        return mBus == bus && mPort == port;
+        return mBus == bus && port != null && port.equalsIgnoreCase(mPortAddress);
     }
 
     /**
@@ -82,9 +82,9 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
     /**
      * USB port number
      */
-    public int getPort()
+    public String getPortAddress()
     {
-        return mPort;
+        return mPortAddress;
     }
 
     @Override
@@ -93,7 +93,7 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
         StringBuilder sb = new StringBuilder();
         sb.append(getTunerClass());
         sb.append(" USB Bus:").append(getBus());
-        sb.append(" Port:").append(getPort());
+        sb.append(" Port:").append(getPortAddress());
         return sb.toString();
     }
 
@@ -104,7 +104,7 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
         {
             try
             {
-                mTuner = TunerFactory.getUsbTuner(getTunerClass(), getPort(), getBus(), this, mChannelizerType);
+                mTuner = TunerFactory.getUsbTuner(getTunerClass(), getPortAddress(), getBus(), this, mChannelizerType);
                 mTuner.start();
             }
             catch(SourceException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -73,9 +73,9 @@ public class RTL2832TunerController extends USBTunerController
      * to determine the tuner type, and construct the corresponding child
      * tuner controller class for that tuner type.
      */
-    public RTL2832TunerController(int bus, int port, ITunerErrorListener tunerErrorListener)
+    public RTL2832TunerController(int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(bus, port, tunerErrorListener);
+        super(bus, portAddress, tunerErrorListener);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
@@ -218,10 +218,10 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
     /**
      * Indicates if this model currently has the discovered tuner that is plugged into the specified bus and port.
      * @param bus number
-     * @param port number
+     * @param portAddress number
      * @return true if it already has the discovered device
      */
-    public boolean hasUsbTuner(int bus, int port)
+    public boolean hasUsbTuner(int bus, String portAddress)
     {
         boolean hasDevice;
         mLock.lock();
@@ -229,7 +229,7 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
         try
         {
             hasDevice = mDiscoveredTuners.stream()
-                    .filter(tuner -> tuner instanceof DiscoveredUSBTuner usbTuner && usbTuner.isAt(bus, port))
+                    .filter(tuner -> tuner instanceof DiscoveredUSBTuner usbTuner && usbTuner.isAt(bus, portAddress))
                     .findFirst()
                     .isPresent();
         }
@@ -244,9 +244,9 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
     /**
      * Removes the USB tuner at bus and port number
      * @param bus usb
-     * @param port usb
+     * @param portAddress usb
      */
-    public DiscoveredTuner removeUsbTuner(int bus, int port)
+    public DiscoveredTuner removeUsbTuner(int bus, String portAddress)
     {
         DiscoveredTuner removed = null;
 
@@ -256,7 +256,7 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
         {
             DiscoveredTuner discoveredTuner = mDiscoveredTuners.stream()
                     .filter(tuner -> tuner instanceof DiscoveredUSBTuner usbTuner &&
-                            usbTuner.isAt(bus, port)).findFirst().get();
+                            usbTuner.isAt(bus, portAddress)).findFirst().get();
 
             if(discoveredTuner != null)
             {


### PR DESCRIPTION
#1229 Resolves issue with correctly identifying the port number for USB tuners that is causing some tuners not to be recognized and also generating udev errors when sdrtrunk attempts to start an already started device because it was incorrectly identified.