### PR TITLE
#1548 Reduce AM Decoder AF Gain

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/am/AMDecoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/am/AMDecoder.java
@@ -29,7 +29,7 @@ import io.github.dsheirer.module.decode.analog.SquelchingAnalogDecoder;
  */
 public class AMDecoder extends SquelchingAnalogDecoder
 {
-    private static final float DEMODULATOR_GAIN = 250.0f;
+    private static final float DEMODULATOR_GAIN = 150.0f;
     private static final float SQUELCH_ALPHA_DECAY = 0.0004f;
     private static final float MINIMUM_GAIN = 0.5f;
     private static final float MAXIMUM_GAIN = 16.0f;


### PR DESCRIPTION
Closes #1548 
Reduces default decoder AF gain by 40% to resolve issue with distorted audio from local strong aircraft transmissions.