### PR TITLE
#1735 Radio Reference API - Temporary Site With County ID 99999 - Unknown Location

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SystemEditor.java
@@ -294,7 +294,11 @@ public class SystemEditor extends VBox
                     {
                         CountyInfo countyInfo = null;
 
-                        if(site.getCountyId() > 0)
+                        int countyId = site.getCountyId();
+
+                        //Temporary sites that have been added to a system where the county/location is unknown, can
+                        //have a county ID of 99,999 as observed from API (undocumented).
+                        if(countyId > 0 && countyId != 99999)
                         {
                             countyInfo = mRadioReference.getService().getCountyInfo(site.getCountyId());
                         }


### PR DESCRIPTION
Closes #1735 
Adds support for county ID with sentinel value of 99999 to indicate county unknown for sites of a system.