### PR TITLE
#1650 Adds 7.5 kHz channel bandwidth option for FM channels.

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/analog/DecodeConfigAnalog.java
+++ b/src/main/java/io/github/dsheirer/module/decode/analog/DecodeConfigAnalog.java
@@ -145,6 +145,7 @@ public abstract class DecodeConfigAnalog extends DecodeConfiguration implements 
     {
         BW_3_0("3.0 kHz", 3000.0),
         BW_5_0("5.0 kHz", 5000.0),
+        BW_7_5("7.5 kHz", 7500.0),
         BW_8_33("8.33 kHz", 8333.0),
         BW_12_5("12.5 kHz", 12500.0),
         BW_15_0("15.0 kHz", 15000.0),
@@ -168,7 +169,7 @@ public abstract class DecodeConfigAnalog extends DecodeConfiguration implements 
         public static EnumSet<Bandwidth> AM_BANDWIDTHS = EnumSet.of(BW_3_0, BW_5_0, BW_8_33, BW_15_0, BW_25_0);
 
         //FM demodulator channel bandwidth options
-        public static EnumSet<Bandwidth> FM_BANDWIDTHS = EnumSet.of(BW_12_5, BW_25_0);
+        public static EnumSet<Bandwidth> FM_BANDWIDTHS = EnumSet.of(BW_7_5, BW_12_5, BW_25_0);
 
         /**
          * Indicates if this entry is valid for the AM decoder.

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
@@ -59,6 +59,8 @@ public class DecodeConfigNBFM extends DecodeConfigAnalog
     {
         switch(getBandwidth())
         {
+            case BW_7_5:
+                return new ChannelSpecification(25000.0, 7500, 3500.0, 3750.0);
             case BW_12_5:
                 return new ChannelSpecification(25000.0, 12500, 6000.0, 7000.0);
             case BW_25_0:


### PR DESCRIPTION
Closes #1650 
Adds 7.5 kHz channel bandwidth option for FM channels to support narrow band railroad channels.
