### PR TITLE
Fixes bitstream recording and adds some tests for changed behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.8.0'
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
     testImplementation 'org.mockito:mockito-core:3.+'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 

--- a/src/main/java/io/github/dsheirer/dsp/symbol/BinaryToByteBufferAssembler.java
+++ b/src/main/java/io/github/dsheirer/dsp/symbol/BinaryToByteBufferAssembler.java
@@ -84,6 +84,7 @@ public class BinaryToByteBufferAssembler implements IBinarySymbolProcessor, IByt
 
             if(!mCurrentBuffer.hasRemaining())
             {
+                mCurrentBuffer.flip();
                 getNextBuffer();
             }
         }

--- a/src/main/java/io/github/dsheirer/util/Dispatcher.java
+++ b/src/main/java/io/github/dsheirer/util/Dispatcher.java
@@ -157,8 +157,6 @@ public class Dispatcher<E> implements Listener<E>
         @Override
         public void run()
         {
-            mQueue.clear();
-
             E element;
 
             while(mRunning.get())
@@ -167,7 +165,7 @@ public class Dispatcher<E> implements Listener<E>
                 {
                     element = mQueue.take();
 
-                    if(mPoisonPill.equals(element))
+                    if(mPoisonPill == element)
                     {
                         mRunning.set(false);
                     }

--- a/src/test/java/io/github/dsheirer/dsp/symbol/BinaryToByteBufferAssemblerTest.java
+++ b/src/test/java/io/github/dsheirer/dsp/symbol/BinaryToByteBufferAssemblerTest.java
@@ -1,0 +1,55 @@
+package io.github.dsheirer.dsp.symbol;
+
+import io.github.dsheirer.sample.CapturingListener;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BinaryToByteBufferAssemblerTest {
+
+  @Test
+  void shouldCallListenerOnFullBuffer() {
+    // given
+    final var listener = new CapturingListener<ByteBuffer>();
+    final var assembler = new BinaryToByteBufferAssembler(1);
+    assembler.setBufferListener(listener);
+
+    // when
+    for (var i = 0; i < 8; i++) assembler.process(true);
+
+    // then
+    assertThat(listener.capturedValues()).hasSize(1);
+
+    final var buffer = listener.capturedValues().get(0);
+    final var softly = new SoftAssertions();
+    softly.assertThat(buffer.limit()).isEqualTo(1);
+    softly.assertThat(buffer.position()).isEqualTo(0);
+    softly.assertThat(buffer.get(0)).isEqualTo((byte) 0b11111111);
+    softly.assertAll();
+  }
+
+  @Test
+  void shouldResetBufferWhenFull() {
+    // given
+    final var listener = new CapturingListener<ByteBuffer>();
+    final var assembler = new BinaryToByteBufferAssembler(1);
+    assembler.setBufferListener(listener);
+
+    // when
+    for (var i = 0; i < 8; i++) assembler.process(true);
+    for (var i = 0; i < 8; i++) assembler.process(false);
+
+    // then
+    assertThat(listener.capturedValues()).hasSize(2);
+
+    final var buffer = listener.capturedValues().get(1);
+    final var softly = new SoftAssertions();
+    softly.assertThat(buffer.limit()).isEqualTo(1);
+    softly.assertThat(buffer.position()).isEqualTo(0);
+    softly.assertThat(buffer.get(0)).isEqualTo((byte) 0b00000000);
+    softly.assertAll();
+  }
+}

--- a/src/test/java/io/github/dsheirer/sample/CapturingListener.java
+++ b/src/test/java/io/github/dsheirer/sample/CapturingListener.java
@@ -1,0 +1,19 @@
+package io.github.dsheirer.sample;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CapturingListener<T> implements Listener<T> {
+
+  private final ArrayList<T> values = new ArrayList<>();
+
+  @Override
+  public synchronized void receive(T t) {
+    values.add(t);
+  }
+
+  public synchronized List<T> capturedValues() {
+    return Collections.unmodifiableList(values);
+  }
+}

--- a/src/test/java/io/github/dsheirer/util/DispatcherTest.java
+++ b/src/test/java/io/github/dsheirer/util/DispatcherTest.java
@@ -1,0 +1,77 @@
+package io.github.dsheirer.util;
+
+import io.github.dsheirer.sample.CapturingListener;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class DispatcherTest {
+
+  @Test
+  void shouldCallListenerWithSuppliedElements() {
+    // given
+    final var dispatcher = new Dispatcher<>(3, "some thread name", "");
+    final var listener = new CapturingListener<String>();
+    dispatcher.setListener(listener);
+
+    // when
+    dispatcher.start();
+    dispatcher.receive("1");
+    dispatcher.receive("2");
+    dispatcher.flushAndStop();
+
+    // then
+    await()
+        .atMost(1, SECONDS)
+        .untilAsserted(() -> assertThat(listener.capturedValues()).containsExactly("1", "2"));
+  }
+
+  @Test
+  void shouldCallListenerOnDedicatedThread() {
+    // given
+    final var dispatcher = new Dispatcher<>(3, "some thread name", "");
+    final var threadCaptor = new AtomicReference<Thread>();
+    dispatcher.setListener(e -> threadCaptor.set(Thread.currentThread()));
+
+    // when
+    dispatcher.start();
+    dispatcher.receive("1");
+    dispatcher.receive("2");
+    dispatcher.flushAndStop();
+
+    // then
+    await()
+        .atMost(1, SECONDS)
+        .untilAsserted(() -> assertThat(threadCaptor.get()).isNotNull());
+
+    // and
+    final var thread = threadCaptor.get();
+    assertThat(thread).isNotEqualTo(Thread.currentThread());
+    assertThat(thread.getName()).isEqualTo("some thread name");
+  }
+
+  @Test
+  void shouldDropElementsWhenQueueIsFull() {
+    // given
+    final var dispatcher = new Dispatcher<>(1, "some thread name", "");
+    final var listener = new CapturingListener<String>();
+    dispatcher.setListener(listener);
+
+    final var elements = IntStream.range(1, 100).mapToObj(String::valueOf).toList();
+
+    // when
+    dispatcher.start();
+    for (final var element : elements) dispatcher.receive(element);
+    dispatcher.flushAndStop();
+
+    // then
+    await()
+        .atMost(1, SECONDS)
+        .untilAsserted(() -> assertThat(listener.capturedValues()).doesNotContainSequence(elements));
+  }
+}


### PR DESCRIPTION
Bitstream recording doesn't seem to work after some fairly recent changes as:

1. `BinaryToByteBufferAssembler` isn't flipping the buffer before handing it out to the listener,
2. `Dispatcher` used `equals` on poison pill which in case of bitstream recording is an empty `ByteBuffer`. Due to [peculiar semantics](https://docs.oracle.com/javase/7/docs/api/java/nio/ByteBuffer.html#equals(java.lang.Object)) of `java.nio.ByteBuffer#equals` the empty ByteBuffer (poison pill) is equal to a fully filled `ByteBuffer`, which immediately stopped the `Dispatcher` and in consequence - the recording.

This PR attempts to fix these issues and adds some basic tests for `BinaryToByteBufferAssembler` and `Dispatcher`