### PR TITLE
Possible fix for RSP config not saving

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerConfiguration.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
 import io.github.dsheirer.source.tuner.sdrplay.api.parameter.control.AgcMode;
 import io.github.dsheirer.source.tuner.sdrplay.api.parameter.tuner.GainReduction;
+import io.github.dsheirer.source.tuner.sdrplay.rsp1.Rsp1TunerConfiguration;
 import io.github.dsheirer.source.tuner.sdrplay.rsp1a.Rsp1aTunerConfiguration;
 import io.github.dsheirer.source.tuner.sdrplay.rsp2.Rsp2TunerConfiguration;
 import io.github.dsheirer.source.tuner.sdrplay.rspDuo.RspDuoTuner1Configuration;
@@ -36,6 +37,7 @@ import io.github.dsheirer.source.tuner.sdrplay.rspDx.RspDxTunerConfiguration;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
+        @JsonSubTypes.Type(value = Rsp1TunerConfiguration.class, name = "rsp1TunerConfiguration"),
         @JsonSubTypes.Type(value = Rsp1aTunerConfiguration.class, name = "rsp1aTunerConfiguration"),
         @JsonSubTypes.Type(value = Rsp2TunerConfiguration.class, name = "rsp2TunerConfiguration"),
         @JsonSubTypes.Type(value = RspDuoTuner1Configuration.class, name = "rspDuoTuner1Configuration"),


### PR DESCRIPTION
Possible fix for RSP1 tuners resetting configuration on strartup

Multiple users reported that RSP tuner configurations are not saving, or resetting to default on startup. 

Andrew provided a java error:
```
TunerConfigurationManager - Error loading tuner configuration file  [22MB/80MB 28%]
com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'Rsp1TunerConfiguration' as a subtype of `io.github.dsheirer.source.tuner.configuration.TunerConfiguration`: known type ids = [airspyTunerConfiguration, e4KTunerConfiguration, fcd1TunerConfiguration, fcd2TunerConfiguration, hackRFTunerConfiguration, r820TTunerConfiguration, recordingTunerConfiguration, rsp1aTunerConfiguration, rsp2TunerConfiguration, rspDuoTuner1Configuration, rspDuoTuner2Configuration, rspDxTunerConfiguration] (for POJO property 'tunerConfigurations')
 at [Source: (File); line: 37, column: 14] (through reference chain: io.github.dsheirer.source.tuner.configuration.TunerConfigurationState["tunerConfigurations"]->java.util.ArrayList[3])
	at com.fasterxml.jackson.databind.exc.InvalidTypeIdException.from(InvalidTypeIdException.java:43)
	at com.fasterxml.jackson.databind.DeserializationContext.invalidTypeIdException(DeserializationContext.java:2078)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownTypeId(DeserializationContext.java:1569)
	at com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase._handleUnknownTypeId(TypeDeserializerBase.java:298)
	at com.fasterxml.jackson.databind.jsontype.impl.TypeDeserializerBase._findDeserializer(TypeDeserializerBase.java:165)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer._deserializeTypedForId(AsPropertyTypeDeserializer.java:125)
	at com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer.deserializeTypedFromObject(AsPropertyTypeDeserializer.java:110)
	at com.fasterxml.jackson.databind.deser.AbstractDeserializer.deserializeWithType(AbstractDeserializer.java:263)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:361)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:244)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4730)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3542)
	at io.github.dsheirer.source.tuner.configuration.TunerConfigurationManager.load(TunerConfigurationManager.java:83)
	at io.github.dsheirer.source.tuner.configuration.TunerConfigurationManager.<init>(TunerConfigurationManager.java:66)
	at io.github.dsheirer.source.tuner.manager.TunerManager.<init>(TunerManager.java:88)
	at io.github.dsheirer.gui.SDRTrunk.<init>(SDRTrunk.java:177)
	at io.github.dsheirer.gui.SDRTrunk.main(SDRTrunk.java:738)
```

I believe that the rsp1TunerConfiguration was missing from the JsonSubTypes for the RspTunerConfiguration class. I added it. I am not able to test if this is working, as I do not own an RSP tuner. If someone could please test it.