### PR TITLE
#1644 SDRPlay API Version 3.12 For Mac OSX

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/Version.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/Version.java
@@ -32,7 +32,8 @@ public enum Version
     V3_08(3.08f, true),
     V3_09(3.09f, true),
     V3_10(3.10f, true),
-    V3_11(3.11f, true);
+    V3_11(3.11f, true),
+    V3_12(3.12f, true);
 
     private float mValue;
     private boolean mSupported;


### PR DESCRIPTION
Partially addresses #1644 by updating sdrtrunk to consider API version 3.12 as a supported version.