### PR TITLE
#968 Playlist Alias Editor - Clear Overlap Error Warning Once Resolved

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasConfigurationEditor.java
@@ -387,7 +387,7 @@ public class AliasConfigurationEditor extends SplitPane
             idsColumn.setCellValueFactory(new IdentifierCountCell());
 
             TableColumn<Alias, Boolean> errorsColumn = new TableColumn<>("Error");
-            errorsColumn.setPrefWidth(80);
+            errorsColumn.setPrefWidth(120);
             errorsColumn.setCellValueFactory(new PropertyValueFactory<>("overlap"));
             errorsColumn.setCellFactory(param ->
             {

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
@@ -362,7 +362,10 @@ public class AliasItemEditor extends Editor<Alias>
                 for(AliasID aliasID: getIdentifiersList().getItems())
                 {
                     //Create a copy of the identifier so that the alias and the editor don't have the same instance
-                    alias.addAliasID(AliasFactory.copyOf(aliasID));
+                    //and reset the overlap flag (if set) so that the alias list can reevaluate the overlap state.
+                    AliasID copy = AliasFactory.copyOf(aliasID);
+                    copy.setOverlap(false);
+                    alias.addAliasID(copy);
                 }
 
                 //Remove and replace alias actions

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r828d/R828DEmbeddedTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/r828d/R828DEmbeddedTuner.java
@@ -123,7 +123,7 @@ public class R828DEmbeddedTuner extends R8xEmbeddedTuner
         }
         catch(UsbException e)
         {
-            throw new SourceException("R820TTunerController - exception while setting frequency [" + frequency + "] - " +
+            throw new SourceException("R828DTunerController - exception while setting frequency [" + frequency + "] - " +
                     e.getLocalizedMessage());
         }
         finally


### PR DESCRIPTION
Closes #968 
Resolves issue with clearing alias ID overlap state when the user edits the alias to correct the overlap.
