### PR TITLE
#1827 UI Thread Deadlock From USB Hotplug Support Callback

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/DiscoveredTunerModel.java
@@ -243,7 +243,7 @@ public class DiscoveredTunerModel extends AbstractTableModel implements Listener
                 }
                 else
                 {
-                    EventQueue.invokeAndWait(() ->
+                    EventQueue.invokeLater(() ->
                     {
                         try
                         {


### PR DESCRIPTION
Closes #1827

Resolves issue causing blank white screen when UI thread becomes dead-locked as the system tries to auto-remove a tuner that is in error state, while multiple channels are decoding and accessing the lock in the DiscoveredTunerModel.