### PR TITLE
#1393 DMR Talkgroup & Radio ID Editors Should Use Correct Formats

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/RadioIdEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/RadioIdEditor.java
@@ -217,6 +217,9 @@ public class RadioIdEditor extends IdentifierEditor<Radio>
             }
         }
 
+        mLog.warn("Unable to find radio id editor for protocol [" + protocol + "] and format [" + integerFormat +
+                "] - using default editor");
+
         //Use a default instance
         for(RadioDetail detail: mRadioDetails)
         {

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/RadioIdRangeEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/RadioIdRangeEditor.java
@@ -159,7 +159,7 @@ public class RadioIdRangeEditor extends IdentifierEditor<RadioRange>
             else
             {
                 mLog.warn("Couldn't find radio ID detail for protocol [" + getItem().getProtocol() +
-                    "] and format [" + format + "]");
+                        "] and format [" + format + "]");
                 getFormatLabel().setText(" ");
             }
         }
@@ -267,6 +267,9 @@ public class RadioIdRangeEditor extends IdentifierEditor<RadioRange>
             }
         }
 
+        mLog.warn("Unable to find radio id range editor for protocol [" + protocol + "] and format [" + integerFormat +
+                "] - using default editor");
+
         //Use a default instance
         for(RadioIdDetail detail: mRadioDetails)
         {
@@ -287,20 +290,23 @@ public class RadioIdRangeEditor extends IdentifierEditor<RadioRange>
     {
         List<RadioIdDetail> details = new ArrayList<>();
         details.add(new RadioIdDetail(Protocol.APCO25, IntegerFormat.DECIMAL, new IntegerFormatter(0,0xFFFFFF),
-            new IntegerFormatter(0,0xFFFFFF), "Format: 0 - 16777215"));
+                new IntegerFormatter(0,0xFFFFFF), "Format: 0 - 16777215"));
         details.add(new RadioIdDetail(Protocol.APCO25, IntegerFormat.HEXADECIMAL, new HexFormatter(0,0xFFFFFF),
-            new HexFormatter(0,0xFFFFFF), "Format: 0 - FFFFFF"));
+                new HexFormatter(0,0xFFFFFF), "Format: 0 - FFFFFF"));
         details.add(new RadioIdDetail(Protocol.PASSPORT, IntegerFormat.DECIMAL, new IntegerFormatter(0,0x7FFFFF),
-            new IntegerFormatter(0,0x7FFFFF), "Format: 0 - 8388607"));
+                new IntegerFormatter(0,0x7FFFFF), "Format: 0 - 8388607"));
         details.add(new RadioIdDetail(Protocol.PASSPORT, IntegerFormat.HEXADECIMAL, new HexFormatter(0,0x7FFFFF),
-            new HexFormatter(0,0x7FFFFF), "Format: 0 - 7FFFFF"));
+                new HexFormatter(0,0x7FFFFF), "Format: 0 - 7FFFFF"));
         details.add(new RadioIdDetail(Protocol.UNKNOWN, IntegerFormat.DECIMAL, new IntegerFormatter(0,16777215),
-            new IntegerFormatter(0,16777215), "Format: 0 - FFFFFF"));
+                new IntegerFormatter(0,16777215), "Format: 0 - FFFFFF"));
         details.add(new RadioIdDetail(Protocol.UNKNOWN, IntegerFormat.FORMATTED, new IntegerFormatter(0,16777215),
-            new IntegerFormatter(0,16777215), "Format: 0 - FFFFFF"));
+                new IntegerFormatter(0,16777215), "Format: 0 - FFFFFF"));
         details.add(new RadioIdDetail(Protocol.UNKNOWN, IntegerFormat.HEXADECIMAL, new HexFormatter(0,16777215),
-            new HexFormatter(0,16777215), "Format: 0 - FFFFFF"));
-
+                new HexFormatter(0,16777215), "Format: 0 - FFFFFF"));
+        details.add(new RadioIdDetail(Protocol.DMR, IntegerFormat.DECIMAL, new IntegerFormatter(0,16777215),
+                new IntegerFormatter(0,16777215), "Format: 0 - 16777215"));
+        details.add(new RadioIdDetail(Protocol.DMR, IntegerFormat.HEXADECIMAL, new HexFormatter(0,16777215),
+                new HexFormatter(0,16777215), "Format: 0 - FFFFFF"));
         return details;
     }
 

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/TalkgroupEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/TalkgroupEditor.java
@@ -135,7 +135,7 @@ public class TalkgroupEditor extends IdentifierEditor<Talkgroup>
             else
             {
                 mLog.warn("Couldn't find talkgroup detail for protocol [" + getItem().getProtocol() +
-                    "] and format [" + format + "]");
+                        "] and format [" + format + "]");
             }
 
             getFormatLabel().setText(talkgroupDetail.getTooltip());
@@ -219,6 +219,9 @@ public class TalkgroupEditor extends IdentifierEditor<Talkgroup>
             }
         }
 
+        mLog.warn("Unable to find talkgroup editor for protocol [" + protocol + "] and format [" + integerFormat +
+                "] - using default editor");
+
         //Use a default instance
         for(TalkgroupDetail detail: mTalkgroupDetails)
         {
@@ -236,37 +239,37 @@ public class TalkgroupEditor extends IdentifierEditor<Talkgroup>
     {
         mTalkgroupDetails.clear();
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.APCO25, IntegerFormat.DECIMAL, new IntegerFormatter(0,65535),
-            "Format: 0 - 65535"));
+                "Format: 0 - 65535"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.APCO25, IntegerFormat.HEXADECIMAL, new HexFormatter(0,65535),
-            "Format: 0 - FFFF"));
-        mTalkgroupDetails.add(new TalkgroupDetail(Protocol.DMR, IntegerFormat.DECIMAL, new IntegerFormatter(0,0xFFFFFF),
-            "Format: 0 - 16,777,215"));
-        mTalkgroupDetails.add(new TalkgroupDetail(Protocol.DMR, IntegerFormat.HEXADECIMAL, new HexFormatter(0,0xFFFFFF),
-            "Format: 0 - FFFFFF"));
+                "Format: 0 - FFFF"));
+        mTalkgroupDetails.add(new TalkgroupDetail(Protocol.DMR, IntegerFormat.DECIMAL, new IntegerFormatter(1,0xFFFFFF),
+                "Format: 1 - 16,777,215"));
+        mTalkgroupDetails.add(new TalkgroupDetail(Protocol.DMR, IntegerFormat.HEXADECIMAL, new HexFormatter(1,0xFFFFFF),
+                "Format: 1 - FFFFFF"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.FLEETSYNC, IntegerFormat.FORMATTED,
-            new PrefixIdentFormatter(0,0xFFFFF), "Format: PPP-IIII = Prefix (0-127), Ident (0-8191)"));
+                new PrefixIdentFormatter(0,0xFFFFF), "Format: PPP-IIII = Prefix (0-127), Ident (0-8191)"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.LTR, IntegerFormat.FORMATTED, new LtrFormatter(0,0x3FFF),
-            "Format: A-HH-TTT = Area (0-1), Home (1-31), Talkgroup (1-255)"));
+                "Format: A-HH-TTT = Area (0-1), Home (1-31), Talkgroup (1-255)"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.MDC1200, IntegerFormat.DECIMAL, new IntegerFormatter(0,0xFFFF),
-            "Format: 0 - 65535"));
+                "Format: 0 - 65535"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.MDC1200, IntegerFormat.HEXADECIMAL, new HexFormatter(0,0xFFFF),
-            "Format: 0 - FFFF"));
+                "Format: 0 - FFFF"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.MPT1327, IntegerFormat.FORMATTED,
-            new PrefixIdentFormatter(0,0xFFFFF), "Format: PPP-IIII = Prefix (0-127), Ident (0-8191)"));
+                new PrefixIdentFormatter(0,0xFFFFF), "Format: PPP-IIII = Prefix (0-127), Ident (0-8191)"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.NBFM, IntegerFormat.DECIMAL, new IntegerFormatter(1,0xFFFF),
-            "Format: 1 - 65535"));
+                "Format: 1 - 65535"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.NBFM, IntegerFormat.HEXADECIMAL, new HexFormatter(1,0xFFFF),
-            "Format: 1 - FFFF"));
+                "Format: 1 - FFFF"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.PASSPORT, IntegerFormat.DECIMAL, new IntegerFormatter(0,0xFFFF),
                 "Format: 0 - 65535"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.PASSPORT, IntegerFormat.HEXADECIMAL, new HexFormatter(0,0xFFFF),
                 "Format: 0 - FFFF"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.UNKNOWN, IntegerFormat.DECIMAL, new IntegerFormatter(0,16777215),
-            "Format: 0 - FFFFFF"));
+                "Format: 0 - FFFFFF"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.UNKNOWN, IntegerFormat.FORMATTED, new IntegerFormatter(0,16777215),
-            "Format: 0 - FFFFFF"));
+                "Format: 0 - FFFFFF"));
         mTalkgroupDetails.add(new TalkgroupDetail(Protocol.UNKNOWN, IntegerFormat.HEXADECIMAL, new HexFormatter(0,16777215),
-            "Format: 0 - FFFFFF"));
+                "Format: 0 - FFFFFF"));
     }
 
     public static class TalkgroupDetail

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/TalkgroupRangeEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/TalkgroupRangeEditor.java
@@ -161,7 +161,7 @@ public class TalkgroupRangeEditor extends IdentifierEditor<TalkgroupRange>
             else
             {
                 mLog.warn("Couldn't find talkgroup detail for protocol [" + getItem().getProtocol() +
-                    "] and format [" + format + "]");
+                        "] and format [" + format + "]");
                 getFormatLabel().setText(" ");
             }
         }
@@ -269,6 +269,9 @@ public class TalkgroupRangeEditor extends IdentifierEditor<TalkgroupRange>
             }
         }
 
+        mLog.warn("Unable to find talkgroup range editor for protocol [" + protocol + "] and format [" + integerFormat +
+                "] - using default editor");
+
         //Use a default instance
         for(TalkgroupDetail detail: mTalkgroupDetails)
         {
@@ -289,31 +292,35 @@ public class TalkgroupRangeEditor extends IdentifierEditor<TalkgroupRange>
     {
         List<TalkgroupDetail> details = new ArrayList<>();
         details.add(new TalkgroupDetail(Protocol.APCO25, IntegerFormat.DECIMAL, new IntegerFormatter(0,65535),
-            new IntegerFormatter(0,65535), "Format: 0 - 65535"));
+                new IntegerFormatter(0,65535), "Format: 0 - 65535"));
         details.add(new TalkgroupDetail(Protocol.APCO25, IntegerFormat.HEXADECIMAL, new HexFormatter(0,65535),
-            new HexFormatter(0,65535), "Format: 0 - FFFF"));
+                new HexFormatter(0,65535), "Format: 0 - FFFF"));
         details.add(new TalkgroupDetail(Protocol.FLEETSYNC, IntegerFormat.FORMATTED,
-            new PrefixIdentFormatter(0,0xFFFFF), new PrefixIdentFormatter(0,0xFFFFF),
-            "Format: PPP-IIII = Prefix (0-127), Ident (0-8191)"));
+                new PrefixIdentFormatter(0,0xFFFFF), new PrefixIdentFormatter(0,0xFFFFF),
+                "Format: PPP-IIII = Prefix (0-127), Ident (0-8191)"));
         details.add(new TalkgroupDetail(Protocol.LTR, IntegerFormat.FORMATTED, new LtrFormatter(0,0x3FFF),
-            new LtrFormatter(0,0x3FFF), "Format: A-HH-TTT = Area (0-1), Home (1-31), Talkgroup (1-255)"));
+                new LtrFormatter(0,0x3FFF), "Format: A-HH-TTT = Area (0-1), Home (1-31), Talkgroup (1-255)"));
         details.add(new TalkgroupDetail(Protocol.MDC1200, IntegerFormat.DECIMAL, new IntegerFormatter(0,0xFFFF),
-            new IntegerFormatter(0,0xFFFF), "Format: 0 - 65535"));
+                new IntegerFormatter(0,0xFFFF), "Format: 0 - 65535"));
         details.add(new TalkgroupDetail(Protocol.MDC1200, IntegerFormat.HEXADECIMAL, new HexFormatter(0,0xFFFF),
-            new HexFormatter(0,0xFFFF), "Format: 0 - FFFF"));
+                new HexFormatter(0,0xFFFF), "Format: 0 - FFFF"));
         details.add(new TalkgroupDetail(Protocol.MPT1327, IntegerFormat.FORMATTED,
-            new PrefixIdentFormatter(0,0xFFFFF), new PrefixIdentFormatter(0,0xFFFFF),
-            "Format: PPP-IIII = Prefix (0-127), Ident (1-8191)"));
+                new PrefixIdentFormatter(0,0xFFFFF), new PrefixIdentFormatter(0,0xFFFFF),
+                "Format: PPP-IIII = Prefix (0-127), Ident (1-8191)"));
         details.add(new TalkgroupDetail(Protocol.PASSPORT, IntegerFormat.DECIMAL, new IntegerFormatter(0,0xFFFF),
-            new IntegerFormatter(0,0xFFFF), "Format: 0 - 65535"));
+                new IntegerFormatter(0,0xFFFF), "Format: 0 - 65535"));
         details.add(new TalkgroupDetail(Protocol.PASSPORT, IntegerFormat.HEXADECIMAL, new HexFormatter(0,0xFFFF),
-            new HexFormatter(0,0xFFFF), "Format: 0 - FFFF"));
+                new HexFormatter(0,0xFFFF), "Format: 0 - FFFF"));
         details.add(new TalkgroupDetail(Protocol.UNKNOWN, IntegerFormat.DECIMAL, new IntegerFormatter(0,16777215),
-            new IntegerFormatter(0,16777215), "Format: 0 - FFFFFF"));
+                new IntegerFormatter(0,16777215), "Format: 0 - 16777215"));
         details.add(new TalkgroupDetail(Protocol.UNKNOWN, IntegerFormat.FORMATTED, new IntegerFormatter(0,16777215),
-            new IntegerFormatter(0,16777215), "Format: 0 - FFFFFF"));
+                new IntegerFormatter(0,16777215), "Format: 0 - FFFFFF"));
         details.add(new TalkgroupDetail(Protocol.UNKNOWN, IntegerFormat.HEXADECIMAL, new HexFormatter(0,16777215),
-            new HexFormatter(0,16777215), "Format: 0 - FFFFFF"));
+                new HexFormatter(0,16777215), "Format: 0 - FFFFFF"));
+        details.add(new TalkgroupDetail(Protocol.DMR, IntegerFormat.DECIMAL, new IntegerFormatter(1,16777215),
+                new IntegerFormatter(1,16777215), "Format: 1 - 16777215"));
+        details.add(new TalkgroupDetail(Protocol.DMR, IntegerFormat.HEXADECIMAL, new HexFormatter(1,0XFFFFFF),
+                new HexFormatter(1, 0xFFFFFF), "Format: 0 - FFFFFF"));
 
         return details;
     }


### PR DESCRIPTION
Closes #1393 

Updates Playlist editor's DMR Talkgroup and Radio ID editors to use correct (decimal vs hex) formatting.  

Patch submitted by @hockeyref2
