### PR TITLE
#1673 Broadcastify Call Streaming Config Editor - Can't Edit System ID

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/control/IntegerTextField.java
+++ b/src/main/java/io/github/dsheirer/gui/control/IntegerTextField.java
@@ -1,32 +1,28 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2023 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2020 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 
 package io.github.dsheirer.gui.control;
 
+import java.util.function.UnaryOperator;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
 import javafx.util.converter.IntegerStringConverter;
-
-import java.util.function.UnaryOperator;
 
 /**
  * Text field control for integer values.
@@ -52,7 +48,7 @@ public class IntegerTextField extends TextField
             return null;
         };
 
-        setTextFormatter(new TextFormatter<Integer>(new IntegerStringConverter(), 0, filter));
+        setTextFormatter(new TextFormatter<Integer>(new IntegerStringConverter(), null, filter));
     }
 
     /**


### PR DESCRIPTION
Closes #1673 

Updates broadcastify call streaming config editor's where the original default value of 0 causes field to be uneditable depending on where in the field you click, either to the left or the right of the default zero value.  When the caret/cursor is to the right of the zero, it blocks any further typing because any system ID is not allowed to start with a zero or zero-prefixed value.

Removed the zero default value and set the field to empty/null.