### PR TITLE
Fix dB power meter heading

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/control/DbPowerMeter.java
+++ b/src/main/java/io/github/dsheirer/gui/control/DbPowerMeter.java
@@ -39,7 +39,7 @@ public class DbPowerMeter extends JComponent
      */
     public DbPowerMeter()
     {
-        setPreferredSize(new Dimension(80, 100));
+        setPreferredSize(new Dimension(90, 100));
         setBorder(BorderFactory.createTitledBorder("Power (dB)"));
     }
 


### PR DESCRIPTION
The power meter on the Channel tab is not wide enough to show the full 'Power (dB)' heading without truncation.

This PR increases the width of the power meter by 10 pixels