### PR TITLE
Explicitly send filename to Rdio-Scanner.

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBroadcaster.java
@@ -232,6 +232,9 @@ public class RdioScannerBroadcaster extends AbstractAudioBroadcaster<RdioScanner
                 String talkgroupLabel = getTalkgroupLabel(audioRecording);
                 String talkgroupGroup = getTalkgroupGroup(audioRecording);
                 String systemLabel = getSystemLabel(audioRecording);
+                String path = audioRecording.getPath().toString();
+                // Remove TEMPORARY_STREAM_FILE_SUFFIX
+                String audioName = path.substring(path.substring(0, path.lastIndexOf("_")).lastIndexOf("_") + 1);
 
                 try
                 {
@@ -252,6 +255,7 @@ public class RdioScannerBroadcaster extends AbstractAudioBroadcaster<RdioScanner
                         RdioScannerBuilder bodyBuilder = new RdioScannerBuilder();
                             bodyBuilder.addPart(FormField.KEY, getBroadcastConfiguration().getApiKey())
                             .addPart(FormField.SYSTEM, getBroadcastConfiguration().getSystemID())
+                            .addAudioName(audioName)
                             .addFile(audioBytes)
                             .addPart(FormField.DATE_TIME, timestampSeconds)
                             .addPart(FormField.TALKGROUP_ID, talkgroup)

--- a/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBuilder.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBuilder.java
@@ -34,7 +34,8 @@ public class RdioScannerBuilder
     private static final String DASH_DASH = "--";
     private static final String BOUNDARY = "--sdrtrunk-sdrtrunk-sdrtrunk";
     private List<Part> mParts = new ArrayList<>();
-    private byte[] audioBytes = null; 
+    private byte[] audioBytes = null;
+    private String audioName = null;
 
     /**
      * Constructs an instance
@@ -49,6 +50,15 @@ public class RdioScannerBuilder
     public String getBoundary()
     {
         return BOUNDARY;
+    }
+
+    /**
+     * Adds a Audio file name part to the call
+     */
+    public RdioScannerBuilder addAudioName(String value)
+    {
+        audioName = value;
+        return this;
     }
 
     /**
@@ -110,7 +120,8 @@ public class RdioScannerBuilder
         }
         StringBuilder sb= new StringBuilder();
         sb.append(DASH_DASH).append(boundary).append("\r\n");
-        sb.append("Content-Disposition: form-data; name=\"").append("audio").append("\"\r\n\r\n");
+        sb.append("Content-Disposition: form-data; filename =\"").append(audioName);
+        sb.append("\"; name=\"").append("audio").append("\"\r\n\r\n");
         return sb.toString();
 
     }


### PR DESCRIPTION
This addresses the issue in the recently closed #1620 where Rdio-Scanner is expecting an explicit filename to be set in the upload.