### PR TITLE
#1456 Shutdown Error When SDRPlay API Not Installed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-version = '0.6.0-alpha1'
+version = '0.6.0-alpha2'
 
 //Java 19 is required for this version of the Project Panama preview/incubator feature
 java {

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRplay.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/SDRplay.java
@@ -561,21 +561,28 @@ public class SDRplay
      */
     public Status close()
     {
-        Status closeStatus;
-
-        try
+        if(mSdrplayLibraryLoaded)
         {
-            closeStatus = Status.fromValue(sdrplay_api_h.sdrplay_api_Close());
-        }
-        catch(Exception e)
-        {
-            closeStatus = Status.FAIL;
-            mLog.error("Error closing SDRPlay API", e);
-        }
+            Status closeStatus;
 
-        mSdrplayLibraryLoaded = false;
-        mAvailable = false;
-        return closeStatus;
+            try
+            {
+                closeStatus = Status.fromValue(sdrplay_api_h.sdrplay_api_Close());
+            }
+            catch(Exception e)
+            {
+                closeStatus = Status.FAIL;
+                mLog.error("Error closing SDRPlay API", e);
+            }
+
+            mSdrplayLibraryLoaded = false;
+            mAvailable = false;
+            return closeStatus;
+        }
+        else
+        {
+            return Status.API_UNAVAILABLE;
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #1456.
Resolves issue with shutdown when sdrplay api is not installed.
