### PR TITLE
#732 P25 Phase 2 - FROM ID Updated For Call Event Logging

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
@@ -1059,6 +1059,8 @@ public class P25P2DecoderState extends TimeslotDecoderState implements Identifie
     {
         if(mCurrentCallEvent != null)
         {
+            //Refresh the identifier collection before we close out the event
+            mCurrentCallEvent.setIdentifierCollection(getIdentifierCollection().copyOf());
             mCurrentCallEvent.end(timestamp);
             broadcast(mCurrentCallEvent);
             mCurrentCallEvent = null;


### PR DESCRIPTION
Closes #732 

Resolves P25P2 call events sometimes missing FROM radio ID even though the ID was decoded.
