### PR TITLE
#1590 RSP Tuners - Excessive Buffer Generation - Out of Memory

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_19_PREVIEW" project-jdk-name="19" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" default="true" project-jdk-name="19" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspNativeBufferFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspNativeBufferFactory.java
@@ -122,7 +122,7 @@ public class RspNativeBufferFactory
         {
             int optimal = 128;
 
-            while((optimal * 2) < length)
+            while((optimal) < length)
             {
                 optimal *= 2;
             }


### PR DESCRIPTION
Closes #1590 
Resolves issue with RSP tuners generating too many native buffers causing excessive memory consumption
