### PR TITLE
Allow duplicate detection by radio ID to record and stream correctly

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/AudioSegment.java
+++ b/src/main/java/io/github/dsheirer/audio/AudioSegment.java
@@ -409,11 +409,33 @@ public class AudioSegment implements Listener<IdentifierUpdateNotification>
     /**
      * Adds the identifier to this audio segment and updates record, priority and streaming properties.
      *
+     * @param identifier object
+     * 
      * Note: identifiers pass to this method must be checked for timeslot match.
      */
     public void addIdentifier(Identifier identifier)
     {
-        mIdentifierCollection.update(identifier);
+        addIdentifier(identifier, true);
+    }
+
+    /**
+     * Adds the identifier to this audio segment and updates record, priority and streaming properties.
+     *
+     * @param identifier object
+     * @param replace true if this identifier should replace the existing
+     * 
+     * Note: identifiers pass to this method must be checked for timeslot match.
+     */
+    public void addIdentifier(Identifier identifier, Boolean replace)
+    {
+        if(replace)
+        {
+            mIdentifierCollection.update(identifier);
+        }
+        else
+        {
+            mIdentifierCollection.add(identifier);
+        }
 
         List<Alias> aliases = mAliasList.getAliases(identifier);
 

--- a/src/main/java/io/github/dsheirer/audio/DuplicateCallDetector.java
+++ b/src/main/java/io/github/dsheirer/audio/DuplicateCallDetector.java
@@ -270,6 +270,15 @@ public class DuplicateCallDetector implements Listener<AudioSegment>
                                 {
                                     if(isDuplicate(current, toCheck))
                                     {
+                                        /* Copy TO identifiers to current audio segment so that duplicates from different TGs broadcast/record correctly */
+                                        for(Identifier identifier: toCheck.getIdentifierCollection().getIdentifiers(Role.TO))
+                                        {
+                                            if(!current.getIdentifierCollection().getIdentifiers().contains(identifier))
+                                            {
+                                                current.addIdentifier(identifier, false);
+                                            }
+                                        }
+
                                         toCheck.setDuplicate(true);
                                         toCheck.decrementConsumerCount();
                                         duplicates.add(toCheck);

--- a/src/main/java/io/github/dsheirer/gui/preference/duplicate/DuplicateCallPreferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/duplicate/DuplicateCallPreferenceEditor.java
@@ -90,16 +90,6 @@ public class DuplicateCallPreferenceEditor extends HBox
             GridPane.setConstraints(radioLabel, 1, row);
             mEditorPane.getChildren().add(radioLabel);
 
-            Label warningLabel = new Label("Note: be careful when enabling duplicate call detection by Radio ID " +
-                "because this can produce unintended side-effects.  For example, if you have two talkgroups with " +
-                "talkgroup 1 set to record and talkgroup 2 set to stream and dispatch radio ID 1234 makes a " +
-                "simultaneous call to both talkgroup 1 and talkgroup 2, there is no way to control which call audio " +
-                "(talkgroup 1 or 2) gets flagged as the duplicate call and therefore either the audio for talkgroup 1 " +
-                "doesn't record, or the audio for talkgroup 2 doesn't stream.");
-            warningLabel.setWrapText(true);
-            GridPane.setConstraints(warningLabel, 0, ++row, 2, 1);
-            mEditorPane.getChildren().add(warningLabel);
-
             Separator separator = new Separator();
             GridPane.setHgrow(separator, Priority.ALWAYS);
             GridPane.setConstraints(separator, 0, ++row, 2, 1);

--- a/src/main/java/io/github/dsheirer/identifier/MutableIdentifierCollection.java
+++ b/src/main/java/io/github/dsheirer/identifier/MutableIdentifierCollection.java
@@ -122,7 +122,7 @@ public class MutableIdentifierCollection extends IdentifierCollection implements
      *
      * @param identifier to add
      */
-    private void add(Identifier identifier)
+    public void add(Identifier identifier)
     {
         if(identifier.isValid() && !mIdentifiers.contains(identifier))
         {


### PR DESCRIPTION
Adds ```TO``` identifiers (most importantly, talkgroup IDs) from duplicates to the audio that survives duplicate detection, so that it gets recorded/streamed correctly.

This PR does not address the assumption in most places about an audio segment having a single identifier. #1395 addresses that assumption for icecast metadata.