### PR TITLE
#1681 Audio Recorder Mixing Up System and Site When Decoding Multiple Systems 

### DIFF
--- a/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
@@ -365,7 +365,7 @@ public class ChannelProcessingManager implements Listener<ChannelEvent>
      * @param request containing channel and other details
      * @throws ChannelException if a source is not available for the channel
      */
-    private void startProcessing(ChannelStartProcessingRequest request) throws ChannelException
+    private synchronized void startProcessing(ChannelStartProcessingRequest request) throws ChannelException
     {
         Channel channel = request.getChannel();
 

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xEmbeddedTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xEmbeddedTuner.java
@@ -236,7 +236,6 @@ public abstract class R8xEmbeddedTuner extends EmbeddedTuner
         writeRegister(Register.DIVIDER, (byte) (div_num << 5), controlI2C);
         /* Get the integral number for this divider and frequency */
         Integral integral = divider.getIntegral(frequency);
-        System.out.println("Using divider [" + divider + "] integral [" + integral + "] for [" + frequency + "]");
         writeRegister(Register.PLL, integral.getRegisterValue(), controlI2C);
         /* Calculate the sigma-delta modulator fractional setting.  If it's non-zero, power up the sdm and apply the
         fractional setting, otherwise turn it off */


### PR DESCRIPTION
Closes #1681 

Resolves issue where audio recordings have incorrect system and site labels in metadata.  Adds synchronized to channel processing manager's start channel request method to ensure that each channel is configured and started sequentially to avoid chance that simultaneous traffic channel grants occurring across two separate systems get inter-mingled on configuration and startup.