### PR TITLE
#1603 De-Duplicate Call Events

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/event/ClearableHistoryModel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/ClearableHistoryModel.java
@@ -56,12 +56,21 @@ public abstract class ClearableHistoryModel<T> extends AbstractTableModel
      */
     public void add(T item)
     {
-        mItems.addFirst(item);
-        ClearableHistoryModel.this.fireTableRowsInserted(0, 0);
-        while(mItems.size() > mHistorySize)
+        if(mItems.contains(item))
         {
-            mItems.removeLast();
-            super.fireTableRowsDeleted(mItems.size() - 1, mItems.size() - 1);
+            int itemRow = mItems.indexOf(item);
+            fireTableRowsUpdated(itemRow, itemRow);
+        }
+        else
+        {
+            mItems.addFirst(item);
+            fireTableRowsInserted(0, 0);
+
+            while(mItems.size() > mHistorySize)
+            {
+                mItems.removeLast();
+                fireTableRowsDeleted(mItems.size() - 1, mItems.size() - 1);
+            }
         }
     }
 
@@ -98,14 +107,6 @@ public abstract class ClearableHistoryModel<T> extends AbstractTableModel
     public int getHistorySize()
     {
         return mHistorySize;
-    }
-
-    /**
-     * Resets the history size to the default value.
-     */
-    public void resetHistorySize()
-    {
-        setHistorySize(DEFAULT_HISTORY_SIZE);
     }
 
     /**


### PR DESCRIPTION
Closes #1603 

Resolves issue with de-duplicating events to allow call duration values to display correctly and minimize the quantity of duplicate events.