### PR TITLE
#1635 Add a special county agency to show all county freqs without an agency

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/AgencyEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/AgencyEditor.java
@@ -23,6 +23,7 @@ import io.github.dsheirer.playlist.PlaylistManager;
 import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.rrapi.type.Agency;
 import io.github.dsheirer.rrapi.type.AgencyInfo;
+import io.github.dsheirer.rrapi.type.CountyInfo;
 import io.github.dsheirer.service.radioreference.RadioReference;
 import io.github.dsheirer.util.ThreadPool;
 import javafx.application.Platform;
@@ -158,8 +159,13 @@ public class AgencyEditor extends VBox
             ThreadPool.CACHED.submit(() -> {
                 try
                 {
-                    final AgencyInfo agencyInfo = mRadioReference.getService().getAgencyInfo(agency);
-                    Platform.runLater(() -> getAgencyFrequencyEditor().setCategories(agencyInfo.getCategories()));
+                    if (mLevel == Level.COUNTY && agency instanceof CountyAgency) {
+                        final CountyInfo countyInfo = mRadioReference.getService().getCountyInfo(-agency.getAgencyId());
+                        Platform.runLater(() -> getAgencyFrequencyEditor().setCategories(countyInfo.getCategories()));
+                    } else {
+                        final AgencyInfo agencyInfo = mRadioReference.getService().getAgencyInfo(agency);
+                        Platform.runLater(() -> getAgencyFrequencyEditor().setCategories(agencyInfo.getCategories()));
+                    }
                 }
                 catch(Throwable t)
                 {
@@ -196,11 +202,11 @@ public class AgencyEditor extends VBox
             {
                 return 0;
             }
-            else if(o1.getName() == null)
+            else if(o1.getName() == null || o2 instanceof CountyAgency)
             {
                 return 1;
             }
-            else if(o2.getName() == null)
+            else if(o2.getName() == null || o1 instanceof CountyAgency)
             {
                 return -1;
             }

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/AgencyFrequencyEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/AgencyFrequencyEditor.java
@@ -158,9 +158,12 @@ public class AgencyFrequencyEditor extends GridPane
 
         if(categories != null && !categories.isEmpty())
         {
-            getCategoryComboBox().getItems().add(ALL_CATEGORIES);
+            // Only allow the combined list of all categories if there aren't that many
+            if (categories.size() < 10) {
+                categories.add(0, ALL_CATEGORIES);
+            }
             getCategoryComboBox().getItems().addAll(categories);
-            getCategoryComboBox().getSelectionModel().select(ALL_CATEGORIES);
+            getCategoryComboBox().getSelectionModel().select(categories.get(0));
         }
         else
         {

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/CountyAgency.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/CountyAgency.java
@@ -1,0 +1,33 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2022 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.playlist.radioreference;
+
+import io.github.dsheirer.rrapi.type.Agency;
+import io.github.dsheirer.rrapi.type.CountyInfo;
+
+public class CountyAgency extends Agency
+{
+    public CountyAgency(CountyInfo countyInfo)
+    {
+        this.setAgencyId(-countyInfo.getCountyId());
+        this.setName(countyInfo.getName() + " County (All)");
+        this.setType(-1);
+    }
+}

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceEditor.java
@@ -56,6 +56,7 @@ import jiconfont.javafx.IconNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -691,9 +692,10 @@ public class RadioReferenceEditor extends BorderPane implements Consumer<Authori
                     Platform.runLater(() -> {
                         getCountySystemEditor().setSystems(countyInfo.getSystems());
 
-                        List<Agency> countyAgencies = countyInfo.getAgencies();
-                        Agency countyAgency = new CountyAgency(countyInfo);
-                        countyAgencies.add(countyAgency);
+                        // Make a new list so we don't add our CountyAgency to the original list of agencies
+                        List<Agency> countyAgencies = new ArrayList<Agency>();
+                        countyAgencies.add(new CountyAgency(countyInfo));
+                        countyAgencies.addAll(countyInfo.getAgencies());
                         getCountyAgencyEditor().setAgencies(countyAgencies);
                     });
                 }

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/RadioReferenceEditor.java
@@ -22,6 +22,7 @@ package io.github.dsheirer.gui.playlist.radioreference;
 import io.github.dsheirer.playlist.PlaylistManager;
 import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.rrapi.RadioReferenceException;
+import io.github.dsheirer.rrapi.type.Agency;
 import io.github.dsheirer.rrapi.type.AuthorizationInformation;
 import io.github.dsheirer.rrapi.type.Country;
 import io.github.dsheirer.rrapi.type.CountryInfo;
@@ -689,7 +690,11 @@ public class RadioReferenceEditor extends BorderPane implements Consumer<Authori
 
                     Platform.runLater(() -> {
                         getCountySystemEditor().setSystems(countyInfo.getSystems());
-                        getCountyAgencyEditor().setAgencies(countyInfo.getAgencies());
+
+                        List<Agency> countyAgencies = countyInfo.getAgencies();
+                        Agency countyAgency = new CountyAgency(countyInfo);
+                        countyAgencies.add(countyAgency);
+                        getCountyAgencyEditor().setAgencies(countyAgencies);
                     });
                 }
                 catch(RadioReferenceException rre)


### PR DESCRIPTION
Closes #1635 

This solves the problem of frequencies tied to the main county page in RadioReference not showing up in the list of frequencies available to import. I'm doing this via a new subclass called `CountyAgency` which acts like an agency, but gets the frequency categories from the county instead of an agency. It will always show up first in the UI, like so:

<img width="636" alt="image" src="https://github.com/DSheirer/sdrtrunk/assets/498525/9b2e8bad-be14-4ea8-9e4f-81d410cc20d8">

For counties with a very large number of categories (and likely subcategories), it will default to showing the first category in the list, instead of trying to show all the frequencies at once (which I've found to be extremely slow):

<img width="177" alt="image" src="https://github.com/DSheirer/sdrtrunk/assets/498525/1653dbfd-2f0c-451e-9eca-06bc299a0e92">

On other smaller counties though, it will have the normal `(All)` selection.