### PR TITLE
#1834 CapMax Adv Mode Call Events With NO FREQUENCY

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
@@ -46,6 +46,7 @@ import io.github.dsheirer.module.decode.dmr.identifier.DMRTalkgroup;
 import io.github.dsheirer.module.decode.dmr.message.DMRMessage;
 import io.github.dsheirer.module.decode.dmr.message.data.DataMessage;
 import io.github.dsheirer.module.decode.dmr.message.data.csbk.CSBKMessage;
+import io.github.dsheirer.module.decode.dmr.message.data.csbk.UnknownCSBKMessage;
 import io.github.dsheirer.module.decode.dmr.message.data.csbk.hytera.HyteraTrafficChannelTalkerStatus;
 import io.github.dsheirer.module.decode.dmr.message.data.csbk.motorola.CapacityMaxAdvantageModeVoiceChannelUpdate;
 import io.github.dsheirer.module.decode.dmr.message.data.csbk.motorola.CapacityMaxAloha;
@@ -886,7 +887,12 @@ public class DMRDecoderState extends TimeslotDecoderState
                 }
                 else
                 {
-                    mLog.error("Unrecognized DMR channel grant CSBK ignored: " + csbk.getClass());
+                    //Log when a CSBK that is not the Unknown CSBK is processed, to detect when new opcodes are added
+                    //that are not ChannelGrant subclass implementations.
+                    if(!(csbk instanceof UnknownCSBKMessage))
+                    {
+                        mLog.error("Unrecognized DMR channel grant CSBK ignored: " + csbk.getClass());
+                    }
                 }
                 break;
             case MOTOROLA_CAPMAX_ALOHA:

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/csbk/motorola/CapacityMaxAdvantageModeVoiceChannelUpdate.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/csbk/motorola/CapacityMaxAdvantageModeVoiceChannelUpdate.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,7 +30,6 @@ import io.github.dsheirer.module.decode.dmr.identifier.DMRTalkgroup;
 import io.github.dsheirer.module.decode.dmr.message.CACH;
 import io.github.dsheirer.module.decode.dmr.message.data.SlotType;
 import io.github.dsheirer.module.decode.dmr.message.data.csbk.CSBKMessage;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -281,18 +280,19 @@ public class CapacityMaxAdvantageModeVoiceChannelUpdate extends CSBKMessage impl
     public int[] getLogicalChannelNumbers()
     {
         //Since both timeslots share the same LCN, we use just TS1's channel for both channel 1 and channel 2
-        if(hasChannel1Timeslot1() && hasChannel2Timeslot1())
+        if((hasChannel1Timeslot1() || hasChannel1Timeslot2()) && (hasChannel2Timeslot1() || hasChannel2Timeslot2()))
         {
             return new int[]{getChannel1TS1().getChannelId(), getChannel2TS1().getChannelId()};
         }
-        else if(hasChannel1Timeslot1())
+        else if((hasChannel1Timeslot1() || hasChannel1Timeslot2()))
         {
             return new int[]{getChannel1TS1().getChannelId()};
         }
-        else if(hasChannel2Timeslot1())
+        else if((hasChannel2Timeslot1() || hasChannel2Timeslot2()))
         {
             return new int[]{getChannel2TS1().getChannelId()};
         }
+
         return getChannel1TS1().getLogicalChannelNumbers();
     }
 


### PR DESCRIPTION
Resolved issue with CapMax Advantage mode producing call events with NO FREQUENY.  Updated the message to ensure all 4x timeslot channels get enriched wth frequency information.

Updated DMR decoder state to not log when an Unknown CSBK message containing a channel grant opcode gets processed.