### PR TITLE
P25-P2 Encryption Synchronization ReSync

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P1CallSequenceRecorder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P1CallSequenceRecorder.java
@@ -25,6 +25,9 @@ import io.github.dsheirer.audio.codec.mbe.MBECallSequenceRecorder;
 import io.github.dsheirer.bits.BinaryMessage;
 import io.github.dsheirer.message.IMessage;
 import io.github.dsheirer.module.decode.p25.phase1.message.P25Message;
+import io.github.dsheirer.module.decode.p25.phase1.message.hdu.HDUMessage;
+import io.github.dsheirer.module.decode.p25.phase1.message.hdu.HeaderData;
+import io.github.dsheirer.identifier.encryption.EncryptionKeyIdentifier;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.LinkControlWord;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.motorola.LCMotorolaPatchGroupVoiceChannelUpdate;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.motorola.LCMotorolaPatchGroupVoiceChannelUser;
@@ -123,6 +126,10 @@ public class P25P1CallSequenceRecorder extends MBECallSequenceRecorder
         else if(message instanceof TDUMessage)
         {
             flush();
+        }
+        else if (message instanceof HDUMessage)
+        {
+            process((HDUMessage)message);
         }
     }
 
@@ -226,6 +233,23 @@ public class P25P1CallSequenceRecorder extends MBECallSequenceRecorder
         {
             mCallSequence.setEncrypted(true);
             mCallSequence.setEncryptionSyncParameters(parameters);
+        }
+    }
+
+    private void process(HDUMessage hduMessage)
+    {
+        if(mCallSequence == null)
+        {
+            mCallSequence = new MBECallSequence(PROTOCOL);
+        }
+
+        HeaderData hd = hduMessage.getHeaderData();
+
+        if (hd.isEncryptedAudio())
+        {
+            mCallSequence.setEncrypted(true);
+            Phase2EncryptionSyncParameters esp = new Phase2EncryptionSyncParameters((EncryptionKeyIdentifier)hd.getEncryptionKey(), hd.getMessageIndicator());
+            mCallSequence.setEncryptionSyncParameters(esp);
         }
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P2CallSequenceRecorder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P2CallSequenceRecorder.java
@@ -27,6 +27,7 @@ import io.github.dsheirer.audio.codec.mbe.MBECallSequence;
 import io.github.dsheirer.audio.codec.mbe.MBECallSequenceRecorder;
 import io.github.dsheirer.bits.BinaryMessage;
 import io.github.dsheirer.message.IMessage;
+import io.github.dsheirer.module.decode.p25.phase2.message.EncryptionSynchronizationSequence;
 import io.github.dsheirer.module.decode.p25.phase2.message.P25P2Message;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacMessage;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacStructure;
@@ -152,6 +153,10 @@ public class P25P2CallSequenceRecorder extends MBECallSequenceRecorder
             else if(message instanceof MacMessage)
             {
                 process((MacMessage)message);
+            }
+            else if (message instanceof EncryptionSynchronizationSequence)
+            {
+                processEss((EncryptionSynchronizationSequence)message);
             }
         }
 
@@ -380,6 +385,19 @@ public class P25P2CallSequenceRecorder extends MBECallSequenceRecorder
             else
             {
                 mLog.warn("Expected push-to-talk structure but found: " + mac.getClass());
+            }
+        }
+
+        private void processEss(EncryptionSynchronizationSequence ess)
+        {
+            if(mCallSequence == null)
+            {
+                mCallSequence = new MBECallSequence(PROTOCOL);
+            }
+            if (ess.isEncrypted())
+            {
+                mCallSequence.setEncrypted(true);
+                mCallSequence.setEncryptionSyncParameters(ess);
             }
         }
     }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2MessageProcessor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2MessageProcessor.java
@@ -101,6 +101,23 @@ public class P25P2MessageProcessor implements Listener<IMessage>
                                 mFrequencyBandMap.put(bandIdentifier.getIdentifier(), bandIdentifier);
                             }
 
+                            switch(macMessage.getMacPduType())
+                            {
+                                case MAC_1_PTT:
+                                case MAC_2_END_PTT:
+                                case MAC_6_HANGTIME:
+                                case MAC_3_IDLE:
+                                    if (timeslot.getTimeslot() == 0)
+                                    {
+                                        mESSProcessor0.reset();
+                                    }
+                                    else
+                                    {
+                                        mESSProcessor1.reset();
+                                    }
+                                    break;
+                            }
+                            
                             mMessageListener.receive(macMessage);
                         }
                     }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2MessageProcessor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2MessageProcessor.java
@@ -123,6 +123,8 @@ public class P25P2MessageProcessor implements Listener<IMessage>
                     }
                     else if(timeslot instanceof AbstractVoiceTimeslot)
                     {
+                        mMessageListener.receive(timeslot);
+
                         if(timeslot.getTimeslot() == 0)
                         {
                             mESSProcessor0.process((AbstractVoiceTimeslot)timeslot);
@@ -155,8 +157,6 @@ public class P25P2MessageProcessor implements Listener<IMessage>
                                 mESSProcessor1.reset();
                             }
                         }
-
-                        mMessageListener.receive(timeslot);
 
                     }
                     else


### PR DESCRIPTION
- Enhanced resync of ESS processor
- Re-Order of AbstractVoiceTimeslot processing
- Updated P25 MBE recorders to include synchronized encryption information (mainly to verify this fix worked)

Resync:
When a channel goes from "Call->Hangtime->PTT->Call", the first call is not guaranteed to end on a Voice-2 (See TIA-102.BBAC, Figure D-5). When the second call initiates, the ESS processor does not always start on the first Voice-4. Updated to reset ESS processor on PTT, END_PTT, HANGTIME, and IDLE.

Re-Order:
On a Voice-2 slice, the computed ESS applies to the following Voice slices. Re-ordered so that the current Voice-2 is processed before the computed ESS is processed.