### PR TITLE
#1604 Event Panel UI Layout Creates Excess Space On Resizing

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
@@ -87,7 +87,7 @@ public class DecodeEventPanel extends JPanel implements Listener<ProcessingChain
     {
         MyEventBus.getGlobalEventBus().register(this);
 
-        setLayout(new MigLayout("insets 0 0 0 0", "[grow,fill]", "[grow,fill]"));
+        setLayout(new MigLayout("insets 0 0 0 0", "[grow,fill]", "[][grow,fill]"));
         mIconModel = iconModel;
         mAliasModel = aliasModel;
         mUserPreferences = userPreferences;


### PR DESCRIPTION
#1604 Resolves issue with event panel UI layout creating excess space between history management panel and events table.