### PR TITLE
Fixes to Decode Event filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,11 @@ dependencies {
 
     // JUnit Tests
     testImplementation 'junit:junit:4.12'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.0"
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.assertj:assertj-core:3.8.0'
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
     testImplementation 'org.mockito:mockito-core:3.+'
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     //Jitpack imports
     implementation 'com.github.dnault:libresample4j:master'

--- a/src/main/java/io/github/dsheirer/filter/FilterSet.java
+++ b/src/main/java/io/github/dsheirer/filter/FilterSet.java
@@ -13,7 +13,7 @@ public class FilterSet<T> implements IFilter<T>
     {
     	mName = name;
     }
-    
+
     public FilterSet()
     {
     	mName = "Message Filter";
@@ -23,22 +23,22 @@ public class FilterSet<T> implements IFilter<T>
 	{
 		addFilter(filter);
 	}
-    
+
     public String getName()
     {
     	return mName;
     }
-    
+
     public void setName( String name )
     {
     	mName = name;
     }
-    
+
     public String toString()
     {
     	return getName();
     }
-    
+
 	@Override
     public boolean passes( T t )
     {
@@ -46,11 +46,9 @@ public class FilterSet<T> implements IFilter<T>
 		{
 			for( IFilter<T> filter: mFilters )
 			{
-				// Make sure to loop through all filters.
-				// Only return if true or all filters have been evaluated.
-				if( filter.canProcess( t ) && filter.passes( t ))
+				if( filter.canProcess( t ))
 				{
-					return true;
+					return filter.passes( t );
 				}
 			}
 		}
@@ -60,8 +58,6 @@ public class FilterSet<T> implements IFilter<T>
 	@Override
     public boolean canProcess( T t )
     {
-		if( mEnabled )
-		{
 			for( IFilter<T> filter: mFilters )
 			{
 				if( filter.canProcess( t ) )
@@ -69,26 +65,25 @@ public class FilterSet<T> implements IFilter<T>
 					return true;
 				}
 			}
-		}
-		
-		return false;
+
+			return false;
     }
-	
+
 	public List<IFilter<T>> getFilters()
 	{
 		return mFilters;
 	}
-	
+
 	public void addFilters( List<IFilter<T>> filters )
 	{
 		mFilters.addAll( filters );
 	}
-	
+
 	public void addFilter( IFilter<T> filter )
 	{
 		mFilters.add( filter );
 	}
-	
+
 	public void removeFilter( IFilter<T> filter )
 	{
 		mFilters.remove( filter );

--- a/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
+++ b/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
@@ -20,6 +20,8 @@
 package io.github.dsheirer.identifier;
 
 import io.github.dsheirer.identifier.configuration.AliasListConfigurationIdentifier;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +81,7 @@ public class IdentifierCollection
                 mAliasListConfigurationIdentifier = (AliasListConfigurationIdentifier)identifier;
             }
         }
+        mTimeslot = timeslot;
     }
 
     public int getTimeslot()
@@ -98,14 +101,6 @@ public class IdentifierCollection
     public AliasListConfigurationIdentifier getAliasListConfiguration()
     {
         return mAliasListConfigurationIdentifier;
-    }
-
-    /**
-     * Indicates if this collection has an alias list specified.
-     */
-    public boolean hasAliasListConfiguration()
-    {
-        return mAliasListConfigurationIdentifier != null;
     }
 
     /**
@@ -331,5 +326,27 @@ public class IdentifierCollection
             sb.append("\t").append(identifier.getClass()).append("\n");
         }
         return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final var that = (IdentifierCollection) o;
+        return new EqualsBuilder()
+            .append(mTimeslot, that.mTimeslot)
+            .append(mIdentifiers, that.mIdentifiers)
+            .append(mAliasListConfigurationIdentifier, that.mAliasListConfigurationIdentifier)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(mIdentifiers)
+            .append(mAliasListConfigurationIdentifier)
+            .append(mTimeslot)
+            .toHashCode();
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEvent.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEvent.java
@@ -374,6 +374,7 @@ public class DecodeEvent implements IDecodeEvent
             decodeEvent.setChannelDescriptor(mChannelDescriptor);
             decodeEvent.setDetails(mDetails);
             decodeEvent.setDuration(mDuration);
+            decodeEvent.setEventType(mDecodeEventType);
             decodeEvent.setEventDescription(mEventDescription);
             decodeEvent.setIdentifierCollection(mIdentifierCollection);
             decodeEvent.setProtocol(mProtocol);

--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEvent.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEvent.java
@@ -30,7 +30,7 @@ import io.github.dsheirer.protocol.Protocol;
  */
 public class DecodeEvent implements IDecodeEvent
 {
-    private long mTimeStart;
+    private final long mTimeStart;
     private long mTimeEnd;
     private String mEventDescription;
     private DecodeEventType mDecodeEventType;
@@ -40,7 +40,7 @@ public class DecodeEvent implements IDecodeEvent
     private Protocol mProtocol;
     private Integer mTimeslot;
 
-    public DecodeEvent(long start)
+    protected DecodeEvent(long start)
     {
         mTimeStart = start;
     }
@@ -281,26 +281,6 @@ public class DecodeEvent implements IDecodeEvent
         public DecodeEventBuilder(long timeStart)
         {
             mTimeStart = timeStart;
-        }
-
-        /**
-         * Sets the duration value
-         * @param duration in milliseconds
-         */
-        public DecodeEventBuilder duration(long duration)
-        {
-            mDuration = duration;
-            return this;
-        }
-
-        /**
-         * Sets the duration value using the end - start timestamps
-         * @param timestamp for end of event
-         */
-        public DecodeEventBuilder end(long timestamp)
-        {
-            mDuration = timestamp - mTimeStart;
-            return this;
         }
 
         /**

--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventModel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventModel.java
@@ -21,6 +21,9 @@
  */
 package io.github.dsheirer.module.decode.event;
 
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.eventbus.Subscribe;
 import io.github.dsheirer.channel.IChannelDescriptor;
 import io.github.dsheirer.eventbus.MyEventBus;
@@ -35,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.table.AbstractTableModel;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -121,7 +125,7 @@ public class DecodeEventModel extends AbstractTableModel implements Listener<IDe
     public void clearAndSet(List<IDecodeEvent> events)
     {
         mEvents.clear();
-        mEvents.addAll(events);
+        mEvents.addAll(Collections2.filter(Lists.reverse(events), mEventFilterSet::passes));
         fireTableDataChanged();
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
@@ -82,7 +82,7 @@ public class DecodeEventPanel extends JPanel implements Listener<ProcessingChain
     {
         MyEventBus.getGlobalEventBus().register(this);
 
-        setLayout(new MigLayout("insets 0 0 0 0", "[grow,fill]", "[grow,fill]"));
+        setLayout(new MigLayout("insets 0 0 0 0", "[grow,fill]", "[]0[grow,fill]"));
         mIconModel = iconModel;
         mAliasModel = aliasModel;
         mUserPreferences = userPreferences;
@@ -97,7 +97,7 @@ public class DecodeEventPanel extends JPanel implements Listener<ProcessingChain
         add(mEventManagementPanel, "span,growx");
 
         mEmptyScroller = new JScrollPane(mTable);
-        add(mEmptyScroller);
+        add(mEmptyScroller, "span,grow");
     }
 
     public void dispose()

--- a/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSet.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSet.java
@@ -20,6 +20,11 @@ public class DecodeEventFilterSet extends FilterSet<IDecodeEvent> {
         // - their type is not handled by filters above
         addFilter(new EventFilter("Everything else", List.of()) {
             @Override
+            public boolean canProcess(IDecodeEvent iDecodeEvent) {
+                return true;
+            }
+
+            @Override
             public boolean passes(IDecodeEvent iDecodeEvent) {
                 return isEnabled();
             }

--- a/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSet.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSet.java
@@ -14,6 +14,10 @@ public class DecodeEventFilterSet extends FilterSet<IDecodeEvent> {
         addFilter(new DecodedDataEventFilter());
         addFilter(new DecodedCommandEventFilter());
         addFilter(new DecodedRegistrationEventFilter());
+
+        // This filter must be last. Its goal is to handle decode events that:
+        // - do not have type set, or
+        // - their type is not handled by filters above
         addFilter(new EventFilter("Everything else", List.of()) {
             @Override
             public boolean passes(IDecodeEvent iDecodeEvent) {

--- a/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSet.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSet.java
@@ -3,6 +3,8 @@ package io.github.dsheirer.module.decode.event.filter;
 import io.github.dsheirer.filter.FilterSet;
 import io.github.dsheirer.module.decode.event.IDecodeEvent;
 
+import java.util.List;
+
 public class DecodeEventFilterSet extends FilterSet<IDecodeEvent> {
     public DecodeEventFilterSet() {
         super ("All Messages");
@@ -12,5 +14,11 @@ public class DecodeEventFilterSet extends FilterSet<IDecodeEvent> {
         addFilter(new DecodedDataEventFilter());
         addFilter(new DecodedCommandEventFilter());
         addFilter(new DecodedRegistrationEventFilter());
+        addFilter(new EventFilter("Everything else", List.of()) {
+            @Override
+            public boolean passes(IDecodeEvent iDecodeEvent) {
+                return isEnabled();
+            }
+        });
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodedCallEventFilter.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/filter/DecodedCallEventFilter.java
@@ -9,6 +9,7 @@ public class DecodedCallEventFilter extends EventFilter
     public DecodedCallEventFilter()
     {
         super("Voice Calls", Arrays.asList(
+                DecodeEventType.CALL,
                 DecodeEventType.CALL_GROUP,
                 DecodeEventType.CALL_PATCH_GROUP,
                 DecodeEventType.CALL_ALERT,

--- a/src/main/java/io/github/dsheirer/module/decode/event/filter/EventFilter.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/filter/EventFilter.java
@@ -18,7 +18,7 @@ import java.util.Map;
  */
 public class EventFilter extends Filter<IDecodeEvent>
 {
-    private Map<DecodeEventType, FilterElement<DecodeEventType>> mElements = new EnumMap<>(DecodeEventType.class);
+    private final Map<DecodeEventType, FilterElement<DecodeEventType>> mElements = new EnumMap<>(DecodeEventType.class);
 
     public EventFilter(String name, List<DecodeEventType> eventTypes)
     {
@@ -30,22 +30,19 @@ public class EventFilter extends Filter<IDecodeEvent>
     }
 
     @Override
+    public boolean canProcess(IDecodeEvent iDecodeEvent)
+    {
+        return mElements.containsKey(iDecodeEvent.getEventType());
+    }
+
+    @Override
     public boolean passes(IDecodeEvent iDecodeEvent)
     {
         if (mEnabled && canProcess(iDecodeEvent))
         {
-            if (mElements.containsKey(iDecodeEvent.getEventType()))
-            {
-                return mElements.get(iDecodeEvent.getEventType()).isEnabled();
-            }
+            return mElements.get(iDecodeEvent.getEventType()).isEnabled();
         }
         return false;
-    }
-
-    @Override
-    public boolean canProcess(IDecodeEvent iDecodeEvent)
-    {
-        return true;
     }
 
     @Override

--- a/src/test/java/io/github/dsheirer/CommonFixtures.java
+++ b/src/test/java/io/github/dsheirer/CommonFixtures.java
@@ -1,0 +1,23 @@
+package io.github.dsheirer;
+
+import io.github.dsheirer.channel.IChannelDescriptor;
+import io.github.dsheirer.identifier.IdentifierCollection;
+import io.github.dsheirer.identifier.Role;
+import io.github.dsheirer.module.decode.dmr.channel.DMRLogicalChannel;
+import io.github.dsheirer.module.decode.dmr.identifier.DMRTalkgroup;
+
+import java.util.List;
+
+public interface CommonFixtures {
+
+  default IChannelDescriptor someChannel() {
+    return new DMRLogicalChannel(1, 1);
+  }
+
+  default IdentifierCollection someIdentifiers() {
+    return new IdentifierCollection(List.of(
+        new DMRTalkgroup(1, Role.FROM),
+        new DMRTalkgroup(2, Role.TO)
+    ));
+  }
+}

--- a/src/test/java/io/github/dsheirer/identifier/IdentifierCollectionTest.java
+++ b/src/test/java/io/github/dsheirer/identifier/IdentifierCollectionTest.java
@@ -1,6 +1,7 @@
 package io.github.dsheirer.identifier;
 
 import io.github.dsheirer.CommonFixtures;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,5 +13,18 @@ public class IdentifierCollectionTest implements CommonFixtures {
     // expect
     assertThat(someIdentifiers()).isEqualTo(someIdentifiers());
     assertThat(someIdentifiers().hashCode()).isEqualTo(someIdentifiers().hashCode());
+  }
+
+  @Test
+  public void shouldSetIdentifiersAndTimeslot() {
+    // given
+    final var identifiers = someIdentifiers().mIdentifiers;
+    final var collection = new IdentifierCollection(identifiers, 8);
+
+    // expect
+    final var softly = new SoftAssertions();
+    softly.assertThat(collection.mIdentifiers).isEqualTo(identifiers);
+    softly.assertThat(collection.getTimeslot()).isEqualTo(8);
+    softly.assertAll();
   }
 }

--- a/src/test/java/io/github/dsheirer/identifier/IdentifierCollectionTest.java
+++ b/src/test/java/io/github/dsheirer/identifier/IdentifierCollectionTest.java
@@ -1,0 +1,15 @@
+package io.github.dsheirer.identifier;
+
+import io.github.dsheirer.CommonFixtures;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IdentifierCollectionTest implements CommonFixtures {
+
+  @Test
+  public void shouldImplementHashCodeAndEquals() {
+    assertThat(someIdentifiers()).isEqualTo(someIdentifiers());
+    assertThat(someIdentifiers().hashCode()).isEqualTo(someIdentifiers().hashCode());
+  }
+}

--- a/src/test/java/io/github/dsheirer/identifier/IdentifierCollectionTest.java
+++ b/src/test/java/io/github/dsheirer/identifier/IdentifierCollectionTest.java
@@ -9,6 +9,7 @@ public class IdentifierCollectionTest implements CommonFixtures {
 
   @Test
   public void shouldImplementHashCodeAndEquals() {
+    // expect
     assertThat(someIdentifiers()).isEqualTo(someIdentifiers());
     assertThat(someIdentifiers().hashCode()).isEqualTo(someIdentifiers().hashCode());
   }

--- a/src/test/java/io/github/dsheirer/module/decode/event/DecodeEventTest.java
+++ b/src/test/java/io/github/dsheirer/module/decode/event/DecodeEventTest.java
@@ -1,0 +1,33 @@
+package io.github.dsheirer.module.decode.event;
+
+import io.github.dsheirer.CommonFixtures;
+import io.github.dsheirer.protocol.Protocol;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+public class DecodeEventTest implements CommonFixtures {
+
+  @Test
+  public void builderShouldHonorSetValues() {
+    final var decodeEvent = DecodeEvent.builder(123L)
+        .channel(someChannel())
+        .eventType(DecodeEventType.CALL)
+        .eventDescription("some description")
+        .identifiers(someIdentifiers())
+        .details("some details")
+        .protocol(Protocol.DMR)
+        .timeslot(2)
+        .build();
+
+    final var softly = new SoftAssertions();
+    softly.assertThat(decodeEvent.getTimeStart()).isEqualTo(123L);
+    softly.assertThat(decodeEvent.getChannelDescriptor()).isEqualTo(someChannel());
+    softly.assertThat(decodeEvent.getEventType()).isEqualTo(DecodeEventType.CALL);
+    softly.assertThat(decodeEvent.getEventDescription()).isEqualTo("some description");
+    softly.assertThat(decodeEvent.getIdentifierCollection()).isEqualTo(someIdentifiers());
+    softly.assertThat(decodeEvent.getDetails()).isEqualTo("some details");
+    softly.assertThat(decodeEvent.getProtocol()).isEqualTo(Protocol.DMR);
+    softly.assertThat(decodeEvent.getTimeslot()).isEqualTo(2);
+    softly.assertAll();
+  }
+}

--- a/src/test/java/io/github/dsheirer/module/decode/event/DecodeEventTest.java
+++ b/src/test/java/io/github/dsheirer/module/decode/event/DecodeEventTest.java
@@ -9,7 +9,7 @@ public class DecodeEventTest implements CommonFixtures {
 
   @Test
   public void builderShouldHonorSetValues() {
-    //given
+    // given
     final var decodeEvent = DecodeEvent.builder(123L)
         .channel(someChannel())
         .eventType(DecodeEventType.CALL)

--- a/src/test/java/io/github/dsheirer/module/decode/event/DecodeEventTest.java
+++ b/src/test/java/io/github/dsheirer/module/decode/event/DecodeEventTest.java
@@ -9,6 +9,7 @@ public class DecodeEventTest implements CommonFixtures {
 
   @Test
   public void builderShouldHonorSetValues() {
+    //given
     final var decodeEvent = DecodeEvent.builder(123L)
         .channel(someChannel())
         .eventType(DecodeEventType.CALL)
@@ -19,6 +20,7 @@ public class DecodeEventTest implements CommonFixtures {
         .timeslot(2)
         .build();
 
+    // expect
     final var softly = new SoftAssertions();
     softly.assertThat(decodeEvent.getTimeStart()).isEqualTo(123L);
     softly.assertThat(decodeEvent.getChannelDescriptor()).isEqualTo(someChannel());

--- a/src/test/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSetTest.java
+++ b/src/test/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSetTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DecodeEventFilterSetTest {
 
   @Test
-  public void shouldContainDisjunctiveFilters() {
+  public void shouldContainDisjointFilters() {
     // given
     final var filters = new DecodeEventFilterSet().getFilters();
 

--- a/src/test/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSetTest.java
+++ b/src/test/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSetTest.java
@@ -1,0 +1,70 @@
+package io.github.dsheirer.module.decode.event.filter;
+
+import com.google.common.collect.Sets;
+import io.github.dsheirer.module.decode.event.DecodeEvent;
+import io.github.dsheirer.module.decode.event.DecodeEventType;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DecodeEventFilterSetTest {
+
+  @Test
+  public void shouldContainDisjunctiveFilters() {
+    // given
+    final var filters = new DecodeEventFilterSet().getFilters();
+
+    for (final var filter1 : filters) {
+      for (final var filter2 : filters) {
+        if (filter1 != filter2) {
+          // when
+          final var intersection = Sets.intersection(
+              Set.copyOf(((EventFilter) filter1).getFilterElements()),
+              Set.copyOf(((EventFilter) filter2).getFilterElements())
+          );
+
+          // then
+          assertThat(intersection)
+              .as("Decode event filters must be disjoint")
+              .isEmpty();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void shouldCoverDecodeEventsWithAllTypes() {
+    // given
+    final var types = DecodeEventType.values();
+    final var filters = new DecodeEventFilterSet().getFilters();
+
+    // when
+    for (final var type : types) {
+      final var capableFilters =
+          filters.stream().filter(f -> {
+            final var someDecodeEvent = DecodeEvent.builder(0).eventType(type).build();
+            return f.canProcess(someDecodeEvent);
+          });
+
+      // then
+      assertThat(capableFilters)
+          .as("Decode event with type " + type + " must be handled by a filter")
+          .isNotEmpty();
+    }
+  }
+
+  @Test
+  public void shouldHandleDecodeEventsWithoutType() {
+    // given
+    final var filters = new DecodeEventFilterSet().getFilters();
+    final var someDecodeEvent = DecodeEvent.builder(0).build();
+
+    // expect
+    assertThat(filters)
+        .filteredOn(f -> f.canProcess(someDecodeEvent))
+        .as("Decode event without type must be handled")
+        .isNotEmpty();
+  }
+}

--- a/src/test/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSetTest.java
+++ b/src/test/java/io/github/dsheirer/module/decode/event/filter/DecodeEventFilterSetTest.java
@@ -58,13 +58,52 @@ public class DecodeEventFilterSetTest {
   @Test
   public void shouldHandleDecodeEventsWithoutType() {
     // given
-    final var filters = new DecodeEventFilterSet().getFilters();
-    final var someDecodeEvent = DecodeEvent.builder(0).build();
+    final var filterSet = new DecodeEventFilterSet();
+    final var decodeEventWithoutType = DecodeEvent.builder(0).build();
 
     // expect
-    assertThat(filters)
-        .filteredOn(f -> f.canProcess(someDecodeEvent))
+    assertThat(filterSet.canProcess(decodeEventWithoutType))
         .as("Decode event without type must be handled")
-        .isNotEmpty();
+        .isTrue();
+  }
+
+  @Test
+  public void shouldPassAllDecodeEventTypesByDefault() {
+    // given
+    final var filterSet = new DecodeEventFilterSet();
+
+    // expect
+    for (final var type : DecodeEventType.values()) {
+      final var someDecodeEvent = DecodeEvent.builder(0).eventType(type).build();
+      assertThat(filterSet.passes(someDecodeEvent)).isTrue();
+    }
+  }
+
+  @Test
+  public void shouldAllowFilteringOutEverything() {
+    // given
+    final var filterSet = new DecodeEventFilterSet();
+    final var someDecodeEvent = DecodeEvent.builder(0).eventType(DecodeEventType.CALL).build();
+
+    // when
+    filterSet.setEnabled(false);
+
+    // then
+    assertThat(filterSet.passes(someDecodeEvent)).isFalse();
+  }
+
+  @Test
+  public void shouldAllowFilteringOutByDecodeEventTypeGroup() {
+    // given
+    final var filterSet = new DecodeEventFilterSet();
+    final var someDecodeEvent = DecodeEvent.builder(0).eventType(DecodeEventType.CALL).build();
+
+    // when
+    filterSet.getFilters().stream()
+        .filter(f -> f.canProcess(someDecodeEvent))
+        .forEach(f -> f.setEnabled(false));
+
+    // then
+    assertThat(filterSet.passes(someDecodeEvent)).isFalse();
   }
 }

--- a/src/test/java/io/github/dsheirer/module/decode/event/filter/EventFilterTest.java
+++ b/src/test/java/io/github/dsheirer/module/decode/event/filter/EventFilterTest.java
@@ -1,0 +1,70 @@
+package io.github.dsheirer.module.decode.event.filter;
+
+import io.github.dsheirer.module.decode.event.DecodeEvent;
+import io.github.dsheirer.module.decode.event.DecodeEventType;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EventFilterTest {
+
+  @Test
+  public void shouldProcessSpecifiedDecodeEventTypesAndAllowThemByDefault() {
+    // given
+    final var types = List.of(DecodeEventType.CALL, DecodeEventType.PAGE);
+    final var filter = new EventFilter("some name", types);
+
+    // expect
+    for (final var type : types) {
+      final var decodeEvent = DecodeEvent.builder(0).eventType(type).build();
+      assertThat(filter.canProcess(decodeEvent)).isTrue();
+      assertThat(filter.passes(decodeEvent)).isTrue();
+    }
+  }
+
+  @Test
+  public void shouldNotProcessOrAllowOtherDecodeEventTypes() {
+    // given
+    final var filter = new EventFilter("some name", List.of(DecodeEventType.CALL, DecodeEventType.PAGE));
+    final var decodeEvent = DecodeEvent.builder(0).eventType(DecodeEventType.ANNOUNCEMENT).build();
+
+    // expect
+    assertThat(filter.canProcess(decodeEvent)).isFalse();
+    assertThat(filter.passes(decodeEvent)).isFalse();
+  }
+
+  @Test
+  public void shouldFilterOutSpecifiedDecodeEventTypesWhenDisabled() {
+    // given
+    final var types = List.of(DecodeEventType.CALL, DecodeEventType.PAGE);
+    final var filter = new EventFilter("some name", types);
+
+    // when
+    filter.setEnabled(false);
+
+    // then
+    for (final var type : types) {
+      final var decodeEvent = DecodeEvent.builder(0).eventType(type).build();
+      assertThat(filter.canProcess(decodeEvent)).isTrue();
+      assertThat(filter.passes(decodeEvent)).isFalse();
+    }
+  }
+
+  @Test
+  public void shouldAllowFilteringOutBySpecificDecodeEventType() {
+    // given
+    final var filter = new EventFilter("some name", List.of(DecodeEventType.CALL, DecodeEventType.PAGE));
+    final var decodeEvent = DecodeEvent.builder(0).eventType(DecodeEventType.CALL).build();
+
+    // when
+    filter.getFilterElements().stream()
+        .filter(f -> f.getElement().equals(decodeEvent.getEventType()))
+        .forEach(f -> f.setEnabled(false));
+
+    // then
+    assertThat(filter.canProcess(decodeEvent)).isTrue();
+    assertThat(filter.passes(decodeEvent)).isFalse();
+  }
+}

--- a/src/test/java/io/github/dsheirer/module/log/DecodeEventLoggerTest.java
+++ b/src/test/java/io/github/dsheirer/module/log/DecodeEventLoggerTest.java
@@ -19,7 +19,6 @@
 
 package io.github.dsheirer.module.log;
 
-import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasModel;
 import io.github.dsheirer.channel.IChannelDescriptor;
 import io.github.dsheirer.identifier.IdentifierCollection;
@@ -29,20 +28,15 @@ import io.github.dsheirer.identifier.configuration.DecoderTypeConfigurationIdent
 import io.github.dsheirer.identifier.configuration.FrequencyConfigurationIdentifier;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.event.DecodeEvent;
-import io.github.dsheirer.module.decode.event.IDecodeEvent;
 import io.github.dsheirer.module.decode.p25.identifier.channel.APCO25Channel;
 import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25Talkgroup;
 import io.github.dsheirer.protocol.Protocol;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class DecodeEventLoggerTest {
     IChannelDescriptor channelDescriptor = APCO25Channel.create(98765, 1);
@@ -79,7 +73,6 @@ class DecodeEventLoggerTest {
         return DecodeEvent.builder(1634428994000L)
                 .channel(channelDescriptor)
                 .identifiers(buildIdentifierCollection())
-                .duration(111)
                 .protocol(Protocol.APCO25)
                 .eventDescription("DATA_PACKET")
                 .timeslot(2)


### PR DESCRIPTION
This is my attempt at fixing current implementation of decode event filtering which has the following problems:

1. Wrong layout with excessive space between button bar and decode event list view:
   ![image](https://user-images.githubusercontent.com/41550889/180646066-3cb837da-7580-431d-b2c0-f94e1a3bbd2c.png)
2. Current decode event filter set not covering all `DecodeEventType`s - `CALL` was missing
3. `DecodeEventBuilder` not honoring `DecodeEventType` set on it
4. Decode event list ("Events" view) is not properly reversing list of events and filtering it using set filters when changing channels in "Now Playing" view - notice the ordering below before the fix. However, new events are added at the top.
   ![image](https://user-images.githubusercontent.com/41550889/180646473-34640597-ac53-4fce-97aa-f39b2bf1b438.png)

5. Most of the `DecodeEvent`s in the codebase do not have `DecodeEventType` set at all (so it's `null`). As a consequence they do not pass `EventFilter.passes` and by extension - they are not added to the "Events" list and do not receive updates (e.g. call duration). This is fixed by adding a new "Everything else" node in the filter tree which acts as a catch-all for all such events. An alternative would be to go over the whole codebase and make sure each created `DecodeEvent` has type specified.

Any remarks welcome :slightly_smiling_face: 

*Edit*: I see that #1099 is a follow-up to the #1098 that introduced event filtering. I think this PR could be an interim solution before #1099 gets merged (and fix issues that are not addressed by #1099)

*Edit 2*: I started adding some JUnit tests to verify the new behavior, following boy-scout approach. I plan to add tests for most of the changes in this PR.

*Edit 3*: I added tests following TDD and then adjusted implementation to adhere to the contract specified by the tests.