### PR TITLE
#1397 Decoding Channels Go IDLE After Period of Time

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/ChannelCalculator.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/ChannelCalculator.java
@@ -1,31 +1,34 @@
-/*******************************************************************************
- * *********************************************************************************************************************
- * sdr-trunk
- * Copyright (C) 2014-2017 Dennis Sheirer
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by  the Free Software Foundation, either version 3 of the License, or  (at your option) any
- * later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied
- * warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License  along with this program.
- * If not, see <http://www.gnu.org/licenses/>
- * *********************************************************************************************************************
- ******************************************************************************/
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
 package io.github.dsheirer.dsp.filter.channelizer;
 
 import io.github.dsheirer.source.tuner.channel.TunerChannel;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.commons.math3.util.FastMath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class ChannelCalculator
 {
+    private static final DecimalFormat FREQUENCY_FORMAT = new DecimalFormat("0.00000");
     private final static Logger mLog = LoggerFactory.getLogger(ChannelCalculator.class);
 
     /**
@@ -546,13 +549,13 @@ public class ChannelCalculator
     public String toString()
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("Channel Calculator Settings");
-        sb.append(" Channels:").append(getChannelCount());
-        sb.append(" Sample Rate:").append(getSampleRate());
-        sb.append(" Channel Bandwidth:").append(getChannelBandwidth());
-        sb.append(" Channel Rate:").append(getChannelSampleRate());
-        sb.append(" Min:").append(getMinimumFrequency());
-        sb.append(" Max:").append(getMaximumFrequency());
+        sb.append("Channel Calculator | Tuner SR:").append(FREQUENCY_FORMAT.format(getSampleRate() / 1E6D));
+        sb.append(" CF:").append(FREQUENCY_FORMAT.format(getCenterFrequency() / 1E6D));
+        sb.append(" MIN:").append(FREQUENCY_FORMAT.format(getMinimumFrequency() / 1E6D));
+        sb.append(" MAX:").append(FREQUENCY_FORMAT.format(getMaximumFrequency() / 1E6D));
+        sb.append(" | Channel COUNT:").append(getChannelCount());
+        sb.append(" BW:").append(FREQUENCY_FORMAT.format(getChannelBandwidth() / 1E6D));
+        sb.append(" SR:").append(FREQUENCY_FORMAT.format(getChannelSampleRate() / 1E6D));
         return sb.toString();
     }
 }

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelSource.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelSource.java
@@ -72,6 +72,14 @@ public class PolyphaseChannelSource extends TunerChannelSource implements Listen
     }
 
     /**
+     * Description of the state or configuration of the output processor.
+     */
+    public String getStateDescription()
+    {
+        return mPolyphaseChannelOutputProcessor.getStateDescription();
+    }
+
+    /**
      * Current output processor indexes.
      * @return indexes
      */
@@ -174,7 +182,7 @@ public class PolyphaseChannelSource extends TunerChannelSource implements Listen
                 {
                     try
                     {
-                        float[] filter = filterManager.getFilter(channelCalculator.getSampleRate(),
+                        float[] filter = filterManager.getFilter(channelCalculator.getChannelSampleRate(),
                                 channelCalculator.getChannelBandwidth(), indexes.size());
                         mPolyphaseChannelOutputProcessor.setSynthesisFilter(filter);
                     }

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/TwoChannelSynthesizerM2.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/TwoChannelSynthesizerM2.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 package io.github.dsheirer.dsp.filter.channelizer;
 
 import io.github.dsheirer.sample.complex.ComplexSamples;
+import java.util.Arrays;
 import org.apache.commons.math3.util.FastMath;
 import org.jtransforms.fft.FloatFFT_1D;
 import org.slf4j.Logger;
@@ -66,6 +67,20 @@ public class TwoChannelSynthesizerM2
     }
 
     /**
+     * Description of the state/configuration of this synthesizer to support debugging.
+     * @return state description.
+     */
+    public String getStateDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Two-Channel Synthesizer");
+        sb.append("\n\t\t Interleaved Filter: " + Arrays.toString(mIQInterleavedFilter));
+        sb.append("\n\t\t Serpentine Buffer Length: ").append(mSerpentineDataBuffer.length);
+        sb.append("\n\t\t Filter Vector Product Length: ").append(mFilterVectorProduct.length);
+        return sb.toString();
+    }
+
+    /**
      * Initializes the synthesizer filter and data buffers for operation.
      *
      * @param filter to use for polyphase synthesis of two channels.
@@ -73,7 +88,6 @@ public class TwoChannelSynthesizerM2
     private void init(float[] filter)
     {
         int tapsPerChannel = (int) FastMath.ceil(filter.length / 2);
-
         mIQInterleavedFilter = getInterleavedFilter(filter, tapsPerChannel);
         mSerpentineDataBuffer = new float[mIQInterleavedFilter.length];
         mFilterVectorProduct = new float[mIQInterleavedFilter.length];

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/IPolyphaseChannelOutputProcessor.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/IPolyphaseChannelOutputProcessor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,6 +24,11 @@ import java.util.List;
 
 public interface IPolyphaseChannelOutputProcessor
 {
+    /**
+     * Description of the state/configuration of this output processor
+     */
+    String getStateDescription();
+
     /**
      * Start processing channel results
      */

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/OneChannelOutputProcessor.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/OneChannelOutputProcessor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,6 +43,16 @@ public class OneChannelOutputProcessor extends ChannelOutputProcessor
         setPolyphaseChannelIndices(channelIndexes);
         mMixerAssembler = new OneChannelMixerAssembler(gain);
         mMixerAssembler.getMixer().setSampleRate(sampleRate);
+    }
+
+    @Override
+    public String getStateDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("One Channel Output Processor");
+        sb.append("\n\tIndex (doubled) [").append(mChannelOffset).append("]");
+        sb.append("\n\tMixer Assembler: none");
+        return sb.toString();
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/TwoChannelMixerAssembler.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/TwoChannelMixerAssembler.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,6 +40,19 @@ public class TwoChannelMixerAssembler extends MixerAssembler
     public TwoChannelMixerAssembler(float gain)
     {
         super(gain);
+    }
+
+    /**
+     * Description of the state/configuration of this mixer assembler.
+     */
+    public String getStateDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Two Channel Mixer Assembler - State Description:");
+        sb.append("\n\tTwo-Channel Synthesizer: ").append(mTwoChannelSynthesizer.getStateDescription());
+        sb.append("\n\tMixer Frequency: ").append(getMixer().getFrequency());
+        sb.append("\n\tGain: ").append(getGain().getGain());
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/TwoChannelOutputProcessor.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/TwoChannelOutputProcessor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,6 +47,16 @@ public class TwoChannelOutputProcessor extends ChannelOutputProcessor
         mMixerAssembler = new TwoChannelMixerAssembler(gain);
         mMixerAssembler.getMixer().setSampleRate(sampleRate);
         setSynthesisFilter(filter);
+    }
+
+    @Override
+    public String getStateDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Two Channel Output Processor");
+        sb.append("\n\tIndices (doubled) 1 [").append(mChannelOffset1).append("] 2 [").append(mChannelOffset2).append("]");
+        sb.append("\n\tMixer Assembler: ").append(mMixerAssembler.getStateDescription());
+        return sb.toString();
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/dsp/gain/complex/ComplexGain.java
+++ b/src/main/java/io/github/dsheirer/dsp/gain/complex/ComplexGain.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,7 +41,7 @@ public abstract class ComplexGain
      * Gain value that will be applied to complex samples
      * @return gain value
      */
-    protected float getGain()
+    public float getGain()
     {
         return mGain;
     }

--- a/src/main/java/io/github/dsheirer/gui/power/ChannelPowerPanel.java
+++ b/src/main/java/io/github/dsheirer/gui/power/ChannelPowerPanel.java
@@ -190,6 +190,7 @@ public class ChannelPowerPanel extends JPanel implements Listener<ProcessingChai
                     sb.append(" Tuner SR:").append(FREQUENCY_FORMAT.format(pcs.getTunerSampleRate() / 1E6d));
                     sb.append(" CF:").append(FREQUENCY_FORMAT.format(pcs.getTunerCenterFrequency() / 1E6d));
                     mLog.info(sb.toString());
+                    mLog.info("Output Processor: " + pcs.getStateDescription());
                 }
                 else if(source instanceof HalfBandTunerChannelSource<?> hbtcs)
                 {

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -51,6 +51,12 @@ public abstract class ChannelSourceManager implements ISourceEventProcessor
      * Sorted set of tuner channels being sourced by this source manager.  Set is ordered by frequency lowest to highest
      */
     public abstract SortedSet<TunerChannel> getTunerChannels();
+
+    /**
+     * State of this channel source manager for logging and debug purposes
+     * @return description of the state or configuration of this manager
+     */
+    public abstract String getStateDescription();
 
     /**
      * Count of tuner channels being sourced by this source manager.

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredTuner.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -53,6 +53,27 @@ public abstract class DiscoveredTuner implements ITunerErrorListener
     public TunerStatus getTunerStatus()
     {
         return mTunerStatus;
+    }
+
+    /**
+     * Logs current state of the tuner
+     */
+    public void logState()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Discovered Tuner: ").append(getId());
+
+        if(hasTuner())
+        {
+            sb.append("\n\tTuner - Frequency:").append(getTuner().getTunerController().getFrequency());
+            sb.append("\n\tChannel Manager:").append(getTuner().getChannelSourceManager().getStateDescription());
+        }
+        else
+        {
+            sb.append("\n\tTuner - no tuner");
+        }
+
+        mLog.info(sb.toString());
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,6 +58,23 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
     {
         mTunerController = tunerController;
         mTunerController.addListener(this);
+    }
+
+    @Override
+    public String getStateDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Heterodyne Channel Source Manager Providing [").append(mTunerChannels.size()).append("] Channels");
+        sb.append("\n\tTuner Controller Frequency: ").append(mTunerController.getFrequency());
+        for(HalfBandTunerChannelSource channelSource: mChannelSources)
+        {
+            sb.append("\n\tChannel [").append(channelSource.getTunerChannel())
+                    .append("] Frequency [").append(channelSource.getFrequency())
+                    .append("] Mixer [").append(channelSource.getMixerFrequency())
+                    .append("]");
+        }
+
+        return sb.toString();
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,6 +52,19 @@ public class PassThroughSourceManager extends ChannelSourceManager
     public PassThroughSourceManager(TunerController tunerController)
     {
         mTunerController = tunerController;
+    }
+
+    @Override
+    public String getStateDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Pass-Through Channel Source Manager Providing [").append(mTunerChannels.size()).append("] Channels");
+        for(TunerChannel channel: mTunerChannels)
+        {
+            sb.append("\n\tChannel: ").append(channel);
+        }
+
+        return sb.toString();
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
@@ -56,6 +56,17 @@ public class PolyphaseChannelSourceManager extends ChannelSourceManager
     }
 
     @Override
+    public String getStateDescription()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Polyphase Channel Source Manager");
+        sb.append("\n\tTuner Controller Frequency: ").append(mTunerController.getFrequency());
+        sb.append("\n\t").append(mPolyphaseChannelManager.getStateDescription());
+
+        return sb.toString();
+    }
+
+    @Override
     public void stopAllChannels()
     {
         mPolyphaseChannelManager.stopAllChannels();
@@ -454,7 +465,12 @@ public class PolyphaseChannelSourceManager extends ChannelSourceManager
                     }
                     catch(IllegalArgumentException iae)
                     {
+                        mLog.error("Center frequency calculation failed", iae);
                         //Center frequency calculation failed
+                    }
+                    catch(Exception e)
+                    {
+                        mLog.error("Error getting source", e);
                     }
                 }
             }

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -189,6 +189,7 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
      */
     public void removeDiscoveredTuner(DiscoveredTuner discoveredTuner)
     {
+        mLog.info("Removing discovered tuner: " + discoveredTuner.getId());
         mLock.lock();
 
         try

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerViewPanel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerViewPanel.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,7 +39,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.JButton;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
@@ -114,6 +116,32 @@ public class TunerViewPanel extends JPanel
                 }
             }
         });
+
+        //Add support for right-click context menu to the tuner table
+        JPopupMenu popupMenu = new JPopupMenu();
+        JMenuItem logStateMenuItem = new JMenuItem("Log Tuner State");
+        logStateMenuItem.addActionListener(e -> {
+            int viewRow = mTunerTable.getSelectedRow();
+
+            DiscoveredTuner selected = null;
+
+            if(viewRow >= 0)
+            {
+                int modelRow = mTunerTable.convertRowIndexToModel(viewRow);
+                selected = mDiscoveredTunerModel.getDiscoveredTuner(modelRow);
+            }
+
+            if(selected != null)
+            {
+                selected.logState();
+            }
+            else
+            {
+                mLog.error("Can't log state - tuner not selected");
+            }
+        });
+        popupMenu.add(logStateMenuItem);
+        mTunerTable.setComponentPopupMenu(popupMenu);
 
         //Monitor for tuner removal events so we can update the editor when our selected tuner is removed
         mDiscoveredTunerModel.addTableModelListener(e ->


### PR DESCRIPTION
Closes #1397 

Resolves issue where decoding channels go IDLE after period of time.  Isolated cause to a multi-threading issue where the polyphase channel manager receives notification that the tuner center frequency has changed and sets a flag to update each of the channels.  This happens concurrent with a previous tuner center frequency change where the flag gets set and the second thread is updating the channel output processors with the previous frequency change and then unsets the frequency change flag, completely missing the second/latest frequency change update and causing the channels to all tune-out their desired signals as the tuner center frequency changes and the output channels continue mixing to the previous frequency.

Identified and resolved issue where a 2-stream polyphase synthesizer was being updated with an incorrectly designed synthesis filter which was causing massive droop on the second half of the reconstructed channel.  Oddly enough, this didn't seem to impact the P25 decoders, but it may have impacted other decoding.

Identified and resolved issue with concurrent modification of the modules list in the processing chain associated with recent addition of the channel FFT view in the channel power tab, with a previous PR under this same issue.