### PR TITLE
Fix Rdio Scanner API call to comply with HTTP standards

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBroadcaster.java
@@ -270,7 +270,6 @@ public class RdioScannerBroadcaster extends AbstractAudioBroadcaster<RdioScanner
                             .uri(URI.create(getBroadcastConfiguration().getHost()))
                             .header(HttpHeaders.CONTENT_TYPE, MULTIPART_FORM_DATA + "; boundary=" + bodyBuilder.getBoundary())
                             .header(HttpHeaders.USER_AGENT, "sdrtrunk")
-                            .header(HttpHeaders.CONTENT_TYPE, "audio/mpeg")
                             .POST(bodyBuilder.build())
                             .build();
 

--- a/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBuilder.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/rdioscanner/RdioScannerBuilder.java
@@ -120,7 +120,7 @@ public class RdioScannerBuilder
         }
         StringBuilder sb= new StringBuilder();
         sb.append(DASH_DASH).append(boundary).append("\r\n");
-        sb.append("Content-Disposition: form-data; filename =\"").append(audioName);
+        sb.append("Content-Disposition: form-data; filename=\"").append(audioName);
         sb.append("\"; name=\"").append("audio").append("\"\r\n\r\n");
         return sb.toString();
 


### PR DESCRIPTION
I was running into some weird issues with my proxy that was processing Rdio scanner API calls, it turns out that SDRTrunk doesn't send a valid HTTP request, so not all servers can process it correctly. There cannot be two content type headers, so I'm removing the `audio/mpeg` one as it's able to be derived from the `.mp3` filename in Rdio scanner itself. Additionally, there was an extra space in the multipart form filename syntax, which may also cause some issues.

I've verified that the changes work fine with Rdio scanner.