### PR TITLE
#1568 NBFM Decoder Allows User To Enable/Disable Audio High-Pass Filter

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/AudioModule.java
+++ b/src/main/java/io/github/dsheirer/audio/AudioModule.java
@@ -43,6 +43,7 @@ public class AudioModule extends AbstractAudioModule implements ISquelchStateLis
 {
     private static final Logger mLog = LoggerFactory.getLogger(AudioModule.class);
     private static float[] sHighPassFilterCoefficients;
+    private final boolean mAudioFilterEnable;
 
     static
     {
@@ -70,27 +71,33 @@ public class AudioModule extends AbstractAudioModule implements ISquelchStateLis
         }
     }
 
-    private IRealFilter mHighPassFilter = FilterFactory.getRealFilter(sHighPassFilterCoefficients);
-    private SquelchStateListener mSquelchStateListener = new SquelchStateListener();
+    private final IRealFilter mHighPassFilter = FilterFactory.getRealFilter(sHighPassFilterCoefficients);
+    private final SquelchStateListener mSquelchStateListener = new SquelchStateListener();
     private SquelchState mSquelchState = SquelchState.SQUELCH;
 
     /**
      * Creates an Audio Module.
      *
      * @param aliasList for aliasing identifiers
+     * @param timeslot for this audio module
      * @param maxAudioSegmentLength in milliseconds
+     * @param audioFilterEnable to enable or disable high-pass audio filter
      */
-    public AudioModule(AliasList aliasList, int timeslot, long maxAudioSegmentLength)
+    public AudioModule(AliasList aliasList, int timeslot, long maxAudioSegmentLength, boolean audioFilterEnable)
     {
         super(aliasList, timeslot, maxAudioSegmentLength);
+        mAudioFilterEnable = audioFilterEnable;
     }
 
     /**
      * Creates an Audio Module.
+     * @param aliasList for aliasing identifiers
+     * @param audioFilterEnable to enable or disable high-pass audio filter
      */
-    public AudioModule(AliasList aliasList)
+    public AudioModule(AliasList aliasList, boolean audioFilterEnable)
     {
         super(aliasList);
+        mAudioFilterEnable = audioFilterEnable;
     }
 
     @Override
@@ -121,7 +128,11 @@ public class AudioModule extends AbstractAudioModule implements ISquelchStateLis
     {
         if(mSquelchState == SquelchState.UNSQUELCH)
         {
-            audioBuffer = mHighPassFilter.filter(audioBuffer);
+            if(mAudioFilterEnable)
+            {
+                audioBuffer = mHighPassFilter.filter(audioBuffer);
+            }
+
             addAudio(audioBuffer);
         }
     }

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
@@ -29,6 +29,11 @@ import io.github.dsheirer.source.tuner.channel.ChannelSpecification;
  */
 public class DecodeConfigNBFM extends DecodeConfigAnalog
 {
+    private boolean mAudioFilter = true;
+
+    /**
+     * Constructs an instance
+     */
     public DecodeConfigNBFM()
     {
     }
@@ -61,5 +66,24 @@ public class DecodeConfigNBFM extends DecodeConfigAnalog
             default:
                 throw new IllegalArgumentException("Unrecognized FM bandwidth value: " + getBandwidth());
         }
+    }
+
+    /**
+     * Indicates if the user wants the demodulated audio to be high-pass filtered.
+     * @return enable status, defaults to true.
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "audioFilter")
+    public boolean isAudioFilter()
+    {
+        return mAudioFilter;
+    }
+
+    /**
+     * Sets the enabled state of high-pass filtering of the demodulated audio.
+     * @param audioFilter to true to enable high-pass filtering.
+     */
+    public void setAudioFilter(boolean audioFilter)
+    {
+        mAudioFilter = audioFilter;
     }
 }


### PR DESCRIPTION
Closes #1568 

Updates NBFM decoder configuration so user can enable/disable high-pass filter option in the audio module to effect audio playback and audio recording of the demodulated audio.  Disabling the filter allows recording of DC and sub-audible signalling that may be present in the demodulated audio (e.g. LTR or squelching signalling).
