### PR TITLE
Don't show tuner on spectral display while disabled

### DIFF
--- a/src/main/java/io/github/dsheirer/spectrum/ClearTunerMenuItem.java
+++ b/src/main/java/io/github/dsheirer/spectrum/ClearTunerMenuItem.java
@@ -36,9 +36,9 @@ public class ClearTunerMenuItem extends JMenuItem
             @Override
             public void actionPerformed(ActionEvent e)
             {
-                mSpectralDisplayPanel.clearTuner();
                 SystemProperties properties = SystemProperties.getInstance();
                 properties.set(SpectralDisplayPanel.SPECTRAL_DISPLAY_ENABLED, false);
+                mSpectralDisplayPanel.clearTuner();
             }
         });
     }

--- a/src/main/java/io/github/dsheirer/spectrum/ShowTunerMenuItem.java
+++ b/src/main/java/io/github/dsheirer/spectrum/ShowTunerMenuItem.java
@@ -49,9 +49,9 @@ public class ShowTunerMenuItem extends JMenuItem
                     @Override
                     public void run()
                     {
-                        mDiscoveredTunerModel.broadcast(new TunerEvent(mTuner, TunerEvent.Event.REQUEST_MAIN_SPECTRAL_DISPLAY));
                         SystemProperties properties = SystemProperties.getInstance();
                         properties.set(SpectralDisplayPanel.SPECTRAL_DISPLAY_ENABLED, true);
+                        mDiscoveredTunerModel.broadcast(new TunerEvent(mTuner, TunerEvent.Event.REQUEST_MAIN_SPECTRAL_DISPLAY));
                     }
                 });
             }

--- a/src/main/java/io/github/dsheirer/spectrum/SpectralDisplayPanel.java
+++ b/src/main/java/io/github/dsheirer/spectrum/SpectralDisplayPanel.java
@@ -423,6 +423,11 @@ public class SpectralDisplayPanel extends JPanel
     public void showTuner(Tuner tuner)
     {
         clearTuner();
+        if(!SystemProperties.getInstance().get(SpectralDisplayPanel.SPECTRAL_DISPLAY_ENABLED, true))
+        {
+            //Spectral display is disabled, stop
+            return;
+        }
 
         mComplexDftProcessor.clearBuffer();
 


### PR DESCRIPTION
Prevent showTuner() from starting spectral display after user has disabled it. Persists disabled state through restarts.

Resolves #1231.