### PR TITLE
#1706 Github Action For Nightly Releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,38 @@
+# Create nightly release for Linux, Mac and Windows using the Linux runner.
+name: Nightly Release
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 20
+        uses: actions/setup-java@v3
+        with:
+          java-version: '20'
+          distribution: 'liberica'
+          java-package: 'jdk+fx'
+
+      - name: Build Linux and Mac releases with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: runtimeZipOthers -PprojectVersion=nightly
+
+      - name: Build Windows release with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: runtimeZipWindows -PprojectVersion=nightly
+
+      - name: Add build artifacts to nightly release
+        uses: pyTooling/Actions/releaser@main
+        with:
+          tag: nightly
+          rm: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: build/image/*.zip

--- a/build.gradle
+++ b/build.gradle
@@ -53,17 +53,8 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 
-/**
- * Version naming conventions:
- *   Alpha: maj.min.patch-alpha-build
- *    Beta: maj.min.patch-beta-build
- * Release: maj.min.patch
- *
- * Note: this is so that the file names for the resultant release build products match the GitLab release asset
- * tag name, specifically the dashes inserted before and after the alpha/beta labels.
- * See: https://github.com/DSheirer/sdrtrunk/issues/1651
- */
-version = '0.6.0-beta-4'
+//Version is defined in gradle.properties so that we can CLI override it for nightly builds.
+version = project.findProperty('projectVersion')
 
 //Java 20 is required for this version of the Project Panama preview/incubator feature
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,29 @@
+#
+# ******************************************************************************
+# Copyright (C) 2014-2023 Dennis Sheirer
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+# *****************************************************************************
+#
+
+# Version naming conventions:
+#   Alpha: maj.min.patch-alpha-build
+#    Beta: maj.min.patch-beta-build
+# Release: maj.min.patch
+#
+# Note: this is so that the file names for the resultant release build products match the GitLab release asset
+# tag name, specifically the dashes inserted before and after the alpha/beta labels.
+# See: https://github.com/DSheirer/sdrtrunk/issues/1651
+
+projectVersion=0.6.0-beta-4


### PR DESCRIPTION
Closes #1706 

Creates a Github action to build sdrtrunk application for each target OS and upload the artifacts to the 'nightly' release tag.