### PR TITLE
#1340 Tuner Frequency Controller - Threading Issue

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" default="true" project-jdk-name="liberica-19.0.1.fx" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="liberica-19.0.1.fx" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/io/github/dsheirer/source/SourceEvent.java
+++ b/src/main/java/io/github/dsheirer/source/SourceEvent.java
@@ -197,7 +197,7 @@ public class SourceEvent
     /**
      * Creates a new locked state change event
      */
-    public static SourceEvent lockedState()
+    public static SourceEvent lockedSampleRateState()
     {
         return new SourceEvent(Event.NOTIFICATION_FREQUENCY_AND_SAMPLE_RATE_LOCKED, 1);
     }
@@ -205,7 +205,7 @@ public class SourceEvent
     /**
      * Creates a new unlocked state change event
      */
-    public static SourceEvent unlockedState()
+    public static SourceEvent unlockedSampleRateState()
     {
         return new SourceEvent(Event.NOTIFICATION_FREQUENCY_AND_SAMPLE_RATE_UNLOCKED, 0);
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
@@ -25,6 +25,9 @@ import io.github.dsheirer.source.tuner.manager.DiscoveredTuner;
 import io.github.dsheirer.source.tuner.manager.TunerManager;
 import io.github.dsheirer.source.tuner.manager.TunerStatus;
 import io.github.dsheirer.source.tuner.ui.TunerEditor;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
 import net.miginfocom.swing.MigLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,9 +43,6 @@ import javax.swing.JSlider;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.List;
 
 /**
  * Airspy tuner editor/controller
@@ -102,7 +102,7 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
         getTunerStatusLabel().setText(status);
         getButtonPanel().updateControls();
         getFrequencyPanel().updateControls();
-        getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLocked());
+        getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
         getTunerInfoButton().setEnabled(hasTuner());
         updateGainComponents((hasTuner() && hasConfiguration()) ? getConfiguration().getGain() : null);
 
@@ -626,7 +626,7 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
      */
     private void updateSampleRateToolTip()
     {
-        if(hasTuner() && getTuner().getController().isLocked())
+        if(hasTuner() && getTuner().getController().isLockedSampleRate())
         {
             mSampleRateCombo.setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
@@ -120,7 +120,7 @@ public class HackRFTunerEditor extends TunerEditor<HackRFTuner,HackRFTunerConfig
         getTunerStatusLabel().setText(status);
         getButtonPanel().updateControls();
         getFrequencyPanel().updateControls();
-        getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLocked());
+        getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
         updateSampleRateToolTip();
         getTunerInfoButton().setEnabled(hasTuner());
 
@@ -295,7 +295,7 @@ public class HackRFTunerEditor extends TunerEditor<HackRFTuner,HackRFTunerConfig
      */
     private void updateSampleRateToolTip()
     {
-        if(hasTuner() && getTuner().getController().isLocked())
+        if(hasTuner() && getTuner().getController().isLockedSampleRate())
         {
             mSampleRateCombo.setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
@@ -82,18 +82,30 @@ public class PassThroughSourceManager extends ChannelSourceManager
     @Override
     public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification)
     {
+
         if(!mRunning)
         {
             return null;
         }
 
-        PassThroughChannelSource channelSource = new PassThroughChannelSource(new SourceEventProxy(),
-                mTunerController, tunerChannel);
+        TunerChannelSource source = null;
 
-        mTunerChannels.add(tunerChannel);
-        mTunerChannelSources.add(channelSource);
+        try
+        {
+            mTunerController.getFrequencyControllerLock().lock();
+            PassThroughChannelSource channelSource = new PassThroughChannelSource(new SourceEventProxy(),
+                    mTunerController, tunerChannel);
 
-        return channelSource;
+            mTunerChannels.add(tunerChannel);
+            mTunerChannelSources.add(channelSource);
+            source = channelSource;
+        }
+        finally
+        {
+            mTunerController.getFrequencyControllerLock().unlock();
+        }
+
+        return source;
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
@@ -29,6 +29,8 @@ import io.github.dsheirer.source.tuner.rtl.e4k.E4KEmbeddedTuner.E4KGain;
 import io.github.dsheirer.source.tuner.rtl.e4k.E4KEmbeddedTuner.E4KLNAGain;
 import io.github.dsheirer.source.tuner.rtl.e4k.E4KEmbeddedTuner.E4KMixerGain;
 import io.github.dsheirer.source.tuner.ui.TunerEditor;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import net.miginfocom.swing.MigLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +43,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JSeparator;
 import javax.swing.SpinnerNumberModel;
 import javax.usb.UsbException;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 /**
  * E4000 tuner editor
@@ -383,7 +383,7 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
      */
     private void updateSampleRateToolTip()
     {
-        if(hasTuner() && getTuner().getTunerController().isLocked())
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
         {
             getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerEditor.java
@@ -416,7 +416,7 @@ public class R820TTunerEditor extends TunerEditor<RTL2832Tuner,R820TTunerConfigu
      */
     private void updateSampleRateToolTip()
     {
-        if(hasTuner() && getTuner().getTunerController().isLocked())
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
         {
             getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
@@ -25,10 +25,6 @@ import io.github.dsheirer.source.tuner.manager.DiscoveredTuner;
 import io.github.dsheirer.source.tuner.manager.DiscoveredUSBTuner;
 import io.github.dsheirer.source.tuner.manager.IDiscoveredTunerStatusListener;
 import io.github.dsheirer.source.tuner.manager.TunerStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.swing.table.AbstractTableModel;
 import java.awt.EventQueue;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -36,6 +32,10 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.table.AbstractTableModel;
 
 /**
  * Model for discovered tuners
@@ -449,7 +449,7 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
                     if(discoveredTuner.hasTuner())
                     {
                         int channelCount = discoveredTuner.getTuner().getChannelSourceManager().getTunerChannelCount();
-                        return channelCount + " (" + (discoveredTuner.getTuner().getTunerController().isLocked() ? "LOCKED)" : "UNLOCKED)");
+                        return channelCount + " (" + (discoveredTuner.getTuner().getTunerController().isLockedSampleRate() ? "LOCKED)" : "UNLOCKED)");
                     }
                     else
                     {

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
@@ -619,8 +619,8 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         {
             getFrequencyControl().clearListeners();
             getFrequencyControl().addListener(mFrequencyAndCorrectionChangeListener);
-            getFrequencyControl().setEnabled(hasTuner() && !getTuner().getTunerController().isLocked());
-            getTunerLockedStatusLabel().setVisible(hasTuner() && getTuner().getTunerController().isLocked());
+            getFrequencyControl().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
+            getTunerLockedStatusLabel().setVisible(hasTuner() && getTuner().getTunerController().isLockedSampleRate());
             getFrequencyCorrectionSpinner().setEnabled(hasTuner());
             getAutoPPMCheckBox().setEnabled(hasTuner());
 

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerViewPanel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerViewPanel.java
@@ -143,7 +143,7 @@ public class TunerViewPanel extends JPanel
 
                             if(selectedTuner != null && selectedTuner.hasTuner() && tunerEvent.getTuner() == selectedTuner.getTuner())
                             {
-                                mDiscoveredTunerEditor.setTunerLockState(selectedTuner.getTuner().getTunerController().isLocked());
+                                mDiscoveredTunerEditor.setTunerLockState(selectedTuner.getTuner().getTunerController().isLockedSampleRate());
                             }
                         }
                     }


### PR DESCRIPTION
#1340 Updates tuner and frequency controllers to apply locking to ensure multi-threaded access to frequency control plane doesn't allow center tuned frequency to become indeterminant which can result in channels being mistuned and stop decoding.  This resolves a likely issue that was causing users to report that their channels stopped decoding after a while.  Decoding multiple control channels, user changing the PPM settings on the tuner, and tuner auto-PPM correction were each allowed unprotected access to the frequency control plane and could potentially step on each other.  New locking behavior ensures that channel source allocations and PPM corrections complete atomically through the use of a reentrant lock.