### PR TITLE
Inherit P25 Trunked Preferred Tuner To Traffic Channels

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -310,7 +310,9 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
                     SourceConfigTuner sourceConfig = new SourceConfigTuner();
                     sourceConfig.setFrequency(frequency);
                     if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+                    {
                         sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
+                    }
                     trafficChannel.setSourceConfiguration(sourceConfig);
                     mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 
@@ -359,7 +361,9 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
             SourceConfigTuner sourceConfig = new SourceConfigTuner();
             sourceConfig.setFrequency(frequency);
             if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+            {
                 sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
+            }
             trafficChannel.setSourceConfiguration(sourceConfig);
             mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 
@@ -460,7 +464,9 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
                     SourceConfigTuner sourceConfig = new SourceConfigTuner();
                     sourceConfig.setFrequency(frequency);
                     if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+                    {
                         sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
+                    }
                     trafficChannel.setSourceConfiguration(sourceConfig);
                     mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 
@@ -524,7 +530,9 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
             SourceConfigTuner sourceConfig = new SourceConfigTuner();
             sourceConfig.setFrequency(frequency);
             if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+            {
                 sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
+            }
             trafficChannel.setSourceConfiguration(sourceConfig);
             mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -309,6 +309,8 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
                     broadcast(event);
                     SourceConfigTuner sourceConfig = new SourceConfigTuner();
                     sourceConfig.setFrequency(frequency);
+                    if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+                        sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
                     trafficChannel.setSourceConfiguration(sourceConfig);
                     mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 
@@ -356,6 +358,8 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
 
             SourceConfigTuner sourceConfig = new SourceConfigTuner();
             sourceConfig.setFrequency(frequency);
+            if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+                sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
             trafficChannel.setSourceConfiguration(sourceConfig);
             mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 
@@ -455,6 +459,8 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
                     broadcast(event);
                     SourceConfigTuner sourceConfig = new SourceConfigTuner();
                     sourceConfig.setFrequency(frequency);
+                    if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+                        sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
                     trafficChannel.setSourceConfiguration(sourceConfig);
                     mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 
@@ -517,6 +523,8 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
 
             SourceConfigTuner sourceConfig = new SourceConfigTuner();
             sourceConfig.setFrequency(frequency);
+            if(mParentChannel.getSourceConfiguration() instanceof  SourceConfigTuner parentConfigTuner)
+                sourceConfig.setPreferredTuner(parentConfigTuner.getPreferredTuner());
             trafficChannel.setSourceConfiguration(sourceConfig);
             mAllocatedTrafficChannelMap.put(frequency, trafficChannel);
 


### PR DESCRIPTION
While monitoring a P25 Trunked system, the control channel will follow the preferred tuner conguration, however all of its traffic channels will not. They may use any Tuner.

The preferred tuner value is null for all the traffic channels, as they are not inherited from the parent.

TunerManaer received a null preferred tuner string value.

I manually set the preferred tuner from the parent in all references on the P25TrafficChannelManager class

This allows all voice channels associated with the P25 site to attempt to first use the preferred tuner.

Please test if this works


#1763 