### PR TITLE
#1245 New Spectral Display Doesn't Override Disabled State

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerSpectralDisplayManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerSpectralDisplayManager.java
@@ -19,6 +19,7 @@
 package io.github.dsheirer.source.tuner.ui;
 
 import io.github.dsheirer.playlist.PlaylistManager;
+import io.github.dsheirer.properties.SystemProperties;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.settings.SettingsManager;
 import io.github.dsheirer.source.tuner.Tuner;
@@ -28,7 +29,6 @@ import io.github.dsheirer.spectrum.SpectralDisplayPanel;
 import io.github.dsheirer.spectrum.SpectrumFrame;
 import io.github.dsheirer.util.SwingUtils;
 import io.github.dsheirer.util.ThreadPool;
-
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -53,6 +53,12 @@ public class TunerSpectralDisplayManager implements Listener<TunerEvent>
      */
     public Tuner showFirstTuner()
     {
+        if(!SystemProperties.getInstance().get(SpectralDisplayPanel.SPECTRAL_DISPLAY_ENABLED, true))
+        {
+            //Spectral display is disabled, stop
+            return null;
+        }
+
         List<DiscoveredTuner> availableTuners = mDiscoveredTunerModel.getAvailableTuners();
 
         for(DiscoveredTuner discoveredTuner: availableTuners)
@@ -76,7 +82,10 @@ public class TunerSpectralDisplayManager implements Listener<TunerEvent>
                 SwingUtils.run(() -> mSpectralDisplayPanel.clearTuner());
                 break;
             case REQUEST_MAIN_SPECTRAL_DISPLAY:
-                SwingUtils.run(() -> mSpectralDisplayPanel.showTuner(event.getTuner()));
+                if(SystemProperties.getInstance().get(SpectralDisplayPanel.SPECTRAL_DISPLAY_ENABLED, true))
+                {
+                    SwingUtils.run(() -> mSpectralDisplayPanel.showTuner(event.getTuner()));
+                }
                 break;
             case REQUEST_NEW_SPECTRAL_DISPLAY:
                 final SpectrumFrame frame = new SpectrumFrame(mPlaylistManager, mSettingsManager, mDiscoveredTunerModel, event.getTuner());

--- a/src/main/java/io/github/dsheirer/spectrum/SpectralDisplayPanel.java
+++ b/src/main/java/io/github/dsheirer/spectrum/SpectralDisplayPanel.java
@@ -47,6 +47,17 @@ import io.github.dsheirer.spectrum.menu.FFTWindowTypeItem;
 import io.github.dsheirer.spectrum.menu.FrameRateItem;
 import io.github.dsheirer.spectrum.menu.SmoothingItem;
 import io.github.dsheirer.spectrum.menu.SmoothingTypeItem;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
+import java.util.ArrayList;
+import java.util.Hashtable;
 import net.miginfocom.swing.MigLayout;
 import org.apache.commons.math3.util.FastMath;
 import org.slf4j.Logger;
@@ -68,17 +79,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.MouseInputAdapter;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.EventQueue;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.ComponentEvent;
-import java.awt.event.ComponentListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseWheelEvent;
-import java.util.ArrayList;
-import java.util.Hashtable;
 
 public class SpectralDisplayPanel extends JPanel
         implements Listener<INativeBuffer>, ISourceEventProcessor, IDFTWidthChangeProcessor
@@ -423,11 +423,6 @@ public class SpectralDisplayPanel extends JPanel
     public void showTuner(Tuner tuner)
     {
         clearTuner();
-        if(!SystemProperties.getInstance().get(SpectralDisplayPanel.SPECTRAL_DISPLAY_ENABLED, true))
-        {
-            //Spectral display is disabled, stop
-            return;
-        }
 
         mComplexDftProcessor.clearBuffer();
 


### PR DESCRIPTION
Closes #1245 
Updates spectral display show tuner options to allow new display without changing disabled state of primary display.