### PR TITLE
Disable resampling if requested sample rate not supported

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/convert/MP3AudioConverter.java
+++ b/src/main/java/io/github/dsheirer/audio/convert/MP3AudioConverter.java
@@ -57,13 +57,21 @@ public class MP3AudioConverter implements IAudioConverter
     public MP3AudioConverter(InputAudioFormat inputAudioFormat, MP3Setting setting, boolean normalizeAudio)
     {
         mInputAudioFormat = inputAudioFormat;
+
         mEncoder = LameFactory.getLameEncoder(inputAudioFormat, setting);
+        if(inputAudioFormat.getSampleRate() != mEncoder.getEffectiveSampleRate())
+        {
+            mLog.warn("MP3 encoder setting '" + setting + "' doesn't support sample rate '" + inputAudioFormat + "', resampling disabled. Increase bitrate or decrease sample rate to fix.");
+            mInputAudioFormat = InputAudioFormat.SR_8000;
+            mEncoder = LameFactory.getLameEncoder(mInputAudioFormat, setting);
+        }
+
         mNormalizeAudio = normalizeAudio;
 
         //Resampling is only required if desired input sample rate is not system default of 8kHz
-        if(inputAudioFormat != InputAudioFormat.SR_8000 && inputAudioFormat != InputAudioFormat.SR_32_8000)
+        if(mInputAudioFormat != InputAudioFormat.SR_8000 && mInputAudioFormat != InputAudioFormat.SR_32_8000)
         {
-            mResampler = LameFactory.getResampler(inputAudioFormat);
+            mResampler = LameFactory.getResampler(mInputAudioFormat);
         }
 
         mOutputFramesBuffer = new byte[mEncoder.getPCMBufferSize()];


### PR DESCRIPTION
If the MP3 encoder is unable to support the configured sample rate, disable resampling and warn, rather than resampling twice to the incorrect sample rate.

Warning should help users identify #1237 and self-resolve configuration, since it's not possible to disable resampling in ```LameEncoder```.

The defaults should be adjusted to 16kbps/16kHz or 32kbps/22.05kHz to have a valid combination.

@DSheirer: Second attempt, now with the correct commit (sorry!). Fixes issue in #1255 with resampling code using the argument ```inputAudioFormat``` instead of ```mInputAudioFormat```. (I had that fixed locally but apparently forgot to push it.)