### PR TITLE
#1284 RTL2832 Samples Exhibit Inherent DC Bias 

### DIFF
--- a/src/main/java/io/github/dsheirer/buffer/ByteNativeBuffer.java
+++ b/src/main/java/io/github/dsheirer/buffer/ByteNativeBuffer.java
@@ -21,7 +21,6 @@ package io.github.dsheirer.buffer;
 
 import io.github.dsheirer.sample.complex.ComplexSamples;
 import io.github.dsheirer.sample.complex.InterleavedComplexSamples;
-
 import java.util.Iterator;
 
 /**
@@ -42,7 +41,7 @@ public class ByteNativeBuffer implements INativeBuffer
 
         for(int x = 0; x < 256; x++)
         {
-            LOOKUP_VALUES[x] = (float)(x - 127) / 128.0f;
+            LOOKUP_VALUES[x] = ((float)x - 127.5f) / 128.0f;
         }
     }
 

--- a/src/main/java/io/github/dsheirer/buffer/ByteNativeBufferFactory.java
+++ b/src/main/java/io/github/dsheirer/buffer/ByteNativeBufferFactory.java
@@ -45,7 +45,7 @@ public class ByteNativeBufferFactory implements INativeBufferFactory
      */
     private void calculateDc(byte[] samples)
     {
-        double dcAccumulator = 0;
+        float dcAccumulator = 0;
 
         for(byte sample: samples)
         {
@@ -53,7 +53,7 @@ public class ByteNativeBufferFactory implements INativeBufferFactory
         }
 
         dcAccumulator /= samples.length;
-        dcAccumulator -= 127.0f;
+        dcAccumulator -= 127.5f;
         dcAccumulator /= 128.0f;
         dcAccumulator -= mAverageDc;
         mAverageDc += (dcAccumulator * DC_FILTER_GAIN);

--- a/src/main/java/io/github/dsheirer/buffer/SignedByteNativeBufferFactory.java
+++ b/src/main/java/io/github/dsheirer/buffer/SignedByteNativeBufferFactory.java
@@ -46,8 +46,8 @@ public class SignedByteNativeBufferFactory implements INativeBufferFactory
      */
     private void calculateDc(byte[] samples)
     {
-        double iDcAccumulator = 0;
-        double qDcAccumulator = 0;
+        float iDcAccumulator = 0;
+        float qDcAccumulator = 0;
 
         for(int x = 0; x < samples.length; x += 2)
         {


### PR DESCRIPTION
#1284 Resolves issue with inherent DC bias (-0.5) in RTL2832 sample conversion code.
