### PR TITLE
#1670 Missing Audio Segments - DMR Cap+

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/lc/full/motorola/CapacityPlusVoiceChannelUser.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/lc/full/motorola/CapacityPlusVoiceChannelUser.java
@@ -21,13 +21,13 @@ package io.github.dsheirer.module.decode.dmr.message.data.lc.full.motorola;
 
 import io.github.dsheirer.bits.CorrectedBinaryMessage;
 import io.github.dsheirer.module.decode.dmr.message.IServiceOptionsProvider;
-import io.github.dsheirer.module.decode.dmr.message.data.lc.full.FullLCMessage;
+import io.github.dsheirer.module.decode.dmr.message.data.lc.full.AbstractVoiceChannelUser;
 import io.github.dsheirer.module.decode.dmr.message.type.CapacityPlusServiceOptions;
 
 /**
  * Any Capacity Plus Voice Channel User link control message that contains vendor-specific service options.
  */
-public abstract class CapacityPlusVoiceChannelUser extends FullLCMessage implements IServiceOptionsProvider
+public abstract class CapacityPlusVoiceChannelUser extends AbstractVoiceChannelUser implements IServiceOptionsProvider
 {
     private static final int[] SERVICE_OPTIONS = new int[]{16, 17, 18, 19, 20, 21, 22, 23};
     //Reed Solomon FEC: 72-95


### PR DESCRIPTION
#1670 Resolves issue with missing audio segments for some DMR Cap+ call events.

Moto Group Voice Channel User message was changed to no longer extend from AbstractVoiceChannelUser message which caused the DMR audio module to no longer recognized these as call-indicator events.