### PR TITLE
#1651 Version 0.6.0 Beta 4 and Version Naming Conventions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,17 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-//Note: this should match the GitLab release tag.
-version = '0.6.0-beta-3'
+/**
+ * Version naming conventions:
+ *   Alpha: maj.min.patch-alpha-build
+ *    Beta: maj.min.patch-beta-build
+ * Release: maj.min.patch
+ *
+ * Note: this is so that the file names for the resultant release build products match the GitLab release asset
+ * tag name, specifically the dashes inserted before and after the alpha/beta labels.
+ * See: https://github.com/DSheirer/sdrtrunk/issues/1651
+ */
+version = '0.6.0-beta-4'
 
 //Java 20 is required for this version of the Project Panama preview/incubator feature
 java {


### PR DESCRIPTION
Closes #1651 

Increment version to 0.6.0 Beta 4
Add instructions to build.gradle for version naming conventions.
