### PR TITLE
#1584 Traffic Channel Shutdown - Residual Buffer Samples Processing Related Errors

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/psk/PSKDemodulator.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/PSKDemodulator.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,6 +30,7 @@ public abstract class PSKDemodulator<T> implements ComplexSampleListener
     private IPhaseLockedLoop mPLL;
     private Complex mReceivedSample = new Complex(0, 0);
     private Listener<T> mSymbolListener;
+    private boolean mRunning;
 
     /**
      * Abstract Phase Shift Keyed (PSK) demodulator
@@ -40,6 +41,31 @@ public abstract class PSKDemodulator<T> implements ComplexSampleListener
     {
         mInterpolatingSampleBuffer = interpolatingSampleBuffer;
         mPLL = phaseLockedLoop;
+    }
+
+    /**
+     * Starts this decoder and sets the running flag to true
+     */
+    public void start()
+    {
+        mRunning = true;
+    }
+
+    /**
+     * Stops this decoder and sets the running flag to false.
+     */
+    public void stop()
+    {
+        mRunning = false;
+    }
+
+    /**
+     * Indicates if this demodulator is running and capable of processing samples
+     * @return true if running
+     */
+    public boolean isRunning()
+    {
+        return mRunning;
     }
 
     /**
@@ -90,7 +116,10 @@ public abstract class PSKDemodulator<T> implements ComplexSampleListener
 
         for(int x = 0; x < i.length; x++)
         {
-            receive(i[x], q[x]);
+            if(isRunning())
+            {
+                receive(i[x], q[x]);
+            }
         }
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/Decoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/Decoder.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,11 +23,14 @@ import io.github.dsheirer.message.IMessageProvider;
 import io.github.dsheirer.module.Module;
 import io.github.dsheirer.sample.Listener;
 
+/**
+ * Base decoder class.
+ */
 public abstract class Decoder extends Module implements IMessageProvider
 {
-    /* This has to be a broadcaster in order for references to persist */
     private Listener<IMessage> mMessageDistributor = new MessageDistributor();
     protected Listener<IMessage> mMessageListener;
+    private boolean mRunning;
 
     /**
      * Decoder - parent class for all decoders, demodulators and components.
@@ -36,14 +39,29 @@ public abstract class Decoder extends Module implements IMessageProvider
     {
     }
 
+    /**
+     * Starts this decoder and sets the running flag to true.
+     */
     public void start()
     {
-        //no-op
+        mRunning = true;
     }
 
+    /**
+     * Stops this decoder and sets the running flag to false.
+     */
     public void stop()
     {
-        //no-op
+        mRunning = false;
+    }
+
+    /**
+     * Indicates if this decoder is currently started and in a running state.
+     * @return true if running or false if not.
+     */
+    public boolean isRunning()
+    {
+        return mRunning;
     }
 
     public void reset()

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoder.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -82,6 +82,20 @@ public class DMRDecoder extends FeedbackDecoder implements ISourceEventListener,
         mMessageProcessor.setMessageListener(getMessageListener());
         getDibitBroadcaster().addListener(mByteBufferAssembler);
         setSampleRate(25000.0);
+    }
+
+    @Override
+    public void start()
+    {
+        super.start();
+        mQPSKDemodulator.start();
+    }
+
+    @Override
+    public void stop()
+    {
+        super.stop();
+        mQPSKDemodulator.stop();
     }
 
     /**
@@ -317,23 +331,5 @@ public class DMRDecoder extends FeedbackDecoder implements ISourceEventListener,
     public Listener<ComplexSamples> getComplexSamplesListener()
     {
         return DMRDecoder.this;
-    }
-
-    /**
-     * Starts the decoder
-     */
-    @Override
-    public void start()
-    {
-        //No-op
-    }
-
-    /**
-     * Stops the decoder
-     */
-    @Override
-    public void stop()
-    {
-        //No-op
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1Decoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1Decoder.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,6 @@ import io.github.dsheirer.sample.complex.IComplexSamplesListener;
 import io.github.dsheirer.source.ISourceEventListener;
 import io.github.dsheirer.source.ISourceEventProvider;
 import io.github.dsheirer.source.SourceEvent;
-
 import java.nio.ByteBuffer;
 
 public abstract class P25P1Decoder extends FeedbackDecoder implements ISourceEventListener, ISourceEventProvider,
@@ -164,24 +163,6 @@ public abstract class P25P1Decoder extends FeedbackDecoder implements ISourceEve
     public Listener<ComplexSamples> getComplexSamplesListener()
     {
         return P25P1Decoder.this;
-    }
-
-    /**
-     * Starts the decoder
-     */
-    @Override
-    public void start()
-    {
-        //No-op
-    }
-
-    /**
-     * Stops the decoder
-     */
-    @Override
-    public void stop()
-    {
-        //No-op
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderC4FM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderC4FM.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,6 +60,20 @@ public class P25P1DecoderC4FM extends P25P1Decoder
     {
         super(4800.0);
         setSampleRate(25000.0);
+    }
+
+    @Override
+    public void start()
+    {
+        super.start();
+        mQPSKDemodulator.start();
+    }
+
+    @Override
+    public void stop()
+    {
+        super.stop();
+        mQPSKDemodulator.stop();
     }
 
     public void setSampleRate(double sampleRate)

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderLSM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderLSM.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,6 +60,20 @@ public class P25P1DecoderLSM extends P25P1Decoder
     {
         super(4800.0);
         setSampleRate(25000.0);
+    }
+
+    @Override
+    public void start()
+    {
+        super.start();
+        mQPSKDemodulator.start();
+    }
+
+    @Override
+    public void stop()
+    {
+        super.stop();
+        mQPSKDemodulator.stop();
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2Decoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2Decoder.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,6 @@ import io.github.dsheirer.sample.complex.IComplexSamplesListener;
 import io.github.dsheirer.source.ISourceEventListener;
 import io.github.dsheirer.source.ISourceEventProvider;
 import io.github.dsheirer.source.SourceEvent;
-
 import java.nio.ByteBuffer;
 
 /**
@@ -167,24 +166,6 @@ public abstract class P25P2Decoder extends FeedbackDecoder implements ISourceEve
     public Listener<ComplexSamples> getComplexSamplesListener()
     {
         return P25P2Decoder.this;
-    }
-
-    /**
-     * Starts the decoder
-     */
-    @Override
-    public void start()
-    {
-        //No-op
-    }
-
-    /**
-     * Stops the decoder
-     */
-    @Override
-    public void stop()
-    {
-        //No-op
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSK.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSK.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,6 +65,27 @@ public class P25P2DecoderHDQPSK extends P25P2Decoder implements IdentifierUpdate
         super(6000.0);
         setSampleRate(25000.0);
         mDecodeConfigP25Phase2 = decodeConfigP25Phase2;
+    }
+
+    @Override
+    public void start()
+    {
+        super.start();
+        mQPSKDemodulator.start();
+
+        //Refresh the scramble parameters each time we start in case they change
+        if(mDecodeConfigP25Phase2 != null && mDecodeConfigP25Phase2.getScrambleParameters() != null &&
+                !mDecodeConfigP25Phase2.isAutoDetectScrambleParameters())
+        {
+            mMessageFramer.setScrambleParameters(mDecodeConfigP25Phase2.getScrambleParameters());
+        }
+    }
+
+    @Override
+    public void stop()
+    {
+        super.stop();
+        mQPSKDemodulator.stop();
     }
 
     public void setSampleRate(double sampleRate)
@@ -186,19 +207,6 @@ public class P25P2DecoderHDQPSK extends P25P2Decoder implements IdentifierUpdate
     public void reset()
     {
         mCostasLoop.reset();
-    }
-
-    @Override
-    public void start()
-    {
-        super.start();
-
-        //Refresh the scramble parameters each time we start in case they change
-        if(mDecodeConfigP25Phase2 != null && mDecodeConfigP25Phase2.getScrambleParameters() != null &&
-            !mDecodeConfigP25Phase2.isAutoDetectScrambleParameters())
-        {
-            mMessageFramer.setScrambleParameters(mDecodeConfigP25Phase2.getScrambleParameters());
-        }
     }
 
     @Override


### PR DESCRIPTION
Closes #1584 

Updates DMR & P25 decoders to stop processing residual samples from the current buffer after a traffic channel shutdown has been signalled.