### PR TITLE
#1837 Channel Stream Thread Naming

### DIFF
--- a/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
@@ -382,8 +382,10 @@ public class ChannelProcessingManager implements Listener<ChannelEvent>
 
         try
         {
+            String threadName = "sdrtrunk channel [" + channel.getChannelID() + "/" +
+                    channel.getDecodeConfiguration().getDecoderType().getShortDisplayString() + "]";
             source = mTunerManager.getSource(channel.getSourceConfiguration(),
-                channel.getDecodeConfiguration().getChannelSpecification());
+                channel.getDecodeConfiguration().getChannelSpecification(), threadName);
         }
         catch(SourceException se)
         {

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
@@ -189,9 +189,10 @@ public class PolyphaseChannelManager implements ISourceEventProcessor
      * Provides a Digital Drop Channel (DDC) for the specified tuner channel or returns null if the channel can't be
      * sourced due to the current center frequency and/or sample rate.
      * @param tunerChannel specifying center frequency and bandwidth.
+     * @param threadName for the channel's dispatcher
      * @return source or null.
      */
-    public TunerChannelSource getChannel(TunerChannel tunerChannel)
+    public TunerChannelSource getChannel(TunerChannel tunerChannel, String threadName)
     {
         PolyphaseChannelSource channelSource = null;
 
@@ -200,7 +201,7 @@ public class PolyphaseChannelManager implements ISourceEventProcessor
             try
             {
                 channelSource = new PolyphaseChannelSource(tunerChannel, mChannelCalculator, mFilterManager,
-                        mChannelSourceEventListener);
+                        mChannelSourceEventListener, threadName);
 
                 mChannelSources.add(channelSource);
             }

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelSource.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelSource.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,12 +56,14 @@ public class PolyphaseChannelSource extends TunerChannelSource implements Listen
      * @param channelCalculator for current channel center frequency and sample rate and index calculations
      * @param filterManager for access to new or cached synthesis filters
      * @param producerSourceEventListener to receive source event requests (e.g. start/stop sample stream)
+     * @param threadName for the channel's dispatcher
      * @throws IllegalArgumentException if a channel low pass filter can't be designed to the channel specification
      */
     public PolyphaseChannelSource(TunerChannel tunerChannel, ChannelCalculator channelCalculator, SynthesisFilterManager filterManager,
-                                  Listener<SourceEvent> producerSourceEventListener) throws IllegalArgumentException
+                                  Listener<SourceEvent> producerSourceEventListener, String threadName)
+            throws IllegalArgumentException
     {
-        super(producerSourceEventListener, tunerChannel);
+        super(producerSourceEventListener, tunerChannel, threadName);
         mChannelSampleRate = channelCalculator.getChannelSampleRate();
         doUpdateOutputProcessor(channelCalculator, filterManager);
     }
@@ -222,7 +224,7 @@ public class PolyphaseChannelSource extends TunerChannelSource implements Listen
             {
                 case 1:
                     mPolyphaseChannelOutputProcessor = new OneChannelOutputProcessor(channelCalculator.getChannelSampleRate(),
-                            indexes, channelCalculator.getChannelCount(), getHeartbeatManager());
+                            indexes, channelCalculator.getChannelCount(), getHeartbeatManager(), mThreadName);
                     mPolyphaseChannelOutputProcessor.setListener(this);
                     mPolyphaseChannelOutputProcessor.setFrequencyOffset(getFrequencyOffset());
                     mPolyphaseChannelOutputProcessor.start();
@@ -233,7 +235,7 @@ public class PolyphaseChannelSource extends TunerChannelSource implements Listen
                         float[] filter = filterManager.getFilter(channelCalculator.getChannelSampleRate(),
                                 channelCalculator.getChannelBandwidth(), 2);
                         mPolyphaseChannelOutputProcessor = new TwoChannelOutputProcessor(channelCalculator.getChannelSampleRate(),
-                                indexes, filter, channelCalculator.getChannelCount(), getHeartbeatManager());
+                                indexes, filter, channelCalculator.getChannelCount(), getHeartbeatManager(), mThreadName);
                         mPolyphaseChannelOutputProcessor.setListener(this);
                         mPolyphaseChannelOutputProcessor.setFrequencyOffset(getFrequencyOffset());
                         mPolyphaseChannelOutputProcessor.start();

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/ChannelOutputProcessor.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/ChannelOutputProcessor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,16 +41,15 @@ public abstract class ChannelOutputProcessor implements IPolyphaseChannelOutputP
      * oscillator support to apply frequency correction to the channel sample stream as requested by sample consumer.
      *
      * @param inputChannelCount is the number of input channels for this output processor
-     * @param sampleRate of the output channel.  This is used to match the oscillator's sample rate to the output
-     * channel sample rate for frequency translation/correction.
      * @param heartbeatManager to receive pings on the dispatcher thread
+     * @param threadName for the dispatcher
      */
-    public ChannelOutputProcessor(int inputChannelCount, double sampleRate, HeartbeatManager heartbeatManager)
+    public ChannelOutputProcessor(int inputChannelCount, HeartbeatManager heartbeatManager, String threadName)
     {
         mInputChannelCount = inputChannelCount;
         //Process 1/10th of the sample rate per second at a rate of 20 times a second (200% of anticipated rate)
         mHeartbeatManager = heartbeatManager;
-        mChannelResultsDispatcher = new Dispatcher("sdrtrunk polyphase channel",50, mHeartbeatManager);
+        mChannelResultsDispatcher = new Dispatcher(threadName,50, mHeartbeatManager);
         mChannelResultsDispatcher.setListener(floats -> {
             try
             {

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/OneChannelOutputProcessor.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/OneChannelOutputProcessor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,11 +38,12 @@ public class OneChannelOutputProcessor extends ChannelOutputProcessor
      * @param channelIndexes containing a single channel index.
      * @param gain value to apply.  This is typically the same as the channelizer's channel count.
      * @param heartbeatManager to receive heartbeats on the dispatch thread
+     * @param threadName to use for this processor
      */
     public OneChannelOutputProcessor(double sampleRate, List<Integer> channelIndexes, float gain,
-                                     HeartbeatManager heartbeatManager)
+                                     HeartbeatManager heartbeatManager, String threadName)
     {
-        super(1, sampleRate, heartbeatManager);
+        super(1, heartbeatManager, threadName);
         setPolyphaseChannelIndices(channelIndexes);
         mMixerAssembler = new OneChannelMixerAssembler(gain);
         mMixerAssembler.getMixer().setSampleRate(sampleRate);

--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/TwoChannelOutputProcessor.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/output/TwoChannelOutputProcessor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -37,15 +37,17 @@ public class TwoChannelOutputProcessor extends ChannelOutputProcessor
      *
      * @param sampleRate of the output sample stream.
      * @param channelIndexes containing two channel indices.
+     * @param filter to use
      * @param gain to apply to output.  Typically this is equal to the channelizer's channel count.
      * @param heartbeatManager to be pinged on the dispatcher thread
+     * @param threadName for the dispatcher
      */
     public TwoChannelOutputProcessor(double sampleRate, List<Integer> channelIndexes, float[] filter, float gain,
-                                     HeartbeatManager heartbeatManager)
+                                     HeartbeatManager heartbeatManager, String threadName)
     {
         //Set the frequency correction oscillator to 2 x output sample rate since we'll be correcting the frequency
         //after synthesizing both input channels
-        super(2, sampleRate, heartbeatManager);
+        super(2, heartbeatManager, threadName);
         setPolyphaseChannelIndices(channelIndexes);
         mMixerAssembler = new TwoChannelMixerAssembler(gain);
         mMixerAssembler.getMixer().setSampleRate(sampleRate);

--- a/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer.java
+++ b/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,6 +35,13 @@ import io.github.dsheirer.spectrum.ComplexDftProcessor;
 import io.github.dsheirer.spectrum.DFTSize;
 import io.github.dsheirer.spectrum.SpectrumPanel;
 import io.github.dsheirer.spectrum.converter.ComplexDecibelConverter;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import net.miginfocom.swing.MigLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,13 +54,6 @@ import javax.swing.JToggleButton;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import java.awt.Dimension;
-import java.awt.EventQueue;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class ChannelizerViewer extends JFrame
 {
@@ -262,7 +262,7 @@ public class ChannelizerViewer extends JFrame
             for(int x = 0; x < mChannelCount; x++)
             {
                 TunerChannel tunerChannel = new TunerChannel(100000000, 12500);
-                TunerChannelSource source = mTestTuner.getChannelSourceManager().getSource(tunerChannel, null);
+                TunerChannelSource source = mTestTuner.getChannelSourceManager().getSource(tunerChannel, null, "test");
                 DiscreteChannelPanel channelPanel = new DiscreteChannelPanel(mSettingsManager, source, x);
                 channelPanel.setDFTSize(mChannelPanelDFTSize);
 
@@ -362,7 +362,7 @@ public class ChannelizerViewer extends JFrame
             mComplexDecibelConverter.addListener(mSpectrumPanel);
 
             TunerChannel tunerChannel = new TunerChannel(frequency, bandwidth);
-            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel, null);
+            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel, null, "test");
 
             if(mSource != null)
             {
@@ -535,7 +535,7 @@ public class ChannelizerViewer extends JFrame
             {
                 if(sourceCount < maxSourceCount)
                 {
-                    TunerChannelSource source = tuner.getChannelSourceManager().getSource(tunerChannel, null);
+                    TunerChannelSource source = tuner.getChannelSourceManager().getSource(tunerChannel, null, "test");
 
                     if(source != null)
                     {

--- a/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer2.java
+++ b/src/main/java/io/github/dsheirer/gui/channelizer/ChannelizerViewer2.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -379,7 +379,8 @@ public class ChannelizerViewer2 extends JFrame
             mComplexDecibelConverter.addListener(mSpectrumPanel);
 
             TunerChannel tunerChannel = new TunerChannel(frequency, bandwidth);
-            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel, new ChannelSpecification(50000, 12500, 6000, 7000));
+            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel,
+                    new ChannelSpecification(50000, 12500, 6000, 7000), "test");
 
             if(mSource != null)
             {

--- a/src/main/java/io/github/dsheirer/gui/channelizer/HeterodyneChannelizerViewer.java
+++ b/src/main/java/io/github/dsheirer/gui/channelizer/HeterodyneChannelizerViewer.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,6 +36,13 @@ import io.github.dsheirer.spectrum.ComplexDftProcessor;
 import io.github.dsheirer.spectrum.DFTSize;
 import io.github.dsheirer.spectrum.SpectrumPanel;
 import io.github.dsheirer.spectrum.converter.ComplexDecibelConverter;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import net.miginfocom.swing.MigLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,13 +55,6 @@ import javax.swing.JToggleButton;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import java.awt.Dimension;
-import java.awt.EventQueue;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 public class HeterodyneChannelizerViewer extends JFrame
 {
@@ -261,7 +261,8 @@ public class HeterodyneChannelizerViewer extends JFrame
             for(int x = 0; x < mChannelCount; x++)
             {
                 TunerChannel tunerChannel = new TunerChannel(100000000, 12500);
-                TunerChannelSource source = mTestTuner.getChannelSourceManager().getSource(tunerChannel, channelSpecification);
+                TunerChannelSource source = mTestTuner.getChannelSourceManager().getSource(tunerChannel,
+                        channelSpecification, "test");
                 DiscreteChannelPanel channelPanel = new DiscreteChannelPanel(mSettingsManager, source, x);
                 channelPanel.setDFTSize(mChannelPanelDFTSize);
 
@@ -362,7 +363,7 @@ public class HeterodyneChannelizerViewer extends JFrame
 
             TunerChannel tunerChannel = new TunerChannel(frequency, bandwidth);
             ChannelSpecification channelSpecification = new ChannelSpecification(25000.0, 12500, 6000.0, 6250.0);
-            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel, channelSpecification);
+            mSource = mTestTuner.getChannelSourceManager().getSource(tunerChannel, channelSpecification, "test");
 
             if(mSource != null)
             {
@@ -533,7 +534,8 @@ public class HeterodyneChannelizerViewer extends JFrame
             {
                 if(sourceCount < maxSourceCount)
                 {
-                    TunerChannelSource source = tuner.getChannelSourceManager().getSource(tunerChannel, null);
+                    TunerChannelSource source = tuner.getChannelSourceManager().getSource(tunerChannel,
+                            null, "test");
 
                     if(source != null)
                     {

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/HalfBandTunerChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/HalfBandTunerChannelSource.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,13 +59,15 @@ public class HalfBandTunerChannelSource<T extends INativeBuffer> extends TunerCh
      * @param tunerChannel that details the desired channel frequency and bandwidth
      * @param sampleRate of the incoming sample stream
      * @param channelSpecification for the requested channel.
+     * @param threadName for the dispatcher
      * @throws FilterDesignException if a final cleanup filter cannot be designed using the remez filter
      *                               designer and the filter parameters.
      */
     public HalfBandTunerChannelSource(Listener<SourceEvent> producerSourceEventListener, TunerChannel tunerChannel,
-                                      double sampleRate, ChannelSpecification channelSpecification) throws FilterDesignException
+                                      double sampleRate, ChannelSpecification channelSpecification, String threadName)
+                                            throws FilterDesignException
     {
-        super(producerSourceEventListener, tunerChannel);
+        super(producerSourceEventListener, tunerChannel, threadName);
 
         int desiredDecimation = (int)(sampleRate / channelSpecification.getMinimumSampleRate());
         int decimation = DecimationFilterFactory.getDecimationRate(desiredDecimation);
@@ -74,7 +76,7 @@ public class HalfBandTunerChannelSource<T extends INativeBuffer> extends TunerCh
         mQDecimationFilter = DecimationFilterFactory.getRealDecimationFilter(decimation);
 
         //Set dispatcher to process 1/10 of estimated sample arrival rate, 20 times per second (up to 200% per interval)
-        mBufferDispatcher = new Dispatcher("sdrtrunk heterodyne channel " + tunerChannel.getFrequency(), 50, getHeartbeatManager());
+        mBufferDispatcher = new Dispatcher(threadName, 50, getHeartbeatManager());
         mBufferDispatcher.setListener(new NativeBufferProcessor());
 
         //Setup the frequency mixer to the current source frequency

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/MultiFrequencyTunerChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/MultiFrequencyTunerChannelSource.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,9 +60,9 @@ public class MultiFrequencyTunerChannelSource extends TunerChannelSource
 
     public MultiFrequencyTunerChannelSource(TunerManager tunerManager, TunerChannelSource tunerChannelSource,
                                             List<Long> frequencies, ChannelSpecification channelSpecification,
-                                            String preferredTuner)
+                                            String preferredTuner, String threadName)
     {
-        super(null, tunerChannelSource.getTunerChannel());
+        super(null, tunerChannelSource.getTunerChannel(), threadName);
         mTunerManager = tunerManager;
         mTunerChannelSource = tunerChannelSource;
         mTunerChannelSource.setSourceEventListener(mConsumerSourceEventAdapter);
@@ -114,7 +114,7 @@ public class MultiFrequencyTunerChannelSource extends TunerChannelSource
     {
         if(mStarted)
         {
-            Source source = mTunerManager.getSource(nextChannel, mChannelSpecification, mPreferredTuner);
+            Source source = mTunerManager.getSource(nextChannel, mChannelSpecification, mPreferredTuner, mThreadName);
 
             if(source instanceof TunerChannelSource)
             {

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/PassThroughChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/PassThroughChannelSource.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,14 +48,14 @@ public class PassThroughChannelSource extends TunerChannelSource implements ISou
      * @param listener to receive source events
      * @param tunerController that provides current sample rate
      * @param tunerChannel requested for this channel
+     * @param threadName for the dispatcher
      */
     public PassThroughChannelSource(Listener<SourceEvent> listener, TunerController tunerController,
-                                    TunerChannel tunerChannel)
+                                    TunerChannel tunerChannel, String threadName)
     {
-        super(listener, tunerChannel);
+        super(listener, tunerChannel, threadName);
         mTunerController = tunerController;
-        mBufferDispatcher = new Dispatcher<>("sdrtrunk pass-through channel " + tunerChannel.getFrequency(),
-                50, getHeartbeatManager());
+        mBufferDispatcher = new Dispatcher<>(threadName, 50, getHeartbeatManager());
         mBufferDispatcher.setListener(new BufferProcessor());
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/TunerChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/TunerChannelSource.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,6 +36,7 @@ public abstract class TunerChannelSource extends ComplexSource implements ISourc
     protected TunerChannel mTunerChannel;
     private Listener<SourceEvent> mProducerSourceEventListener;
     private Listener<SourceEvent> mConsumerSourceEventListener;
+    protected String mThreadName;
 
     /**
      * Tuner Channel Source is a Digital Drop Channel (DDC) abstract class that defines the minimum functionality
@@ -43,12 +44,15 @@ public abstract class TunerChannelSource extends ComplexSource implements ISourc
      *
      * @param producerSourceEventListener to receive source event requests (e.g. start/stop sample stream)
      * @param tunerChannel describing the desired channel frequency and bandwidth/minimum sample rate
+     * @param threadName for the channel's dispatcher
      */
-    public TunerChannelSource(Listener<SourceEvent> producerSourceEventListener, TunerChannel tunerChannel)
+    public TunerChannelSource(Listener<SourceEvent> producerSourceEventListener, TunerChannel tunerChannel,
+                              String threadName)
     {
         mProducerSourceEventListener = producerSourceEventListener;
         mTunerChannel = tunerChannel;
         mConsumerSourceEventListenerAdapter = new SourceEventListenerToProcessorAdapter(this);
+        mThreadName = threadName;
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/ChannelSourceManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -77,9 +77,11 @@ public abstract class ChannelSourceManager implements ISourceEventProcessor
      *
      * @param tunerChannel for requested source
      * @param channelSpecification for the requested channel
+     * @param threadName for the source thread pool
      * @return tuner channel source or null
      */
-    public abstract TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification);
+    public abstract TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification,
+                                                 String threadName);
 
     /**
      * Signals that the complex buffer provider has an error and can no long provider buffers.  The subclass should

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/HeterodyneChannelSourceManager.java
@@ -104,7 +104,8 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
     }
 
     @Override
-    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification)
+    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification,
+                                        String threadName)
     {
         if(!mRunning)
         {
@@ -122,7 +123,7 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
                 {
                     //Attempt to create the channel source first, in case we get a filter design exception
                     HalfBandTunerChannelSource tunerChannelSource = new HalfBandTunerChannelSource(mChannelSourceEventProcessor,
-                            tunerChannel, mTunerController.getSampleRate(), channelSpecification);
+                            tunerChannel, mTunerController.getSampleRate(), channelSpecification, threadName);
 
                     //Add to the list of channel sources so that it will receive the tuner frequency change
                     mChannelSources.add(tunerChannelSource);
@@ -227,7 +228,6 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
      */
     private void broadcastToChannels(SourceEvent sourceEvent)
     {
-//        for(CICTunerChannelSource channelSource : mChannelSources)
         for(HalfBandTunerChannelSource channelSource : mChannelSources)
         {
             try
@@ -248,7 +248,6 @@ public class HeterodyneChannelSourceManager extends ChannelSourceManager
      */
     private void updateTunerFrequency(long tunerFrequency)
     {
-//        for(CICTunerChannelSource channelSource : mChannelSources)
         for(HalfBandTunerChannelSource channelSource : mChannelSources)
         {
             channelSource.setFrequency(tunerFrequency);

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PassThroughSourceManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -93,7 +93,8 @@ public class PassThroughSourceManager extends ChannelSourceManager
     }
 
     @Override
-    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification)
+    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification,
+                                        String threadName)
     {
 
         if(!mRunning)
@@ -107,7 +108,7 @@ public class PassThroughSourceManager extends ChannelSourceManager
         {
             mTunerController.getFrequencyControllerLock().lock();
             PassThroughChannelSource channelSource = new PassThroughChannelSource(new SourceEventProxy(),
-                    mTunerController, tunerChannel);
+                    mTunerController, tunerChannel, threadName);
 
             mTunerChannels.add(tunerChannel);
             mTunerChannelSources.add(channelSource);

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/PolyphaseChannelSourceManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -421,10 +421,12 @@ public class PolyphaseChannelSourceManager extends ChannelSourceManager
      *
      * @param tunerChannel for requested source
      * @param channelSpecification for the requested channel
+     * @param threadName for the dispatcher
      * @return allocated DDC tuner channel source, or null if the channel cannot be provided by this source manager
      */
     @Override
-    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification)
+    public TunerChannelSource getSource(TunerChannel tunerChannel, ChannelSpecification channelSpecification,
+                                        String threadName)
     {
         TunerChannelSource tunerChannelSource = null;
 
@@ -455,7 +457,7 @@ public class PolyphaseChannelSourceManager extends ChannelSourceManager
                         }
 
                         //If we're successful to here, allocate the channel
-                        tunerChannelSource = mPolyphaseChannelManager.getChannel(tunerChannel);
+                        tunerChannelSource = mPolyphaseChannelManager.getChannel(tunerChannel, threadName);
                     }
                     catch(SourceException se)
                     {

--- a/src/main/java/io/github/dsheirer/util/Dispatcher.java
+++ b/src/main/java/io/github/dsheirer/util/Dispatcher.java
@@ -44,7 +44,7 @@ public class Dispatcher<E> implements Listener<E>
     private final LinkedTransferQueue<E> mQueue = new LinkedTransferQueue<>();
     private Listener<E> mListener;
     private final AtomicBoolean mRunning = new AtomicBoolean();
-    private final String mThreadName;
+    private String mThreadName;
     private ScheduledExecutorService mExecutorService;
     private ScheduledFuture<?> mScheduledFuture;
     private final long mInterval;
@@ -71,6 +71,15 @@ public class Dispatcher<E> implements Listener<E>
     {
         mThreadName = threadName;
         mInterval = interval;
+    }
+
+    /**
+     * Sets the thread name.  If this dispatcher is already started, this has no effect.
+     * @param threadName to use for this dispatcher.
+     */
+    public void setThreadName(String threadName)
+    {
+        mThreadName = threadName;
     }
 
     /**


### PR DESCRIPTION
Sets thread name for each channel stream dispatcher to include the channel configuration number, protocol, and frequency.

Closes #1837