### PR TITLE
#1753 SDRPlay - Remove Deprecated AGC Modes

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerEditor.java
@@ -35,10 +35,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.JButton;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JSlider;
+import javax.swing.JToggleButton;
 
 /**
  * Abstract RSP tuner editor
@@ -48,7 +48,7 @@ public abstract class RspTunerEditor<C extends RspTunerConfiguration> extends Tu
     private Logger mLog = LoggerFactory.getLogger(RspTunerEditor.class);
     private JSlider mGainSlider;
     private JLabel mGainValueLabel;
-    private JComboBox<AgcMode> mAgcModeCombo;
+    private JToggleButton mAgcButton;
     private JButton mGainOverloadButton;
     private AtomicBoolean mGainOverloadAlert = new AtomicBoolean();
 
@@ -120,22 +120,20 @@ public abstract class RspTunerEditor<C extends RspTunerConfiguration> extends Tu
     }
 
     /**
-     * IF AGC mode combobox control
+     * IF AGC mode (enable/disable) toggle button
      */
-    protected JComboBox<AgcMode> getAgcModeCombo()
+    protected JToggleButton getAgcButton()
     {
-        if(mAgcModeCombo == null)
+        if(mAgcButton == null)
         {
-            mAgcModeCombo = new JComboBox<>(AgcMode.values());
-            mAgcModeCombo.setEnabled(false);
-            mAgcModeCombo.addActionListener(e -> {
+            mAgcButton = new JToggleButton("IF AGC");
+            mAgcButton.setEnabled(false);
+            mAgcButton.addActionListener(e -> {
                 if(hasTuner() && !isLoading())
                 {
-                    AgcMode selected = (AgcMode)mAgcModeCombo.getSelectedItem();
                     try
                     {
-                        getTunerController().getControlRsp().setAgcMode(selected);
-                        save();
+                        getTunerController().getControlRsp().setAgcMode(mAgcButton.isSelected() ? AgcMode.ENABLE : AgcMode.DISABLE);
                     }
                     catch(SDRPlayException se)
                     {
@@ -146,7 +144,7 @@ public abstract class RspTunerEditor<C extends RspTunerConfiguration> extends Tu
             });
         }
 
-        return mAgcModeCombo;
+        return mAgcButton;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/control/AgcMode.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/control/AgcMode.java
@@ -20,16 +20,19 @@
 package io.github.dsheirer.source.tuner.sdrplay.api.parameter.control;
 
 import io.github.dsheirer.source.tuner.sdrplay.api.v3_07.sdrplay_api_h;
+import java.util.EnumSet;
 
 /**
  * Automatic Gain Control (AGC) Control (mode)
  */
 public enum AgcMode
 {
+    //Deprecated modes ... only use the ENABLE or DISABLE, in conjunction with the
+    AGC_100_HZ(sdrplay_api_h.sdrplay_api_AGC_100HZ(), "Deprecated - 100 Hz"),
+    AGC_50_HZ(sdrplay_api_h.sdrplay_api_AGC_50HZ(), "Deprecated 50 Hz"),
+    AGC_5_HZ(sdrplay_api_h.sdrplay_api_AGC_5HZ(), "Deprecated 5 Hz"),
+
     DISABLE(sdrplay_api_h.sdrplay_api_AGC_DISABLE(), "DISABLE"),
-    AGC_100_HZ(sdrplay_api_h.sdrplay_api_AGC_100HZ(), "100 Hz"),
-    AGC_50_HZ(sdrplay_api_h.sdrplay_api_AGC_50HZ(), "50 Hz"),
-    AGC_5_HZ(sdrplay_api_h.sdrplay_api_AGC_5HZ(), "5 Hz"),
     ENABLE(sdrplay_api_h.sdrplay_api_AGC_CTRL_EN(), "ENABLE");
 
     private int mValue;
@@ -41,12 +44,23 @@ public enum AgcMode
         mDescription = description;
     }
 
+    public static EnumSet<AgcMode> SUPPORTED_MODES = EnumSet.of(ENABLE, DISABLE);
+
     /**
      * Numeric value
      */
     public int getValue()
     {
         return mValue;
+    }
+
+    /**
+     * Indicates if the mode is a supported mode.
+     * @return true if it's a supported mode.
+     */
+    public boolean isSupported()
+    {
+        return SUPPORTED_MODES.contains(this);
     }
 
     /**
@@ -60,7 +74,16 @@ public enum AgcMode
         {
             if(status.getValue() == value)
             {
-                return status;
+                //legacy support in case some users had the deprecated values stored in their tuner configs.  In
+                //this situation we return ENABLED instead of one of these deprecated values.
+                if(status.isSupported())
+                {
+                    return status;
+                }
+                else
+                {
+                    return ENABLE;
+                }
             }
         }
         

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1/Rsp1TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1/Rsp1TunerEditor.java
@@ -82,7 +82,7 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
         add(new JLabel("IF AGC Mode:"));
         JPanel gainPanel = new JPanel();
         gainPanel.setLayout(new MigLayout("insets 0","[grow,fill][]",""));
-        gainPanel.add(getAgcModeCombo());
+        gainPanel.add(getAgcButton());
         gainPanel.add(getGainOverloadButton());
         add(gainPanel, "wrap");
 
@@ -134,10 +134,11 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
         updateSampleRateToolTip();
 
-        getAgcModeCombo().setEnabled(hasTuner());
+        getAgcButton().setEnabled(hasTuner());
         if(hasTuner())
         {
-            getAgcModeCombo().setSelectedItem(getTunerController().getControlRsp().getAgcMode());
+            AgcMode current = getTunerController().getControlRsp().getAgcMode();
+            getAgcButton().setSelected(current == null || current.equals(AgcMode.ENABLE));
             //Register to receive gain overload notifications
             getTunerController().getControlRsp().setGainOverloadListener(this);
         }
@@ -160,7 +161,7 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
             getConfiguration().setSampleRate((RspSampleRate)getSampleRateCombo().getSelectedItem());
             getConfiguration().setGain(getGainSlider().getValue());
-            getConfiguration().setAgcMode((AgcMode)getAgcModeCombo().getSelectedItem());
+            getConfiguration().setAgcMode(getAgcButton().isSelected() ? AgcMode.ENABLE : AgcMode.DISABLE);
 
             saveConfiguration();
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1a/Rsp1aTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1a/Rsp1aTunerEditor.java
@@ -86,7 +86,7 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
         add(new JLabel("IF AGC Mode:"));
         JPanel gainPanel = new JPanel();
         gainPanel.setLayout(new MigLayout("insets 0","[grow,fill][]",""));
-        gainPanel.add(getAgcModeCombo());
+        gainPanel.add(getAgcButton());
         gainPanel.add(getGainOverloadButton());
         add(gainPanel, "wrap");
 
@@ -145,10 +145,11 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
         updateSampleRateToolTip();
 
-        getAgcModeCombo().setEnabled(hasTuner());
+        getAgcButton().setEnabled(hasTuner());
         if(hasTuner())
         {
-            getAgcModeCombo().setSelectedItem(getTunerController().getControlRsp().getAgcMode());
+            AgcMode current = getTunerController().getControlRsp().getAgcMode();
+            getAgcButton().setSelected(current == null || current.equals(AgcMode.ENABLE));
             //Register to receive gain overload notifications
             getTunerController().getControlRsp().setGainOverloadListener(this);
         }
@@ -204,7 +205,7 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
             getConfiguration().setRfNotch(getRfNotchCheckBox().isSelected());
             getConfiguration().setRfDabNotch(getRfDabNotchCheckBox().isSelected());
             getConfiguration().setGain(getGainSlider().getValue());
-            getConfiguration().setAgcMode((AgcMode)getAgcModeCombo().getSelectedItem());
+            getConfiguration().setAgcMode(getAgcButton().isSelected() ? AgcMode.ENABLE : AgcMode.DISABLE);
 
             saveConfiguration();
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
@@ -88,7 +88,7 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
         add(new JLabel("IF AGC Mode:"));
         JPanel gainPanel = new JPanel();
         gainPanel.setLayout(new MigLayout("insets 0","[grow,fill][]",""));
-        gainPanel.add(getAgcModeCombo());
+        gainPanel.add(getAgcButton());
         gainPanel.add(getGainOverloadButton());
         add(gainPanel, "wrap");
 
@@ -149,10 +149,11 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
         updateSampleRateToolTip();
 
-        getAgcModeCombo().setEnabled(hasTuner());
+        getAgcButton().setEnabled(hasTuner());
         if(hasTuner())
         {
-            getAgcModeCombo().setSelectedItem(getTunerController().getControlRsp().getAgcMode());
+            AgcMode current = getTunerController().getControlRsp().getAgcMode();
+            getAgcButton().setSelected(current == null || current.equals(AgcMode.ENABLE));
             //Register to receive gain overload notifications
             getTunerController().getControlRsp().setGainOverloadListener(this);
         }
@@ -218,7 +219,7 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
             getConfiguration().setRfNotch(getRfNotchCheckBox().isSelected());
             getConfiguration().setAntennaSelection((Rsp2AntennaSelection)getAntennaSelectionCombo().getSelectedItem());
             getConfiguration().setGain(getGainSlider().getValue());
-            getConfiguration().setAgcMode((AgcMode)getAgcModeCombo().getSelectedItem());
+            getConfiguration().setAgcMode(getAgcButton().isSelected() ? AgcMode.ENABLE : AgcMode.DISABLE);
 
             saveConfiguration();
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner1Editor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner1Editor.java
@@ -97,7 +97,7 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
         add(new JLabel("IF AGC Mode:"));
         JPanel gainPanel = new JPanel();
         gainPanel.setLayout(new MigLayout("insets 0","[grow,fill][]",""));
-        gainPanel.add(getAgcModeCombo());
+        gainPanel.add(getAgcButton());
         gainPanel.add(getGainOverloadButton());
         add(gainPanel, "wrap");
 
@@ -154,8 +154,6 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
         }
         getTunerStatusLabel().setText(status);
         getButtonPanel().updateControls();
-        mLog.info("Update tuner status - has tuner: " + hasTuner() + " is locked:" + getTuner().getTunerController().isLockedSampleRate());
-
         getFrequencyPanel().updateControls();
 
         clearSampleRates();
@@ -167,10 +165,11 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
         updateSampleRateToolTip();
 
-        getAgcModeCombo().setEnabled(hasTuner());
+        getAgcButton().setEnabled(hasTuner());
         if(hasTuner())
         {
-            getAgcModeCombo().setSelectedItem(getTunerController().getControlRsp().getAgcMode());
+            AgcMode current = getTunerController().getControlRsp().getAgcMode();
+            getAgcButton().setSelected(current == null || current.equals(AgcMode.ENABLE));
             //Register to receive gain overload notifications
             getTunerController().getControlRsp().setGainOverloadListener(this);
         }
@@ -249,7 +248,7 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
             getConfiguration().setRfDabNotch(getRfDabNotchCheckBox().isSelected());
             getConfiguration().setRfNotch(getRfNotchCheckBox().isSelected());
             getConfiguration().setGain(getGainSlider().getValue());
-            getConfiguration().setAgcMode((AgcMode)getAgcModeCombo().getSelectedItem());
+            getConfiguration().setAgcMode(getAgcButton().isSelected() ? AgcMode.ENABLE : AgcMode.DISABLE);
 
             saveConfiguration();
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner2Editor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner2Editor.java
@@ -95,7 +95,7 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
         add(new JLabel("IF AGC Mode:"));
         JPanel gainPanel = new JPanel();
         gainPanel.setLayout(new MigLayout("insets 0","[grow,fill][]",""));
-        gainPanel.add(getAgcModeCombo());
+        gainPanel.add(getAgcButton());
         gainPanel.add(getGainOverloadButton());
         add(gainPanel, "wrap");
 
@@ -182,10 +182,11 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
         updateSampleRateToolTip();
 
-        getAgcModeCombo().setEnabled(hasTuner());
+        getAgcButton().setEnabled(hasTuner());
         if(hasTuner())
         {
-            getAgcModeCombo().setSelectedItem(getTunerController().getControlRsp().getAgcMode());
+            AgcMode current = getTunerController().getControlRsp().getAgcMode();
+            getAgcButton().setSelected(current == null || current.equals(AgcMode.ENABLE));
             //Register to receive gain overload notifications
             getTunerController().getControlRsp().setGainOverloadListener(this);
         }
@@ -259,7 +260,7 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
             getConfiguration().setRfDabNotch(getRfDabNotchCheckBox().isSelected());
             getConfiguration().setRfNotch(getRfNotchCheckBox().isSelected());
             getConfiguration().setGain(getGainSlider().getValue());
-            getConfiguration().setAgcMode((AgcMode)getAgcModeCombo().getSelectedItem());
+            getConfiguration().setAgcMode(getAgcButton().isSelected() ? AgcMode.ENABLE : AgcMode.DISABLE);
 
             saveConfiguration();
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDx/RspDxTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDx/RspDxTunerEditor.java
@@ -91,7 +91,7 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
         add(new JLabel("IF AGC Mode:"));
         JPanel gainPanel = new JPanel();
         gainPanel.setLayout(new MigLayout("insets 0","[grow,fill][]",""));
-        gainPanel.add(getAgcModeCombo());
+        gainPanel.add(getAgcButton());
         gainPanel.add(getGainOverloadButton());
         add(gainPanel, "wrap");
 
@@ -158,10 +158,11 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
         getSampleRateCombo().setSelectedItem(hasTuner() ? getTunerController().getControlRsp().getSampleRateEnumeration() : null);
         updateSampleRateToolTip();
 
-        getAgcModeCombo().setEnabled(hasTuner());
+        getAgcButton().setEnabled(hasTuner());
         if(hasTuner())
         {
-            getAgcModeCombo().setSelectedItem(getTunerController().getControlRsp().getAgcMode());
+            AgcMode current = getTunerController().getControlRsp().getAgcMode();
+            getAgcButton().setSelected(current == null || current.equals(AgcMode.ENABLE));
             //Register to receive gain overload notifications
             getTunerController().getControlRsp().setGainOverloadListener(this);
         }
@@ -239,7 +240,7 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
             getConfiguration().setRfNotch(getRfNotchCheckBox().isSelected());
             getConfiguration().setAntenna((RspDxAntenna) getAntennaCombo().getSelectedItem());
             getConfiguration().setGain(getGainSlider().getValue());
-            getConfiguration().setAgcMode((AgcMode)getAgcModeCombo().getSelectedItem());
+            getConfiguration().setAgcMode(getAgcButton().isSelected() ? AgcMode.ENABLE : AgcMode.DISABLE);
 
             saveConfiguration();
         }


### PR DESCRIPTION
Closes #1753 

Changes tuner editors to use toggle button for IF AGC mode and updates enum lookup to always return either ENABLE or DISABLE.  Deprecates 3x enum values as no longer supported.