### PR TITLE
Fixed bug with recording tuners

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTuner.java
@@ -20,6 +20,7 @@ package io.github.dsheirer.source.tuner.recording;
 
 import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.preference.source.ChannelizerType;
+import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.tuner.ITunerErrorListener;
 import io.github.dsheirer.source.tuner.Tuner;
 import io.github.dsheirer.source.tuner.TunerClass;
@@ -46,6 +47,11 @@ public class RecordingTuner extends Tuner
         super(new RecordingTunerController(tunerErrorListener, config.getPath(), config.getFrequency()), tunerErrorListener);
 
         mUserPreferences = userPreferences;
+    }
+
+    @Override
+    public void start() throws SourceException {
+        super.start();
 
         if(getTunerController().getCurrentSampleRate() < 100000.0d)
         {
@@ -53,7 +59,7 @@ public class RecordingTuner extends Tuner
         }
         else
         {
-            ChannelizerType channelizerType = userPreferences.getTunerPreference().getChannelizerType();
+            ChannelizerType channelizerType = mUserPreferences.getTunerPreference().getChannelizerType();
 
             if(channelizerType == ChannelizerType.POLYPHASE)
             {


### PR DESCRIPTION
When RecordingTuner.java was initialized and source manager was being determined. The sample rate was 0, because the recording tuner would be loaded and started after this condition. 
Because the sample rate was returned as 0 the source manager selected would be PassThroughSourceManager. Which was not working for the normal full bandwidth baseband recordings. 

I overridden the start method of recording tuner, and had it done in there, immediately after the recording tuner was actually loaded and started, and the sample rate was determined.