### PR TITLE
#1489 SDRPlay RSP Tuners - Sample Rate Control Lock/Unlocking on Channel Sourcing

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -628,19 +628,20 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
     {
         if(hasTuner() && getTuner().getController().isLockedSampleRate())
         {
-            mSampleRateCombo.setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
+            getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
         }
         else
         {
-            mSampleRateCombo.setToolTipText("Select a sample rate for the tuner");
+            getSampleRateCombo().setToolTipText("Select a sample rate for the tuner");
         }
     }
 
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
+        getFrequencyPanel().updateControls();
         getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
     }
 
     private String getTunerInfo()

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@ import io.github.dsheirer.source.tuner.fcd.proV1.FCD1TunerController.MixerGain;
 import io.github.dsheirer.source.tuner.manager.DiscoveredTuner;
 import io.github.dsheirer.source.tuner.manager.TunerManager;
 import io.github.dsheirer.source.tuner.ui.TunerEditor;
+import java.text.DecimalFormat;
 import net.miginfocom.swing.MigLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +40,6 @@ import javax.swing.JSpinner;
 import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
-import java.text.DecimalFormat;
 
 /**
  * Funcube Dongle Pro tuner editor
@@ -312,7 +312,7 @@ public class FCD1TunerEditor extends TunerEditor<FCDTuner,FCD1TunerConfiguration
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
+        getFrequencyPanel().updateControls();
     }
 
     public JButton getTunerInfoButton()

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -195,7 +195,7 @@ public class FCD2TunerEditor extends TunerEditor<FCDTuner, FCD2TunerConfiguratio
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
+        getFrequencyPanel().updateControls();
     }
 
     private String getTunerInfo()

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -308,8 +308,9 @@ public class HackRFTunerEditor extends TunerEditor<HackRFTuner,HackRFTunerConfig
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
-        mSampleRateCombo.setEnabled(!locked);
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
     }
 
     private String getTunerInfo()

--- a/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -54,7 +54,7 @@ public class RecordingTunerEditor extends TunerEditor<RecordingTuner,RecordingTu
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
+        getFrequencyPanel().updateControls();
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832UnknownTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832UnknownTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -97,6 +97,6 @@ public class RTL2832UnknownTunerEditor extends TunerEditor<RTL2832Tuner, RTL2832
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
+        getFrequencyPanel().updateControls();
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -400,8 +400,9 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
-        mSampleRateCombo.setEnabled(!locked);
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
     }
 
     private String getTunerInfo()

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r820t/R820TTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -123,6 +123,7 @@ public class R820TTunerEditor extends TunerEditor<RTL2832Tuner,R820TTunerConfigu
     @Override
     protected void tunerStatusUpdated()
     {
+        mLog.info("Tuner status was updated.");
         setLoading(true);
 
         if(hasTuner())
@@ -433,8 +434,9 @@ public class R820TTunerEditor extends TunerEditor<RTL2832Tuner,R820TTunerConfigu
     @Override
     public void setTunerLockState(boolean locked)
     {
-        super.setTunerLockState(locked);
-        mSampleRateCombo.setEnabled(!locked);
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
     }
 
     private String getTunerInfo()

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1/Rsp1TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1/Rsp1TunerEditor.java
@@ -107,6 +107,14 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
     }
 
     @Override
+    public void setTunerLockState(boolean locked)
+    {
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
+    }
+
+    @Override
     protected void tunerStatusUpdated()
     {
         setLoading(true);
@@ -124,6 +132,7 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
 
         getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
+        updateSampleRateToolTip();
 
         getAgcModeCombo().setEnabled(hasTuner());
         if(hasTuner())
@@ -186,5 +195,24 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
         }
 
         return mSampleRateCombo;
+    }
+
+    /**
+     * Updates the sample rate tooltip according to the tuner controller's lock state.
+     */
+    private void updateSampleRateToolTip()
+    {
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
+        {
+            getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
+        }
+        else if(hasTuner())
+        {
+            getSampleRateCombo().setToolTipText("Select a sample rate for the tuner");
+        }
+        else
+        {
+            getSampleRateCombo().setToolTipText("No tuner available");
+        }
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1a/Rsp1aTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1a/Rsp1aTunerEditor.java
@@ -118,6 +118,14 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
     }
 
     @Override
+    public void setTunerLockState(boolean locked)
+    {
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
+    }
+
+    @Override
     protected void tunerStatusUpdated()
     {
         setLoading(true);
@@ -135,6 +143,7 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
 
         getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
+        updateSampleRateToolTip();
 
         getAgcModeCombo().setEnabled(hasTuner());
         if(hasTuner())
@@ -315,4 +324,24 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
 
         return mRfNotchCheckBox;
     }
+
+    /**
+     * Updates the sample rate tooltip according to the tuner controller's lock state.
+     */
+    private void updateSampleRateToolTip()
+    {
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
+        {
+            getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
+        }
+        else if(hasTuner())
+        {
+            getSampleRateCombo().setToolTipText("Select a sample rate for the tuner");
+        }
+        else
+        {
+            getSampleRateCombo().setToolTipText("No tuner available");
+        }
+    }
+
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
@@ -122,6 +122,14 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
     }
 
     @Override
+    public void setTunerLockState(boolean locked)
+    {
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
+    }
+
+    @Override
     protected void tunerStatusUpdated()
     {
         setLoading(true);
@@ -139,6 +147,7 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
 
         getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
+        updateSampleRateToolTip();
 
         getAgcModeCombo().setEnabled(hasTuner());
         if(hasTuner())
@@ -359,5 +368,24 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
         }
 
         return mAntennaSelectionCombo;
+    }
+
+    /**
+     * Updates the sample rate tooltip according to the tuner controller's lock state.
+     */
+    private void updateSampleRateToolTip()
+    {
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
+        {
+            getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
+        }
+        else if(hasTuner())
+        {
+            getSampleRateCombo().setToolTipText("Select a sample rate for the tuner");
+        }
+        else
+        {
+            getSampleRateCombo().setToolTipText("No tuner available");
+        }
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner1Editor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner1Editor.java
@@ -133,6 +133,14 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
     }
 
     @Override
+    public void setTunerLockState(boolean locked)
+    {
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
+    }
+
+    @Override
     protected void tunerStatusUpdated()
     {
         setLoading(true);
@@ -146,6 +154,8 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
         }
         getTunerStatusLabel().setText(status);
         getButtonPanel().updateControls();
+        mLog.info("Update tuner status - has tuner: " + hasTuner() + " is locked:" + getTuner().getTunerController().isLockedSampleRate());
+
         getFrequencyPanel().updateControls();
 
         clearSampleRates();
@@ -155,6 +165,7 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
         }
         getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
+        updateSampleRateToolTip();
 
         getAgcModeCombo().setEnabled(hasTuner());
         if(hasTuner())
@@ -454,5 +465,24 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
         }
 
         return mTunerPreferencesButton;
+    }
+
+    /**
+     * Updates the sample rate tooltip according to the tuner controller's lock state.
+     */
+    private void updateSampleRateToolTip()
+    {
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
+        {
+            getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
+        }
+        else if(hasTuner())
+        {
+            getSampleRateCombo().setToolTipText("Select a sample rate for the tuner");
+        }
+        else
+        {
+            getSampleRateCombo().setToolTipText("No tuner available");
+        }
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner2Editor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner2Editor.java
@@ -142,6 +142,14 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
     }
 
     @Override
+    public void setTunerLockState(boolean locked)
+    {
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
+    }
+
+    @Override
     protected void tunerStatusUpdated()
     {
         setLoading(true);
@@ -172,6 +180,7 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
         }
         getSampleRateCombo().setEnabled(hasTuner() && !isSlaveMode() && !getTuner().getTunerController().isLockedSampleRate());
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
+        updateSampleRateToolTip();
 
         getAgcModeCombo().setEnabled(hasTuner());
         if(hasTuner())
@@ -436,5 +445,24 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
         }
 
         return mTunerPreferencesButton;
+    }
+
+    /**
+     * Updates the sample rate tooltip according to the tuner controller's lock state.
+     */
+    private void updateSampleRateToolTip()
+    {
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
+        {
+            getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
+        }
+        else if(hasTuner())
+        {
+            getSampleRateCombo().setToolTipText("Select a sample rate for the tuner");
+        }
+        else
+        {
+            getSampleRateCombo().setToolTipText("No tuner available");
+        }
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDx/RspDxTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDx/RspDxTunerEditor.java
@@ -131,6 +131,14 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
     }
 
     @Override
+    public void setTunerLockState(boolean locked)
+    {
+        getFrequencyPanel().updateControls();
+        getSampleRateCombo().setEnabled(!locked);
+        updateSampleRateToolTip();
+    }
+
+    @Override
     protected void tunerStatusUpdated()
     {
         setLoading(true);
@@ -148,6 +156,7 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
 
         getSampleRateCombo().setEnabled(hasTuner() && !getTuner().getTunerController().isLockedSampleRate());
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
+        updateSampleRateToolTip();
 
         getAgcModeCombo().setEnabled(hasTuner());
         if(hasTuner())
@@ -437,5 +446,24 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
         }
 
         return mHdrModeBandwidthCombo;
+    }
+
+    /**
+     * Updates the sample rate tooltip according to the tuner controller's lock state.
+     */
+    private void updateSampleRateToolTip()
+    {
+        if(hasTuner() && getTuner().getTunerController().isLockedSampleRate())
+        {
+            getSampleRateCombo().setToolTipText("Sample Rate is locked.  Disable decoding channels to unlock.");
+        }
+        else if(hasTuner())
+        {
+            getSampleRateCombo().setToolTipText("Select a sample rate for the tuner");
+        }
+        else
+        {
+            getSampleRateCombo().setToolTipText("No tuner available");
+        }
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
@@ -547,12 +547,11 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
     /**
      * Sets the lock state for the tuner so that the frequency and sample rate controls can be enabled/disabled.
      *
+     * Note: implementing classes should invoke: getFrequencyPanel().updateControls() method.
+     *
      * @param locked true if the tuner is locked.
      */
-    public void setTunerLockState(boolean locked)
-    {
-        getFrequencyPanel().updateControls();
-    }
+    public abstract void setTunerLockState(boolean locked);
 
     /**
      * Tuner buttons panel


### PR DESCRIPTION
#1489 SDRPlay RSP tuner editors now lock/unlock sample rate combo when sourcing channels.
