### PR TITLE
#1586 P25P1 Message Framer NPE

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageFramer.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageFramer.java
@@ -322,17 +322,19 @@ public class P25P1MessageFramer implements Listener<Dibit>, IP25P1DataUnitDetect
                     TSBKMessage tsbkMessage = TSBKMessageFactory.create(mChannelStatusProcessor.getDirection(),
                         mDataUnitID, mBinaryMessage, mNAC, getTimestamp());
 
+                    int messageLength = mDataUnitID.getMessageLength();
+
                     mMessageListener.receive(tsbkMessage);
 
                     if(tsbkMessage.isLastBlock())
                     {
-                        reset(mDataUnitID.getMessageLength());
+                        reset(messageLength);
                         mTrailingDibitsToSuppress = 1;
                     }
                     else
                     {
-                        updateBitsProcessed(mDataUnitID.getMessageLength());
-                        mBinaryMessage = new CorrectedBinaryMessage(mDataUnitID.getMessageLength());
+                        updateBitsProcessed(messageLength);
+                        mBinaryMessage = new CorrectedBinaryMessage(messageLength);
                         if(mDataUnitID == P25P1DataUnitID.TRUNKING_SIGNALING_BLOCK_1)
                         {
                             mDataUnitID = P25P1DataUnitID.TRUNKING_SIGNALING_BLOCK_2;


### PR DESCRIPTION
Close #1586 

Resolves issue in P25 message framer where after transmitting the current message the mDataUnitId is set to null and this causes an NPE when subsequent code is executed prior to shutdown of the channel.