### PR TITLE
#1643 RTL2832/R828D aka RTL-SDR V4 Dongle & Bias-T Support

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
@@ -55,9 +55,11 @@ import io.github.dsheirer.source.tuner.rtl.RTL2832UnknownTunerEditor;
 import io.github.dsheirer.source.tuner.rtl.e4k.E4KEmbeddedTuner;
 import io.github.dsheirer.source.tuner.rtl.e4k.E4KTunerConfiguration;
 import io.github.dsheirer.source.tuner.rtl.e4k.E4KTunerEditor;
-import io.github.dsheirer.source.tuner.rtl.r820t.R820TEmbeddedTuner;
-import io.github.dsheirer.source.tuner.rtl.r820t.R820TTunerConfiguration;
-import io.github.dsheirer.source.tuner.rtl.r820t.R820TTunerEditor;
+import io.github.dsheirer.source.tuner.rtl.r8x.R8xTunerEditor;
+import io.github.dsheirer.source.tuner.rtl.r8x.r820t.R820TEmbeddedTuner;
+import io.github.dsheirer.source.tuner.rtl.r8x.r820t.R820TTunerConfiguration;
+import io.github.dsheirer.source.tuner.rtl.r8x.r828d.R828DEmbeddedTuner;
+import io.github.dsheirer.source.tuner.rtl.r8x.r828d.R828DTunerConfiguration;
 import io.github.dsheirer.source.tuner.sdrplay.DiscoveredRspTuner;
 import io.github.dsheirer.source.tuner.sdrplay.RspTuner;
 import io.github.dsheirer.source.tuner.sdrplay.api.DeviceSelectionMode;
@@ -367,7 +369,8 @@ public class TunerFactory
         {
             case ELONICS_E4000 -> new E4KEmbeddedTuner(adapter);
             case RAFAELMICRO_R820T -> new R820TEmbeddedTuner(adapter);
-            default -> throw new SourceException("Unsupported/Unrecognized Tuner Type");
+            case RAFAELMICRO_R828D -> new R828DEmbeddedTuner(adapter);
+            default -> throw new SourceException("Unsupported/Unrecognized Tuner Type: " + tunerType);
         };
     }
 
@@ -394,6 +397,8 @@ public class TunerFactory
                 return new HackRFTunerConfiguration(uniqueID);
             case RAFAELMICRO_R820T:
                 return new R820TTunerConfiguration(uniqueID);
+            case RAFAELMICRO_R828D:
+                return new R828DTunerConfiguration(uniqueID);
             case RECORDING:
                 return RecordingTunerConfiguration.create();
             case RSP_1:
@@ -475,7 +480,8 @@ public class TunerFactory
                         case ELONICS_E4000:
                             return new E4KTunerEditor(userPreferences, tunerManager, discoveredTuner);
                         case RAFAELMICRO_R820T:
-                            return new R820TTunerEditor(userPreferences, tunerManager, discoveredTuner);
+                        case RAFAELMICRO_R828D:
+                            return new R8xTunerEditor(userPreferences, tunerManager, discoveredTuner);
                     }
                 }
                 return new RTL2832UnknownTunerEditor(userPreferences, tunerManager, discoveredTuner);

--- a/src/main/java/io/github/dsheirer/source/tuner/configuration/TunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/configuration/TunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,7 +31,8 @@ import io.github.dsheirer.source.tuner.fcd.proplusV2.FCD2TunerConfiguration;
 import io.github.dsheirer.source.tuner.hackrf.HackRFTunerConfiguration;
 import io.github.dsheirer.source.tuner.recording.RecordingTunerConfiguration;
 import io.github.dsheirer.source.tuner.rtl.e4k.E4KTunerConfiguration;
-import io.github.dsheirer.source.tuner.rtl.r820t.R820TTunerConfiguration;
+import io.github.dsheirer.source.tuner.rtl.r8x.r820t.R820TTunerConfiguration;
+import io.github.dsheirer.source.tuner.rtl.r8x.r828d.R828DTunerConfiguration;
 import io.github.dsheirer.source.tuner.sdrplay.RspTunerConfiguration;
 
 /**
@@ -47,6 +48,7 @@ import io.github.dsheirer.source.tuner.sdrplay.RspTunerConfiguration;
         @JsonSubTypes.Type(value = HackRFTunerConfiguration.class, name = "hackRFTunerConfiguration"),
         @JsonSubTypes.Type(value = RecordingTunerConfiguration.class, name = "recordingTunerConfiguration"),
         @JsonSubTypes.Type(value = R820TTunerConfiguration.class, name = "r820TTunerConfiguration"),
+        @JsonSubTypes.Type(value = R828DTunerConfiguration.class, name = "r828DTunerConfiguration"),
         @JsonSubTypes.Type(value = RspTunerConfiguration.class, name = "rspTunerConfiguration"),
 })
 @JacksonXmlRootElement(localName = "tuner_configuration")

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
 import io.github.dsheirer.source.tuner.rtl.e4k.E4KTunerConfiguration;
-import io.github.dsheirer.source.tuner.rtl.r820t.R820TTunerConfiguration;
+import io.github.dsheirer.source.tuner.rtl.r8x.r820t.R820TTunerConfiguration;
+import io.github.dsheirer.source.tuner.rtl.r8x.r828d.R828DTunerConfiguration;
 
 /**
  * RTL2832 tuner configuration
@@ -33,11 +34,13 @@ import io.github.dsheirer.source.tuner.rtl.r820t.R820TTunerConfiguration;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = E4KTunerConfiguration.class, name = "e4KTunerConfiguration"),
         @JsonSubTypes.Type(value = R820TTunerConfiguration.class, name = "r820TTunerConfiguration"),
+        @JsonSubTypes.Type(value = R828DTunerConfiguration.class, name = "r828DTunerConfiguration"),
 })
 @JacksonXmlRootElement(localName = "tuner_configuration")
 public abstract class RTL2832TunerConfiguration extends TunerConfiguration
 {
     private RTL2832TunerController.SampleRate mSampleRate = RTL2832TunerController.SampleRate.RATE_2_400MHZ;
+    private boolean mBiasTEnabled = false;
 
     /**
      * Default constructor to support Jackson
@@ -60,5 +63,24 @@ public abstract class RTL2832TunerConfiguration extends TunerConfiguration
     public void setSampleRate(RTL2832TunerController.SampleRate sampleRate)
     {
         mSampleRate = sampleRate;
+    }
+
+    /**
+     * Sets the enabled state of the Bias-T
+     * @param enabled true to turn-on the bias-T
+     */
+    public void setBiasT(boolean enabled)
+    {
+        mBiasTEnabled = enabled;
+    }
+
+    /**
+     * Indicates if the Bias-T is enabled.
+     * @return true if enabled.
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "bias_t")
+    public boolean isBiasT()
+    {
+        return mBiasTEnabled;
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,6 +66,7 @@ public class RTL2832TunerController extends USBTunerController
     private Descriptor mDescriptor;
     private EmbeddedTuner mEmbeddedTuner;
     private long mTunedFrequency = 0;
+    private boolean mBiasTEnabled = false;
     private ReentrantLock mLock = new ReentrantLock();
 
     /**
@@ -174,7 +175,7 @@ public class RTL2832TunerController extends USBTunerController
 
         try
         {
-            writeRegister(Block.USB, Address.USB_SYSCTL.getAddress(), 0x09, 1);
+            writeRegister(Block.USB, Address.USB_SYSCTL, 0x09, 1);
         }
         catch(LibUsbException lue)
         {
@@ -195,7 +196,7 @@ public class RTL2832TunerController extends USBTunerController
 
             try
             {
-                writeRegister(Block.USB, Address.USB_SYSCTL.getAddress(), 0x09, 1);
+                writeRegister(Block.USB, Address.USB_SYSCTL, 0x09, 1);
             }
             catch(LibUsbException lue)
             {
@@ -238,7 +239,7 @@ public class RTL2832TunerController extends USBTunerController
 
         if(tunerType == TunerType.UNKNOWN)
         {
-            throw new SourceException("Unrecognized embedded tuner type for RTL-2832");
+            throw new SourceException("Unrecognized RTL-2832 embedded tuner type: " + tunerType);
         }
 
         mEmbeddedTuner = TunerFactory.getRtlEmbeddedTuner(tunerType, new ControllerAdapter(this));
@@ -297,6 +298,26 @@ public class RTL2832TunerController extends USBTunerController
         }
 
         return null;
+    }
+
+    /**
+     * Sets the enabled state of the bias-t
+     * @param enabled true to turn-on the bias-t or false to turn-off the bias-t.
+     */
+    public void setBiasT(boolean enabled)
+    {
+        setGPIOOutput((byte)0x01);
+        setGPIOBit((byte)0x01, enabled);
+        mBiasTEnabled = enabled;
+    }
+
+    /**
+     * Indicates if the bias-t is enabled.
+     * @return true if enabled.
+     */
+    public boolean isBiasT()
+    {
+        return mBiasTEnabled;
     }
 
     /**
@@ -437,8 +458,8 @@ public class RTL2832TunerController extends USBTunerController
      */
     public void resetUSBBuffer() throws LibUsbException
     {
-        writeRegister(Block.USB, Address.USB_EPA_CTL.getAddress(), 0x1002, 2);
-        writeRegister(Block.USB, Address.USB_EPA_CTL.getAddress(), 0x0000, 2);
+        writeRegister(Block.USB, Address.USB_EPA_CTL, 0x1002, 2);
+        writeRegister(Block.USB, Address.USB_EPA_CTL, 0x0000, 2);
     }
 
     /**
@@ -448,13 +469,13 @@ public class RTL2832TunerController extends USBTunerController
     public void initBaseband() throws LibUsbException
     {
         /* Initialize USB */
-        writeRegister(Block.USB, Address.USB_SYSCTL.getAddress(), 0x09, 1);
-        writeRegister(Block.USB, Address.USB_EPA_MAXPKT.getAddress(), 0x0002, 2);
-        writeRegister(Block.USB, Address.USB_EPA_CTL.getAddress(), 0x1002, 2);
+        writeRegister(Block.USB, Address.USB_SYSCTL, 0x09, 1);
+        writeRegister(Block.USB, Address.USB_EPA_MAXPKT, 0x0002, 2);
+        writeRegister(Block.USB, Address.USB_EPA_CTL, 0x1002, 2);
 
         /* Power on demod */
-        writeRegister(Block.SYS, Address.DEMOD_CTL_1.getAddress(), 0x22, 1);
-        writeRegister(Block.SYS, Address.DEMOD_CTL.getAddress(), 0xE8, 1);
+        writeRegister(Block.SYS, Address.DEMOD_CTL_1, 0x22, 1);
+        writeRegister(Block.SYS, Address.DEMOD_CTL, 0xE8, 1);
 
         /* Reset demod */
         writeDemodRegister(Page.ONE, (short) 0x01, 0x14, 1); //Bit 3 = soft reset
@@ -513,7 +534,7 @@ public class RTL2832TunerController extends USBTunerController
      */
     private void deinitBaseband() throws IllegalArgumentException, UsbDisconnectedException
     {
-        writeRegister(Block.SYS, Address.DEMOD_CTL.getAddress(), 0x20, 1);
+        writeRegister(Block.SYS, Address.DEMOD_CTL, 0x20, 1);
     }
 
     /**
@@ -527,7 +548,7 @@ public class RTL2832TunerController extends USBTunerController
     private void setGPIOBit(byte bitMask, boolean enabled) throws LibUsbException
     {
         //Get current register value
-        int value = readRegister(Block.SYS, Address.GPO.getAddress(), 1);
+        int value = readRegister(Block.SYS, Address.GPO, 1);
 
         //Update the masked bits
         if(enabled)
@@ -540,7 +561,7 @@ public class RTL2832TunerController extends USBTunerController
         }
 
         //Write the change back to the device
-        writeRegister(Block.SYS, Address.GPO.getAddress(), value, 1);
+        writeRegister(Block.SYS, Address.GPO, value, 1);
     }
 
     /**
@@ -553,16 +574,16 @@ public class RTL2832TunerController extends USBTunerController
     private void setGPIOOutput(byte bitMask) throws LibUsbException
     {
         //Get current register value
-        int value = readRegister(Block.SYS, Address.GPD.getAddress(), 1);
+        int value = readRegister(Block.SYS, Address.GPD, 1);
 
         //Mask the value and rewrite it
-        writeRegister(Block.SYS, Address.GPO.getAddress(), value & ~bitMask, 1);
+        writeRegister(Block.SYS, Address.GPO, value & ~bitMask, 1);
 
         //Get current register value
-        value = readRegister(Block.SYS, Address.GPOE.getAddress(), 1);
+        value = readRegister(Block.SYS, Address.GPOE, 1);
 
         //Mask the value and rewrite it
-        writeRegister(Block.SYS, Address.GPOE.getAddress(), value | bitMask, 1);
+        writeRegister(Block.SYS, Address.GPOE, value | bitMask, 1);
     }
 
     /**
@@ -720,7 +741,7 @@ public class RTL2832TunerController extends USBTunerController
      * @param length of value in bytes
      * @throws LibUsbException on error
      */
-    private void writeRegister(Block block, short address, int value, int length) throws LibUsbException
+    private void writeRegister(Block block, Address address, int value, int length) throws LibUsbException
     {
         ByteBuffer buffer = ByteBuffer.allocateDirect(length);
         buffer.order(ByteOrder.BIG_ENDIAN);
@@ -740,7 +761,7 @@ public class RTL2832TunerController extends USBTunerController
         }
 
         buffer.rewind();
-        write(address, block, buffer);
+        write(address.getAddress(), block, buffer);
     }
 
     /**
@@ -751,10 +772,10 @@ public class RTL2832TunerController extends USBTunerController
      * @return value read
      * @throws LibUsbException on error
      */
-    private int readRegister(Block block, short address, int length) throws LibUsbException
+    private int readRegister(Block block, Address address, int length) throws LibUsbException
     {
         ByteBuffer buffer = ByteBuffer.allocateDirect(2);
-        read(address, block, buffer);
+        read(address.getAddress(), block, buffer);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
 
         if(length == 2)
@@ -869,11 +890,11 @@ public class RTL2832TunerController extends USBTunerController
 
             if(type == TunerTypeCheck.FC2580)
             {
-                return ((value & 0x7F) == type.getCheckValue());
+                return ((value & 0x7F) == (type.getCheckValue() & 0xFF));
             }
             else
             {
-                return (value == type.getCheckValue());
+                return (value == (type.getCheckValue() & 0xFF));
             }
         }
         catch(LibUsbException e)
@@ -973,7 +994,7 @@ public class RTL2832TunerController extends USBTunerController
 
     public void setSampleRateFrequencyCorrection(int ppm) throws SourceException
     {
-        int offset = -ppm * TWO_TO_22_POWER / 1000000;
+        int offset = -ppm * TWO_TO_22_POWER / 1_000_000;
         writeDemodRegister(Page.ONE, (short) 0x3F, (offset & 0xFF), 1);
         writeDemodRegister(Page.ONE, (short) 0x3E, (Integer.rotateRight(offset, 8) & 0xFF), 1);
         /* Test to retune controller to apply frequency correction */
@@ -983,7 +1004,7 @@ public class RTL2832TunerController extends USBTunerController
         }
         catch(Exception e)
         {
-            throw new SourceException("couldn't set sample rate frequency correction", e);
+            throw new SourceException("Couldn't set sample rate frequency correction", e);
         }
     }
 
@@ -1027,7 +1048,7 @@ public class RTL2832TunerController extends USBTunerController
         try
         {
             /* Tell the RTL-2832 to address the EEPROM */
-            writeRegister(Block.I2C, EEPROM_ADDRESS, (byte) offset, 1);
+            writeRegister(Block.I2C, Address.EEPROM, (byte) offset, 1);
         }
         catch(LibUsbException e)
         {
@@ -1068,7 +1089,7 @@ public class RTL2832TunerController extends USBTunerController
         }
 
         int offsetAndValue = Integer.rotateLeft((0xFF & offset), 8) | (0xFF & value);
-        writeRegister(Block.I2C, EEPROM_ADDRESS, offsetAndValue, 2);
+        writeRegister(Block.I2C, Address.EEPROM, offsetAndValue, 2);
     }
 
     public enum Address
@@ -1093,7 +1114,8 @@ public class RTL2832TunerController extends USBTunerController
         SYSINTE_1(0x3009),
         SYSINTS_1(0x300A),
         DEMOD_CTL_1(0x300B),
-        IR_SUSPEND(0x300C);
+        IR_SUSPEND(0x300C),
+        EEPROM(0xA0);
 
         private int mAddress;
 
@@ -1314,6 +1336,14 @@ public class RTL2832TunerController extends USBTunerController
             getLabels();
         }
 
+        /**
+         * Indicates if this is a rtl-sdr.com V4 R828D dongle with notch filtering.
+         */
+        public boolean isRtlSdrV4()
+        {
+            return "RTLSDRBlog".equals(getVendorLabel()) && "Blog V4".equals(getProductLabel());
+        }
+
         public boolean isValid()
         {
             return mData[0] != (byte)0x0 && mData[1] != (byte)0x0;
@@ -1477,6 +1507,15 @@ public class RTL2832TunerController extends USBTunerController
         public boolean isRunning()
         {
             return mController.isRunning();
+        }
+
+        /**
+         * Indicates if this is a rtl-sdr.com V4 dongle with support for notch filtering.
+         * @return true if this is a V4 R828D tuner.
+         */
+        public boolean isV4Dongle()
+        {
+            return mController.getDescriptor().isRtlSdrV4();
         }
 
         /**

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
@@ -41,6 +41,7 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JSeparator;
+import javax.swing.JToggleButton;
 import javax.swing.SpinnerNumberModel;
 import javax.usb.UsbException;
 
@@ -52,6 +53,7 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
     private final static Logger mLog = LoggerFactory.getLogger(E4KTunerEditor.class);
     private static final long serialVersionUID = 1L;
     private JButton mTunerInfoButton;
+    private JToggleButton mBiasTButton;
     private JComboBox<SampleRate> mSampleRateCombo;
     private JComboBox<E4KGain> mMasterGainCombo;
     private JComboBox<E4KMixerGain> mMixerGainCombo;
@@ -95,7 +97,8 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         add(getTunerInfoButton());
 
         add(new JLabel("Status:"));
-        add(getTunerStatusLabel(), "wrap");
+        add(getTunerStatusLabel());
+        add(getBiasTButton(), "wrap");
 
         add(getButtonPanel(), "span,align left");
 
@@ -144,6 +147,8 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
 
         if(hasTuner())
         {
+            getBiasTButton().setEnabled(true);
+            getBiasTButton().setSelected(getConfiguration().isBiasT());
             getTunerInfoButton().setEnabled(true);
             getSampleRateCombo().setEnabled(true);
             getSampleRateCombo().setSelectedItem(getConfiguration().getSampleRate());
@@ -174,6 +179,8 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         }
         else
         {
+            getBiasTButton().setEnabled(false);
+            getBiasTButton().setSelected(false);
             getTunerInfoButton().setEnabled(false);
             getSampleRateCombo().setEnabled(false);
             getMasterGainCombo().setEnabled(false);
@@ -185,6 +192,28 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         updateSampleRateToolTip();
 
         setLoading(false);
+    }
+
+    /**
+     * Bias-T toggle button
+     * @return
+     */
+    private JToggleButton getBiasTButton()
+    {
+        if(mBiasTButton == null)
+        {
+            mBiasTButton = new JToggleButton("Bias-T");
+            mBiasTButton.setEnabled(false);
+            mBiasTButton.addActionListener(e -> {
+                if(!isLoading())
+                {
+                    getTuner().getController().setBiasT(mBiasTButton.isSelected());
+                    save();
+                }
+            });
+        }
+
+        return mBiasTButton;
     }
 
     private JComboBox getIfGainCombo()
@@ -459,7 +488,7 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
             double value = ((SpinnerNumberModel)getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             config.setFrequencyCorrection(value);
             config.setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
-
+            config.setBiasT(getTuner().getController().isBiasT());
             config.setSampleRate((SampleRate)getSampleRateCombo().getSelectedItem());
             config.setMasterGain((E4KGain)getMasterGainCombo().getSelectedItem());
             config.setMixerGain((E4KMixerGain)getMixerGainCombo().getSelectedItem());

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,35 +16,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  * ****************************************************************************
  */
-package io.github.dsheirer.source.tuner.rtl.r820t;
+package io.github.dsheirer.source.tuner.rtl.r8x;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.rtl.RTL2832TunerConfiguration;
 
 /**
- * RTL-2832 with embedded R820T tuner configuration
+ * RTL-2832 with embedded R8xxx tuner configuration
  */
-public class R820TTunerConfiguration extends RTL2832TunerConfiguration
+public abstract class R8xTunerConfiguration extends RTL2832TunerConfiguration
 {
-    private R820TEmbeddedTuner.R820TGain mMasterGain = R820TEmbeddedTuner.R820TGain.GAIN_327;
-    private R820TEmbeddedTuner.R820TMixerGain mMixerGain = R820TEmbeddedTuner.R820TMixerGain.GAIN_105;
-    private R820TEmbeddedTuner.R820TLNAGain mLNAGain = R820TEmbeddedTuner.R820TLNAGain.GAIN_222;
-    private R820TEmbeddedTuner.R820TVGAGain mVGAGain = R820TEmbeddedTuner.R820TVGAGain.GAIN_210;
+    private R8xEmbeddedTuner.MasterGain mMasterMasterGain = R8xEmbeddedTuner.MasterGain.GAIN_327;
+    private R8xEmbeddedTuner.MixerGain mMixerGain = R8xEmbeddedTuner.MixerGain.GAIN_105;
+    private R8xEmbeddedTuner.LNAGain mLNAGain = R8xEmbeddedTuner.LNAGain.GAIN_222;
+    private R8xEmbeddedTuner.VGAGain mVGAGain = R8xEmbeddedTuner.VGAGain.GAIN_210;
 
     /**
      * Default constructor for JAXB
      */
-    public R820TTunerConfiguration()
+    public R8xTunerConfiguration()
     {
-    }
-
-    @JsonIgnore
-    @Override
-    public TunerType getTunerType()
-    {
-        return TunerType.RAFAELMICRO_R820T;
     }
 
     /**
@@ -52,51 +43,51 @@ public class R820TTunerConfiguration extends RTL2832TunerConfiguration
      *
      * @param uniqueID for the tuner
      */
-    public R820TTunerConfiguration(String uniqueID)
+    public R8xTunerConfiguration(String uniqueID)
     {
         super(uniqueID);
     }
 
     @JacksonXmlProperty(isAttribute = true, localName = "master_gain")
-    public R820TEmbeddedTuner.R820TGain getMasterGain()
+    public R8xEmbeddedTuner.MasterGain getMasterGain()
     {
-        return mMasterGain;
+        return mMasterMasterGain;
     }
 
-    public void setMasterGain(R820TEmbeddedTuner.R820TGain gain)
+    public void setMasterGain(R8xEmbeddedTuner.MasterGain masterGain)
     {
-        mMasterGain = gain;
+        mMasterMasterGain = masterGain;
     }
 
     @JacksonXmlProperty(isAttribute = true, localName = "mixer_gain")
-    public R820TEmbeddedTuner.R820TMixerGain getMixerGain()
+    public R8xEmbeddedTuner.MixerGain getMixerGain()
     {
         return mMixerGain;
     }
 
-    public void setMixerGain(R820TEmbeddedTuner.R820TMixerGain mixerGain)
+    public void setMixerGain(R8xEmbeddedTuner.MixerGain mixerGain)
     {
         mMixerGain = mixerGain;
     }
 
     @JacksonXmlProperty(isAttribute = true, localName = "lna_gain")
-    public R820TEmbeddedTuner.R820TLNAGain getLNAGain()
+    public R8xEmbeddedTuner.LNAGain getLNAGain()
     {
         return mLNAGain;
     }
 
-    public void setLNAGain(R820TEmbeddedTuner.R820TLNAGain lnaGain)
+    public void setLNAGain(R8xEmbeddedTuner.LNAGain lnaGain)
     {
         mLNAGain = lnaGain;
     }
 
     @JacksonXmlProperty(isAttribute = true, localName = "vga_gain")
-    public R820TEmbeddedTuner.R820TVGAGain getVGAGain()
+    public R8xEmbeddedTuner.VGAGain getVGAGain()
     {
         return mVGAGain;
     }
 
-    public void setVGAGain(R820TEmbeddedTuner.R820TVGAGain vgaGain)
+    public void setVGAGain(R8xEmbeddedTuner.VGAGain vgaGain)
     {
         mVGAGain = vgaGain;
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r820t/R820TEmbeddedTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r820t/R820TEmbeddedTuner.java
@@ -1,0 +1,85 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2023 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+package io.github.dsheirer.source.tuner.rtl.r8x.r820t;
+
+import io.github.dsheirer.source.SourceException;
+import io.github.dsheirer.source.tuner.TunerType;
+import io.github.dsheirer.source.tuner.rtl.RTL2832TunerController;
+import io.github.dsheirer.source.tuner.rtl.r8x.R8xEmbeddedTuner;
+
+import javax.usb.UsbException;
+
+/**
+ * Rafael Micro R820T and R820T2 Embedded Tuner implementation
+ */
+public class R820TEmbeddedTuner extends R8xEmbeddedTuner
+{
+    private static final byte I2C_ADDRESS = (byte) 0x34;
+    private static final int VCO_POWER_REF = 2;
+
+    /**
+     * Constructs an instance
+     * @param adapter for accessing RTL2832USBController interfaces
+     */
+    public R820TEmbeddedTuner(RTL2832TunerController.ControllerAdapter adapter)
+    {
+        super(adapter, VCO_POWER_REF);
+    }
+
+    @Override
+    public TunerType getTunerType()
+    {
+        return TunerType.RAFAELMICRO_R820T;
+    }
+
+    @Override
+    public byte getI2CAddress()
+    {
+        return I2C_ADDRESS;
+    }
+
+    /**
+     * Sets the center frequency.  Setting the frequency is a two-part process
+     * of setting the multiplexer and then setting the Oscillator (PLL).
+     */
+    @Override
+    public synchronized void setTunedFrequency(long frequency) throws SourceException
+    {
+        getAdapter().getLock().lock();
+
+        try
+        {
+            getAdapter().enableI2CRepeater();
+            boolean controlI2C = false;
+            long offsetFrequency = frequency + IF_FREQUENCY;
+            setMux(offsetFrequency, controlI2C);
+            setPLL(offsetFrequency, controlI2C);
+            getAdapter().disableI2CRepeater();
+        }
+        catch(UsbException e)
+        {
+            throw new SourceException("R820TTunerController - exception while setting frequency [" + frequency + "] - " +
+                    e.getLocalizedMessage());
+        }
+        finally
+        {
+            getAdapter().getLock().unlock();
+        }
+    }
+}

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r820t/R820TTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r820t/R820TTunerConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2023 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+package io.github.dsheirer.source.tuner.rtl.r8x.r820t;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.github.dsheirer.source.tuner.TunerType;
+import io.github.dsheirer.source.tuner.rtl.r8x.R8xTunerConfiguration;
+
+/**
+ * RTL-2832 with embedded R820T tuner configuration
+ */
+public class R820TTunerConfiguration extends R8xTunerConfiguration
+{
+    /**
+     * Empty constructor for Jackson serialization
+     */
+    public R820TTunerConfiguration()
+    {
+    }
+
+    /**
+     * Constructs an instance
+     * @param uniqueId for the tuner
+     */
+    public R820TTunerConfiguration(String uniqueId)
+    {
+        super(uniqueId);
+    }
+
+    @JsonIgnore
+    @Override
+    public TunerType getTunerType()
+    {
+        return TunerType.RAFAELMICRO_R820T;
+    }
+}

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r828d/R828DEmbeddedTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r828d/R828DEmbeddedTuner.java
@@ -1,0 +1,127 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2023 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+package io.github.dsheirer.source.tuner.rtl.r8x.r828d;
+
+import io.github.dsheirer.source.SourceException;
+import io.github.dsheirer.source.tuner.TunerType;
+import io.github.dsheirer.source.tuner.rtl.RTL2832TunerController;
+import io.github.dsheirer.source.tuner.rtl.r8x.R8xEmbeddedTuner;
+
+import javax.usb.UsbException;
+
+/**
+ * Rafael Micro R828D Embedded Tuner implementation
+ */
+public class R828DEmbeddedTuner extends R8xEmbeddedTuner
+{
+    private static final byte I2C_ADDRESS = (byte) 0x74;
+    private static final int VCO_POWER_REF = 1;
+    /**
+     * RTL-SDR.com blog V4 dongle indicator.
+     */
+    private final boolean mIsV4Dongle;
+
+    /**
+     * Constructs an instance
+     * @param adapter for accessing RTL2832USBController interfaces
+     */
+    public R828DEmbeddedTuner(RTL2832TunerController.ControllerAdapter adapter)
+    {
+        super(adapter, VCO_POWER_REF);
+
+        //Set flag to indicate if this is a V4 dongle that supports notch filtering.
+        mIsV4Dongle = adapter.isV4Dongle();
+    }
+
+    @Override
+    public TunerType getTunerType()
+    {
+        return TunerType.RAFAELMICRO_R828D;
+    }
+
+    @Override
+    public byte getI2CAddress()
+    {
+        return I2C_ADDRESS;
+    }
+
+    /**
+     * Sets the center frequency.  Setting the frequency is a two-part process
+     * of setting the multiplexer and then setting the Oscillator (PLL).
+     */
+    @Override
+    public synchronized void setTunedFrequency(long frequency) throws SourceException
+    {
+        getAdapter().getLock().lock();
+
+        try
+        {
+            getAdapter().enableI2CRepeater();
+            boolean controlI2C = false;
+            long offsetFrequency = frequency + IF_FREQUENCY;
+            setMux(offsetFrequency, controlI2C);
+            setPLL(offsetFrequency, controlI2C);
+
+            //Select the RF input
+            if(mIsV4Dongle)
+            {
+                //Disable notch filtering if frequency falls into a notched band, otherwise enable it.
+                boolean isNotchFilterFrequency = (frequency < 2_200_000) ||
+                        (85_000_000 < frequency && frequency < 112_000_000) ||
+                        (172_000_000 < frequency && frequency < 242_000_000);
+                writeRegister(Register.DRAIN, isNotchFilterFrequency ? (byte)0x00 : (byte)0x08, controlI2C);
+
+                if(frequency <= 28_800_000) //Use cable 2 input
+                {
+                    writeRegister(Register.INPUT_SELECTOR_AIR, (byte)0x20, controlI2C); //disabled
+                    writeRegister(Register.INPUT_SELECTOR_CABLE_1, (byte)0x00, controlI2C); //disabled
+                    writeRegister(Register.INPUT_SELECTOR_CABLE_2, (byte)0x08, controlI2C); //enabled
+                }
+                else if(frequency < 250_000_000)
+                {
+                    writeRegister(Register.INPUT_SELECTOR_AIR, (byte)0x20, controlI2C); //disabled
+                    writeRegister(Register.INPUT_SELECTOR_CABLE_1, (byte)0x40, controlI2C); //enabled
+                    writeRegister(Register.INPUT_SELECTOR_CABLE_2, (byte)0x00, controlI2C); //disabled
+                }
+                else
+                {
+                    writeRegister(Register.INPUT_SELECTOR_AIR, (byte)0x00, controlI2C); //enabled
+                    writeRegister(Register.INPUT_SELECTOR_CABLE_1, (byte)0x00, controlI2C); //disabled
+                    writeRegister(Register.INPUT_SELECTOR_CABLE_2, (byte)0x00, controlI2C); //disabled
+                }
+            }
+            else
+            {
+                byte air_cable_in = (frequency > 345_000_000) ? (byte)0x00 : (byte)0x60;
+                writeRegister(Register.INPUT_SELECTOR_AIR_AND_CABLE_1, air_cable_in, controlI2C);
+            }
+
+            getAdapter().disableI2CRepeater();
+        }
+        catch(UsbException e)
+        {
+            throw new SourceException("R820TTunerController - exception while setting frequency [" + frequency + "] - " +
+                    e.getLocalizedMessage());
+        }
+        finally
+        {
+            getAdapter().getLock().unlock();
+        }
+    }
+}

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r828d/R828DTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r828d/R828DTunerConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2023 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+package io.github.dsheirer.source.tuner.rtl.r8x.r828d;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.github.dsheirer.source.tuner.TunerType;
+import io.github.dsheirer.source.tuner.rtl.r8x.R8xTunerConfiguration;
+
+/**
+ * RTL-2832 with embedded R828D tuner configuration
+ */
+public class R828DTunerConfiguration extends R8xTunerConfiguration
+{
+    /**
+     * Empty constructor for Jackson serialization
+     */
+    public R828DTunerConfiguration()
+    {
+    }
+
+    /**
+     * Constructs an instance
+     * @param uniqueId for the tuner
+     */
+    public R828DTunerConfiguration(String uniqueId)
+    {
+        super(uniqueId);
+    }
+
+    @JsonIgnore
+    @Override
+    public TunerType getTunerType()
+    {
+        return TunerType.RAFAELMICRO_R828D;
+    }
+}


### PR DESCRIPTION
Closes #1643 
* Adds support for RTL2832 with embedded R828D tuner and RTL-SDR.com V4 dongles.
* Introduces Bias-T support for all RTL2832 dongles.