### PR TITLE
#1839 DMR Tone Identifiers Don't Clear At Call End

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
@@ -1441,6 +1441,7 @@ public class DMRDecoderState extends TimeslotDecoderState
         }
 
         getIdentifierCollection().remove(IdentifierClass.USER, Form.TALKER_ALIAS, Role.FROM);
+        getIdentifierCollection().remove(IdentifierClass.USER, Form.TONE, Role.FROM);
     }
 
     @Override


### PR DESCRIPTION
Clears DMR tone identifiers from call metadata when the decoder state is reset at the end of the call.

Closes #1839