### PR TITLE
#1726 Don't Auto-Create App Root In User Home Directory Once Changed

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_20_PREVIEW" project-jdk-name="liberica-20" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="liberica-20" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
+++ b/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
@@ -156,18 +156,10 @@ public class SDRTrunk implements Listener<TunerEvent>
             }
         }
 
-        //Setup the application home directory
-        Path home = getHomePath();
-
         ThreadPool.logSettings();
 
-        mLog.info("Home path: " + home.toString());
-
         //Load properties file
-        if(home != null)
-        {
-            loadProperties(home);
-        }
+        loadProperties();
 
         //Log current properties setting
         SystemProperties.getInstance().logCurrentSettings();
@@ -632,34 +624,30 @@ public class SDRTrunk implements Listener<TunerEvent>
      * Loads the application properties file from the user's home directory,
      * creating the properties file for the first-time, if necessary
      */
-    private void loadProperties(Path homePath)
+    private void loadProperties()
     {
-        Path propsPath = homePath.resolve("SDRTrunk.properties");
+        Path propertiesPath = mUserPreferences.getDirectoryPreference().getDirectoryApplicationRoot().resolve("SDRTrunk.properties");
 
-        if(!Files.exists(propsPath))
+        if(!Files.exists(propertiesPath))
         {
             try
             {
-                mLog.info("SDRTrunk - creating application properties file [" +
-                    propsPath.toAbsolutePath() + "]");
-
-                Files.createFile(propsPath);
+                mLog.info("SDRTrunk - creating application properties file [" + propertiesPath.toAbsolutePath() + "]");
+                Files.createFile(propertiesPath);
             }
             catch(IOException e)
             {
-                mLog.error("SDRTrunk - couldn't create application properties "
-                    + "file [" + propsPath.toAbsolutePath(), e);
+                mLog.error("SDRTrunk - couldn't create application properties file [" + propertiesPath.toAbsolutePath(), e);
             }
         }
 
-        if(Files.exists(propsPath))
+        if(Files.exists(propertiesPath))
         {
-            SystemProperties.getInstance().load(propsPath);
+            SystemProperties.getInstance().load(propertiesPath);
         }
         else
         {
-            mLog.error("SDRTrunk - couldn't find or recreate the SDRTrunk " +
-                "application properties file");
+            mLog.error("SDRTrunk - couldn't find or recreate the SDRTrunk application properties file");
         }
     }
 

--- a/src/main/java/io/github/dsheirer/properties/SystemProperties.java
+++ b/src/main/java/io/github/dsheirer/properties/SystemProperties.java
@@ -161,10 +161,6 @@ public class SystemProperties
         {
             mLog.info("SystemProperties - no properties file loaded - using defaults");
         }
-        else
-        {
-            mLog.info("SystemProperties - application properties loaded [" + mPropertiesPath.toString() + "]");
-        }
     }
 
     /**


### PR DESCRIPTION
#1726 On startup, application no longer auto-creates SDRTrunk folder and system properties in user's home directory when user has changed the application root in the user preferences.