### PR TITLE
#172 Tuner Supports Adjusting Min/Max Frequencies

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/control/FrequencyTextField.java
+++ b/src/main/java/io/github/dsheirer/gui/control/FrequencyTextField.java
@@ -1,0 +1,192 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.control;
+
+import java.awt.EventQueue;
+import net.miginfocom.swing.MigLayout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.DocumentFilter;
+import javax.swing.text.PlainDocument;
+
+/**
+ * Swing text field control for entering frequency (MHz) values.
+ */
+public class FrequencyTextField extends JTextField
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(FrequencyTextField.class);
+    private static final String REGEX = "[1-9][0-9]{0,3}(\\.[0-9]{0,6})?";
+    private double mMinimum;
+    private double mMaximum;
+
+    /**
+     * Constructs an instance
+     *
+     * @param minimum allowable frequency value in Hertz
+     * @param maximum allowable frequency value in Hertz
+     * @param current frequency value in Hertz
+     */
+    public FrequencyTextField(long minimum, long maximum, long current)
+    {
+        super(8);
+        mMinimum = minimum / 1E6d;
+        mMaximum = maximum / 1E6d;
+
+        PlainDocument document = (PlainDocument)this.getDocument();
+        document.setDocumentFilter(new FrequencyFilter());
+        setFrequency(current);
+    }
+
+    /**
+     * Current frequency value
+     * @return frequency in Hertz
+     */
+    public long getFrequency()
+    {
+        String value = getText();
+
+        if(value == null || value.isEmpty())
+        {
+            return 0;
+        }
+
+        try
+        {
+            return (long)(Double.parseDouble(getText()) * 1E6d);
+        }
+        catch(Exception e)
+        {
+            LOGGER.error("Unable to parse frequency value from text [" + value + "] " + e.getLocalizedMessage());
+        }
+
+        return 0;
+    }
+
+    /**
+     * Sets the current frequency value
+     * @param frequency in Hertz
+     */
+    public void setFrequency(long frequency)
+    {
+        double frequencyMHz = frequency / 1E6d;
+
+        if(isValid(String.valueOf(frequencyMHz)))
+        {
+            setText(String.valueOf(frequencyMHz));
+        }
+        else
+        {
+            LOGGER.warn("Can't set frequency [" + frequency + "Hz / " + frequencyMHz + "MHz] with current minimum [" + mMinimum + "MHz] and maximum [" + mMaximum + "MHz] limits");
+        }
+    }
+
+    /**
+     * Indicates if the value is a valid double value that is between the minimum and maximum extents.
+     * @param value to test
+     * @return true if it is valid.
+     */
+    private boolean isValid(String value)
+    {
+        if(value == null || value.isEmpty())
+        {
+            return true;
+        }
+
+        if(value.matches(REGEX))
+        {
+            try
+            {
+                double frequency = Double.parseDouble(value);
+                return mMinimum <= frequency && frequency <= mMaximum;
+            }
+            catch(NumberFormatException e)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Input filter for user entered values.
+     */
+    class FrequencyFilter extends DocumentFilter
+    {
+        @Override
+        public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr) throws BadLocationException
+        {
+            Document doc = fb.getDocument();
+            StringBuilder sb = new StringBuilder();
+            sb.append(doc.getText(0, doc.getLength()));
+            sb.insert(offset, string);
+
+            if(isValid(sb.toString()))
+            {
+                super.insertString(fb, offset, string, attr);
+            }
+        }
+
+        @Override
+        public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs) throws BadLocationException
+        {
+            Document doc = fb.getDocument();
+            StringBuilder sb = new StringBuilder();
+            sb.append(doc.getText(0, doc.getLength()));
+            sb.replace(offset, offset + length, text);
+
+            if(isValid(sb.toString()))
+            {
+                super.replace(fb, offset, length, text, attrs);
+            }
+        }
+
+        @Override
+        public void remove(FilterBypass fb, int offset, int length) throws BadLocationException
+        {
+            Document doc = fb.getDocument();
+            StringBuilder sb = new StringBuilder();
+            sb.append(doc.getText(0, doc.getLength()));
+            sb.delete(offset, offset + length);
+
+            if(isValid(sb.toString()))
+            {
+                super.remove(fb, offset, length);
+            }
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        JFrame frame = new JFrame("Frequency Control Test");
+        frame.setSize(300, 200);
+        FrequencyTextField ftf = new FrequencyTextField(20, 2_000_000_000, 101_100_000);
+        frame.setLayout(new MigLayout());
+        frame.add(ftf);
+
+        EventQueue.invokeLater(() -> frame.setVisible(true));
+    }
+}

--- a/src/main/java/io/github/dsheirer/gui/control/JFrequencyControl.java
+++ b/src/main/java/io/github/dsheirer/gui/control/JFrequencyControl.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -434,8 +434,7 @@ public class JFrequencyControl extends JPanel implements ISourceEventProcessor
 
                     if(se instanceof InvalidFrequencyException ife)
                     {
-                        JOptionPane.showMessageDialog(this, "Frequency [" + ife.getInvalidFrequency() +
-                            "] exceeds the frequency limit [" + ife.getValidFrequency() + "] for this tuner.");
+                        JOptionPane.showMessageDialog(this, ife.getMessage() + " for this tuner.");
                     }
                 }
             }

--- a/src/main/java/io/github/dsheirer/gui/control/LongFormatter.java
+++ b/src/main/java/io/github/dsheirer/gui/control/LongFormatter.java
@@ -21,38 +21,43 @@ package io.github.dsheirer.gui.control;
 
 import java.util.function.UnaryOperator;
 import javafx.scene.control.TextFormatter;
-import javafx.util.converter.IntegerStringConverter;
+import javafx.util.converter.LongStringConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Text formatter for integer values that constrains values to specified minimum and maximum valid values.
+ * Text formatter for long values that constrains values to specified minimum and maximum valid values.
  */
-public class IntegerFormatter extends TextFormatter<Integer>
+public class LongFormatter extends TextFormatter<Long>
 {
-    private static final Logger mLog = LoggerFactory.getLogger(IntegerFormatter.class);
+    private static final Logger mLog = LoggerFactory.getLogger(LongFormatter.class);
 
     /**
      * Constructs an instance
      * @param minimum allowed value
      * @param maximum allowed value
      */
-    public IntegerFormatter(int minimum, int maximum)
+    public LongFormatter(int minimum, int maximum)
     {
-        super(new IntegerStringConverter(), null, new IntegerFilter(minimum, maximum));
+        super(new LongStringConverter(), null, new LongFilter(minimum, maximum));
     }
 
     /**
      * Formatted text change filter that only allows hexadecimal characters where the converted decimal value
      * is also constrained within minimum and maximum valid values.
      */
-    public static class IntegerFilter implements UnaryOperator<Change>
+    public static class LongFilter implements UnaryOperator<Change>
     {
         private String DECIMAL_REGEX = "\\-?[0-9].*";
         private int mMinimum;
         private int mMaximum;
 
-        public IntegerFilter(int minimum, int maximum)
+        /**
+         * Constructs an instance
+         * @param minimum value
+         * @param maximum value
+         */
+        public LongFilter(int minimum, int maximum)
         {
             mMinimum = minimum;
             mMaximum = maximum;
@@ -70,7 +75,7 @@ public class IntegerFormatter extends TextFormatter<Integer>
 
             try
             {
-                int parsed = Integer.parseInt(value);
+                long parsed = Long.parseLong(value);
                 return mMinimum <= parsed && parsed <= mMaximum;
             }
             catch(Exception e)

--- a/src/main/java/io/github/dsheirer/source/InvalidFrequencyException.java
+++ b/src/main/java/io/github/dsheirer/source/InvalidFrequencyException.java
@@ -1,6 +1,6 @@
-/*******************************************************************************
- * sdrtrunk
- * Copyright (C) 2014-2016 Dennis Sheirer
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,8 +14,8 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *
- ******************************************************************************/
+ * ****************************************************************************
+ */
 package io.github.dsheirer.source;
 
 public class InvalidFrequencyException extends SourceException
@@ -53,12 +53,5 @@ public class InvalidFrequencyException extends SourceException
     public long getValidFrequency()
     {
         return mValidFrequency;
-    }
-
-    @Override
-    public String getMessage()
-    {
-        return super.getMessage() + " Invalid Frequency: " + getInvalidFrequency() +
-            " - current valid frequency:" + getValidFrequency();
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,6 +38,7 @@ public class AirspyTunerConfiguration extends TunerConfiguration
      */
     public AirspyTunerConfiguration()
     {
+        super(AirspyTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ, AirspyTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerController.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,8 +59,8 @@ public class AirspyTunerController extends USBTunerController
     public static final int IF_GAIN_MIN = 0;
     public static final int IF_GAIN_MAX = 15;
     public static final int IF_GAIN_DEFAULT = 9;
-    public static final long FREQUENCY_MIN = 24000000l;
-    public static final long FREQUENCY_MAX = 1800000000l;
+    public static final long MINIMUM_TUNABLE_FREQUENCY_HZ = 24000000l;
+    public static final long MAXIMUM_TUNABLE_FREQUENCY_HZ = 1800000000l;
     public static final long FREQUENCY_DEFAULT = 101100000;
     public static final double USABLE_BANDWIDTH_PERCENT = 0.90;
     private static final long USB_TIMEOUT_MS = 2000l; //milliseconds
@@ -82,7 +82,7 @@ public class AirspyTunerController extends USBTunerController
      */
     public AirspyTunerController(int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(bus, portAddress, FREQUENCY_MIN, FREQUENCY_MAX, 0, USABLE_BANDWIDTH_PERCENT, tunerErrorListener);
+        super(bus, portAddress, MINIMUM_TUNABLE_FREQUENCY_HZ, MAXIMUM_TUNABLE_FREQUENCY_HZ, 0, USABLE_BANDWIDTH_PERCENT, tunerErrorListener);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class AirspyTunerController extends USBTunerController
     @Override
     public synchronized void setTunedFrequency(long frequency) throws SourceException
     {
-        if(FREQUENCY_MIN <= frequency && frequency <= FREQUENCY_MAX)
+        if(MINIMUM_TUNABLE_FREQUENCY_HZ <= frequency && frequency <= MAXIMUM_TUNABLE_FREQUENCY_HZ)
         {
             ByteBuffer buffer = ByteBuffer.allocateDirect(4);
             buffer.order(ByteOrder.LITTLE_ENDIAN);
@@ -252,7 +252,7 @@ public class AirspyTunerController extends USBTunerController
         }
         else
         {
-            throw new SourceException("Frequency [" + frequency + "] outside " + "of tunable range " + FREQUENCY_MIN + "-" + FREQUENCY_MAX);
+            throw new SourceException("Frequency [" + frequency + "] outside " + "of tunable range " + MINIMUM_TUNABLE_FREQUENCY_HZ + "-" + MAXIMUM_TUNABLE_FREQUENCY_HZ);
         }
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/AirspyTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -78,6 +78,18 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
         super(userPreferences, tunerManager, discoveredTuner);
         init();
         tunerStatusUpdated();
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return AirspyTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return AirspyTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override
@@ -472,6 +484,10 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
                         try
                         {
                             getTuner().getController().setSampleRate(rate);
+
+                            //Adjust the min/max values for the sample rate.
+                            adjustForSampleRate(rate.getRate());
+
                             save();
                         }
                         catch(Exception e1)
@@ -578,6 +594,8 @@ public class AirspyTunerEditor extends TunerEditor<AirspyTuner, AirspyTunerConfi
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/hf/AirspyHfTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/hf/AirspyHfTunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,6 +38,7 @@ public class AirspyHfTunerConfiguration extends TunerConfiguration
      */
     public AirspyHfTunerConfiguration()
     {
+        super(AirspyHfTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ, AirspyHfTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/hf/AirspyHfTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/hf/AirspyHfTunerController.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,8 +46,8 @@ public class AirspyHfTunerController extends USBTunerController
     private static final AirspyHfSampleRate DEFAULT_SAMPLE_RATE = new AirspyHfSampleRate(0, 768_000, false);
     private static final long IF_SHIFT_LIF = 0;
     private static final long IF_SHIFT_ZIF = 5_000;
-    private static final long MINIMUM_FREQUENCY_HZ = 500_000;
-    private static final long MAXIMUM_FREQUENCY_HZ = 260_000_000;
+    public static final long MINIMUM_TUNABLE_FREQUENCY_HZ = 500_000;
+    public static final long MAXIMUM_TUNABLE_FREQUENCY_HZ = 260_000_000;
     private static final byte REQUEST_TYPE_IN = LibUsb.ENDPOINT_IN | LibUsb.REQUEST_TYPE_VENDOR | LibUsb.RECIPIENT_DEVICE;
     private static final byte REQUEST_TYPE_OUT = LibUsb.ENDPOINT_OUT | LibUsb.REQUEST_TYPE_VENDOR | LibUsb.RECIPIENT_DEVICE;
     private static final int BUFFER_SAMPLE_COUNT = 1024;
@@ -75,8 +75,8 @@ public class AirspyHfTunerController extends USBTunerController
     public AirspyHfTunerController(int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
         super(bus, portAddress, tunerErrorListener);
-        setMinimumFrequency(MINIMUM_FREQUENCY_HZ);
-        setMaximumFrequency(MAXIMUM_FREQUENCY_HZ);
+        setMinimumFrequency(MINIMUM_TUNABLE_FREQUENCY_HZ);
+        setMaximumFrequency(MAXIMUM_TUNABLE_FREQUENCY_HZ);
         setUsableBandwidthPercentage(.9); //90% usable after filter rolloff
         setMiddleUnusableHalfBandwidth(3000);
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/airspy/hf/AirspyHfTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/airspy/hf/AirspyHfTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -62,6 +62,18 @@ public class AirspyHfTunerEditor extends TunerEditor<AirspyHfTuner,AirspyHfTuner
         tunerStatusUpdated();
     }
 
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return AirspyHfTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return AirspyHfTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
     private void init()
     {
         setLayout(new MigLayout("fill,wrap 3", "[right][grow,fill][fill]",
@@ -102,6 +114,8 @@ public class AirspyHfTunerEditor extends TunerEditor<AirspyHfTuner,AirspyHfTuner
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -216,6 +230,10 @@ public class AirspyHfTunerEditor extends TunerEditor<AirspyHfTuner,AirspyHfTuner
                         try
                         {
                             getTuner().getController().setSampleRate(sampleRate);
+
+                            //Adjust the min/max values for the sample rate.
+                            adjustForSampleRate(sampleRate.getSampleRate());
+
                             save();
                         }
                         catch(SourceException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/configuration/TunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/configuration/TunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,16 +56,21 @@ import io.github.dsheirer.source.tuner.sdrplay.RspTunerConfiguration;
 @JacksonXmlRootElement(localName = "tuner_configuration")
 public abstract class TunerConfiguration
 {
+    public static final long DEFAULT_FREQUENCY = 101_100_000;
     private String mUniqueID;
-    private long mFrequency = 101100000;
+    private long mFrequency = DEFAULT_FREQUENCY;
+    private long mMinimumFrequency;
+    private long mMaximumFrequency;
     private double mFrequencyCorrection = 0.0d;
     private boolean mAutoPPMCorrection = true;
 
     /**
      * Default constructor to support Jackson
      */
-    public TunerConfiguration()
+    public TunerConfiguration(long minimumFrequency, long maximumFrequency)
     {
+        mMinimumFrequency = minimumFrequency;
+        mMaximumFrequency = maximumFrequency;
     }
 
     /**
@@ -123,7 +128,7 @@ public abstract class TunerConfiguration
     /**
      * Indicates if automatic correction of PPM from measured frequency error is enabled/disabled.
      *
-     * @return true if auto-correction is enabled.
+     * @return true if autocorrection is enabled.
      */
     @JacksonXmlProperty(isAttribute = true, localName = "auto_ppm_correction_enabled")
     public boolean getAutoPPMCorrectionEnabled()
@@ -139,5 +144,43 @@ public abstract class TunerConfiguration
     public void setAutoPPMCorrectionEnabled(boolean enabled)
     {
         mAutoPPMCorrection = enabled;
+    }
+
+    /**
+     * Minimum tunable frequency.
+     * @return minimum frequency
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "min_frequency")
+    public long getMinimumFrequency()
+    {
+        return mMinimumFrequency;
+    }
+
+    /**
+     * Sets the minimum tunable frequency
+     * @param minimumFrequency to set
+     */
+    public void setMinimumFrequency(long minimumFrequency)
+    {
+        mMinimumFrequency = minimumFrequency;
+    }
+
+    /**
+     * Maximum tunable frequency.
+     * @return maximum frequency
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "max_frequency")
+    public long getMaximumFrequency()
+    {
+        return mMaximumFrequency;
+    }
+
+    /**
+     * Sets the maximum tunable frequency
+     * @param maximumFrequency to set
+     */
+    public void setMaximumFrequency(long maximumFrequency)
+    {
+        mMaximumFrequency = maximumFrequency;
     }
 }

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,6 +41,7 @@ public class FCD1TunerConfiguration extends TunerConfiguration
      */
     public FCD1TunerConfiguration()
     {
+        super(FCD1TunerController.MINIMUM_TUNABLE_FREQUENCY_HZ, FCD1TunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     public FCD1TunerConfiguration(String uniqueID)

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerController.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,14 +26,14 @@ import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
 import io.github.dsheirer.source.tuner.fcd.FCDCommand;
 import io.github.dsheirer.source.tuner.fcd.FCDTunerController;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sound.sampled.TargetDataLine;
 import javax.usb.UsbClaimException;
 import javax.usb.UsbException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Funcube Dongle Pro tuner controller.  Combines USB HID control with Audio Mixer data streaming interface.
@@ -41,8 +41,8 @@ import java.nio.ByteOrder;
 public class FCD1TunerController extends FCDTunerController
 {
     private final static Logger mLog = LoggerFactory.getLogger(FCD1TunerController.class);
-    public static final int MINIMUM_TUNABLE_FREQUENCY = 64000000;
-    public static final int MAXIMUM_TUNABLE_FREQUENCY = 1700000000;
+    public static final int MINIMUM_TUNABLE_FREQUENCY_HZ = 64000000;
+    public static final int MAXIMUM_TUNABLE_FREQUENCY_HZ = 1700000000;
     public static final int SAMPLE_RATE = 96000;
     private double mDCCorrectionInPhase = 0.0;
     private double mDCCorrectionQuadrature = 0.0;
@@ -61,8 +61,8 @@ public class FCD1TunerController extends FCDTunerController
      */
     public FCD1TunerController(TargetDataLine mixerTDL, int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(MixerTunerType.FUNCUBE_DONGLE_PRO, mixerTDL, bus, portAddress, MINIMUM_TUNABLE_FREQUENCY,
-                MAXIMUM_TUNABLE_FREQUENCY, tunerErrorListener);
+        super(MixerTunerType.FUNCUBE_DONGLE_PRO, mixerTDL, bus, portAddress, MINIMUM_TUNABLE_FREQUENCY_HZ,
+                MAXIMUM_TUNABLE_FREQUENCY_HZ, tunerErrorListener);
     }
 
     protected void deviceStart() throws SourceException

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proV1/FCD1TunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -78,6 +78,18 @@ public class FCD1TunerEditor extends TunerEditor<FCDTuner,FCD1TunerConfiguration
         }
 
         return null;
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return FCD1TunerController.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return FCD1TunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override
@@ -366,6 +378,8 @@ public class FCD1TunerEditor extends TunerEditor<FCDTuner,FCD1TunerConfiguration
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,6 +33,7 @@ public class FCD2TunerConfiguration extends TunerConfiguration
      */
     public FCD2TunerConfiguration()
     {
+        super(FCD2TunerController.MINIMUM_TUNABLE_FREQUENCY_HZ, FCD2TunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     @JsonIgnore

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerController.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,12 +26,12 @@ import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
 import io.github.dsheirer.source.tuner.fcd.FCDCommand;
 import io.github.dsheirer.source.tuner.fcd.FCDTunerController;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sound.sampled.TargetDataLine;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Funcube Dongle Pro Plus tuner controller.  Combines USB HID control with Audio Mixer for data streaming.
@@ -40,8 +40,8 @@ public class FCD2TunerController extends FCDTunerController
 {
     private final static Logger mLog = LoggerFactory.getLogger(FCD2TunerController.class);
 
-    public static final int MINIMUM_TUNABLE_FREQUENCY = 150000;
-    public static final int MAXIMUM_TUNABLE_FREQUENCY = 2050000000;
+    public static final int MINIMUM_TUNABLE_FREQUENCY_HZ = 150000;
+    public static final int MAXIMUM_TUNABLE_FREQUENCY_HZ = 2050000000;
     public static final int SAMPLE_RATE = 192000;
 
     /**
@@ -53,8 +53,8 @@ public class FCD2TunerController extends FCDTunerController
      */
     public FCD2TunerController(TargetDataLine mixerTDL, int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS, mixerTDL, bus, portAddress, MINIMUM_TUNABLE_FREQUENCY,
-                MAXIMUM_TUNABLE_FREQUENCY, tunerErrorListener);
+        super(MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS, mixerTDL, bus, portAddress, MINIMUM_TUNABLE_FREQUENCY_HZ,
+                MAXIMUM_TUNABLE_FREQUENCY_HZ, tunerErrorListener);
     }
 
     protected void deviceStart() throws SourceException

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/proplusV2/FCD2TunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -67,6 +67,18 @@ public class FCD2TunerEditor extends TunerEditor<FCDTuner, FCD2TunerConfiguratio
         }
 
         return null;
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return FCD2TunerController.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return FCD2TunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override
@@ -236,6 +248,8 @@ public class FCD2TunerEditor extends TunerEditor<FCDTuner, FCD2TunerConfiguratio
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());

--- a/src/main/java/io/github/dsheirer/source/tuner/frequency/FrequencyController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/frequency/FrequencyController.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -182,21 +182,20 @@ public class FrequencyController
      */
     private void setFrequency(long frequency, boolean broadcastChange) throws SourceException
     {
-        long tunedFrequency = getTunedFrequency(frequency);
-
-        if(tunedFrequency < mMinimumFrequency)
+        if(frequency < mMinimumFrequency)
         {
-            throw new InvalidFrequencyException("Requested frequency not valid", frequency, mMinimumFrequency);
+            throw new InvalidFrequencyException("Frequency [" + frequency + "] is below the minimum [" +
+                    mMinimumFrequency + "]", frequency, mMinimumFrequency);
         }
 
-        if(tunedFrequency > mMaximumFrequency)
+        if(frequency > mMaximumFrequency)
         {
-            throw new InvalidFrequencyException("Requested frequency not valid", frequency, mMaximumFrequency);
+            throw new InvalidFrequencyException("Frequency [" + frequency + "] is above the maximum [" +
+                    mMaximumFrequency + "]", frequency, mMaximumFrequency);
         }
 
         mFrequency = frequency;
-
-        mTunedFrequency = tunedFrequency;
+        mTunedFrequency = getTunedFrequency(frequency);
 
         if(mTunable != null)
         {
@@ -230,7 +229,7 @@ public class FrequencyController
      */
     public void setMinimumFrequency(long minimum)
     {
-        mMaximumFrequency = minimum;
+        mMinimumFrequency = minimum;
     }
 
     /**
@@ -252,15 +251,12 @@ public class FrequencyController
     }
 
     /**
-     * Calculate the tuned frequency by adding frequency correction to the
-     * corrected frequency.
-     *
+     * Calculate the tuned frequency by adding frequency correction to the corrected frequency.
      * @param correctedFrequency
      */
     private long getTunedFrequency(long correctedFrequency)
     {
-        return (long)((double)correctedFrequency /
-            (1.0 + (mFrequencyCorrection / 1000000.0)));
+        return (long)((double)correctedFrequency / (1.0 + (mFrequencyCorrection / 1000000.0)));
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,6 +39,7 @@ public class HackRFTunerConfiguration extends TunerConfiguration
      */
     public HackRFTunerConfiguration()
     {
+        super(HackRFTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ, HackRFTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     public HackRFTunerConfiguration(String uniqueID)

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerController.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,8 +47,8 @@ public class HackRFTunerController extends USBTunerController
     public static final byte REQUEST_TYPE_IN = (byte)(LibUsb.ENDPOINT_IN | LibUsb.REQUEST_TYPE_VENDOR | LibUsb.RECIPIENT_DEVICE);
     public static final byte REQUEST_TYPE_OUT = (byte)(LibUsb.ENDPOINT_OUT | LibUsb.REQUEST_TYPE_VENDOR | LibUsb.RECIPIENT_DEVICE);
 
-    public static final long MINIMUM_TUNABLE_FREQUENCY = 10000000l;
-    public static final long MAXIMUM_TUNABLE_FREQUENCY = 6000000000l;
+    public static final long MINIMUM_TUNABLE_FREQUENCY_HZ = 10000000l;
+    public static final long MAXIMUM_TUNABLE_FREQUENCY_HZ = 6000000000l;
     public static final long DEFAULT_FREQUENCY = 101100000;
     public static final double USABLE_BANDWIDTH = 0.90;
     public static final int DC_HALF_BANDWIDTH = 5000;
@@ -64,7 +64,7 @@ public class HackRFTunerController extends USBTunerController
      */
     public HackRFTunerController(int bus, String portAddress, ITunerErrorListener tunerErrorListener)
     {
-        super(bus, portAddress, MINIMUM_TUNABLE_FREQUENCY, MAXIMUM_TUNABLE_FREQUENCY, DC_HALF_BANDWIDTH, USABLE_BANDWIDTH,
+        super(bus, portAddress, MINIMUM_TUNABLE_FREQUENCY_HZ, MAXIMUM_TUNABLE_FREQUENCY_HZ, DC_HALF_BANDWIDTH, USABLE_BANDWIDTH,
                 tunerErrorListener);
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/hackrf/HackRFTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -63,6 +63,18 @@ public class HackRFTunerEditor extends TunerEditor<HackRFTuner,HackRFTunerConfig
         super(userPreferences, tunerManager, discoveredTuner);
         init();
         tunerStatusUpdated();
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return HackRFTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return HackRFTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     private void init()
@@ -258,6 +270,8 @@ public class HackRFTunerEditor extends TunerEditor<HackRFTuner,HackRFTunerConfig
                     try
                     {
                         getTuner().getController().setSampleRate(sampleRate);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate(sampleRate.getRate());
                         save();
                     }
                     catch(SourceException | UsbException e2)
@@ -400,6 +414,8 @@ public class HackRFTunerEditor extends TunerEditor<HackRFTuner,HackRFTunerConfig
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredTuner.java
@@ -215,7 +215,7 @@ public abstract class DiscoveredTuner implements ITunerErrorListener
             catch(SourceException se)
             {
                 mLog.error("Error applying tuner configuration [" + mTunerConfiguration.getClass() +
-                        "] to discovered tuner [" + getId() + "}");
+                        "] to discovered tuner [" + getId() + "}", se);
             }
         }
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,6 +39,7 @@ public class RecordingTunerConfiguration extends TunerConfiguration
      */
     public RecordingTunerConfiguration()
     {
+        super(0, Long.MAX_VALUE);
     }
 
     /**
@@ -47,6 +48,7 @@ public class RecordingTunerConfiguration extends TunerConfiguration
      */
     public RecordingTunerConfiguration(String uniqueId)
     {
+        this();
         setUniqueID(uniqueId);
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/recording/RecordingTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,6 +55,18 @@ public class RecordingTunerEditor extends TunerEditor<RecordingTuner,RecordingTu
     public void setTunerLockState(boolean locked)
     {
         getFrequencyPanel().updateControls();
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return Long.MAX_VALUE;
     }
 
     @Override
@@ -125,6 +137,8 @@ public class RecordingTunerEditor extends TunerEditor<RecordingTuner,RecordingTu
         {
             RecordingTunerConfiguration config = getConfiguration();
             config.setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             saveConfiguration();
         }
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,9 +46,12 @@ public abstract class RTL2832TunerConfiguration extends TunerConfiguration
 
     /**
      * Default constructor to support Jackson
+     * @param minimumFrequency tunable
+     * @param maximumFrequency tunable
      */
-    public RTL2832TunerConfiguration()
+    public RTL2832TunerConfiguration(long minimumFrequency, long maximumFrequency)
     {
+        super(minimumFrequency, maximumFrequency);
     }
 
     public RTL2832TunerConfiguration(String uniqueID)

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832UnknownTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832UnknownTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ package io.github.dsheirer.source.tuner.rtl;
 import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.source.tuner.manager.DiscoveredTuner;
 import io.github.dsheirer.source.tuner.manager.TunerManager;
+import io.github.dsheirer.source.tuner.rtl.r8x.R8xEmbeddedTuner;
 import io.github.dsheirer.source.tuner.ui.TunerEditor;
 import net.miginfocom.swing.MigLayout;
 
@@ -63,13 +64,20 @@ public class RTL2832UnknownTunerEditor extends TunerEditor<RTL2832Tuner, RTL2832
 
         add(new JSeparator(), "span,growx,push");
 
-//        add(new JLabel("Frequency (MHz):"));
-//        add(getFrequencyPanel(), "wrap");
-//
-//        add(new JLabel("Sample Rate:"));
-////        add(getSampleRateCombo(), "wrap");
-//
-//        add(new JSeparator(), "span,growx,push");
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        //Bogus value.
+        return R8xEmbeddedTuner.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        //Bogus value.
+        return R8xEmbeddedTuner.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KEmbeddedTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KEmbeddedTuner.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,13 +23,13 @@ import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.configuration.TunerConfiguration;
 import io.github.dsheirer.source.tuner.rtl.EmbeddedTuner;
 import io.github.dsheirer.source.tuner.rtl.RTL2832TunerController;
+import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.usb4java.LibUsb;
 import org.usb4java.LibUsbException;
 
 import javax.usb.UsbException;
-import java.util.EnumSet;
 
 /**
  * Elonic E4000 Tuner
@@ -38,8 +38,8 @@ public class E4KEmbeddedTuner extends EmbeddedTuner
 {
     private final static Logger mLog = LoggerFactory.getLogger(E4KEmbeddedTuner.class);
 
-    public static final long MINIMUM_SUPPORTED_FREQUENCY = 52000000;
-    public static final long MAXIMUM_SUPPORTED_FREQUENCY = 2200000000l;
+    public static final long MINIMUM_TUNABLE_FREQUENCY_HZ = 52000000;
+    public static final long MAXIMUM_TUNABLE_FREQUENCY_HZ = 2200000000l;
     public static final double USABLE_BANDWIDTH_PERCENT = 0.95;
     public static final int DC_SPIKE_AVOID_BUFFER = 15000;
 
@@ -99,13 +99,13 @@ public class E4KEmbeddedTuner extends EmbeddedTuner
     @Override
     public long getMinimumFrequencySupported()
     {
-        return MINIMUM_SUPPORTED_FREQUENCY;
+        return MINIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override
     public long getMaximumFrequencySupported()
     {
-        return MAXIMUM_SUPPORTED_FREQUENCY;
+        return MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override
@@ -1039,7 +1039,7 @@ public class E4KEmbeddedTuner extends EmbeddedTuner
         NO_FILTER(0, 0, 0),
 
         //VHF-II Filters (0.0 - 140.0) Optimal (64-108)
-        LP268(0, MINIMUM_SUPPORTED_FREQUENCY, 86_000_000),  //Values 0 - 7 are all the same
+        LP268(0, MINIMUM_TUNABLE_FREQUENCY_HZ, 86_000_000),  //Values 0 - 7 are all the same
         LP299(8, 86_000_000, 140_000_000), //Values 8 - 15 are all the same
 
         //VHF-III Filters (140.0 - 350.0) Optimal (170-240)
@@ -1080,7 +1080,7 @@ public class E4KEmbeddedTuner extends EmbeddedTuner
         BP1680(12, 1670000000, 1690000000),
         BP1700(13, 1690000000, 1710000000),
         BP1720(14, 1710000000, 1735000000),
-        BP1750(15, 1735000000, MAXIMUM_SUPPORTED_FREQUENCY);
+        BP1750(15, 1735000000, MAXIMUM_TUNABLE_FREQUENCY_HZ);
 
         private int mValue;
         private long mMinFrequency;

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ public class E4KTunerConfiguration extends RTL2832TunerConfiguration
      */
     public E4KTunerConfiguration()
     {
+        super(E4KEmbeddedTuner.MINIMUM_TUNABLE_FREQUENCY_HZ, E4KEmbeddedTuner.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     @JsonIgnore

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,6 +71,18 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         super(userPreferences, tunerManager, discoveredTuner);
         init();
         tunerStatusUpdated();
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return E4KEmbeddedTuner.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return E4KEmbeddedTuner.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     /**
@@ -373,6 +385,8 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
                     try
                     {
                         getTuner().getController().setSampleRate(sampleRate);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate(sampleRate.getRate());
                         save();
                     }
                     catch(SourceException | LibUsbException eSampleRate)
@@ -485,6 +499,8 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         {
             E4KTunerConfiguration config = getConfiguration();
             config.setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel)getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             config.setFrequencyCorrection(value);
             config.setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013EmbeddedTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013EmbeddedTuner.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -61,8 +61,8 @@ public class FC0013EmbeddedTuner extends EmbeddedTuner
 {
     private final static Logger mLog = LoggerFactory.getLogger(FC0013EmbeddedTuner.class);
     private DecimalFormat FREQUENCY_FORMAT = new DecimalFormat("0.000000");
-    private static final long MINIMUM_SUPPORTED_FREQUENCY = 13_500_000;
-    private static final long MAXIMUM_SUPPORTED_FREQUENCY = 1_907_999_890l;
+    public static final long MINIMUM_TUNABLE_FREQUENCY_HZ = 13_500_000;
+    public static final long MAXIMUM_TUNABLE_FREQUENCY_HZ = 1_907_999_890l;
     private static final double USABLE_BANDWIDTH_PERCENT = 0.95;
     private static final int DC_SPIKE_AVOID_BUFFER = 15000;
     //Hardware I2C address
@@ -74,7 +74,7 @@ public class FC0013EmbeddedTuner extends EmbeddedTuner
     private static byte[] REGISTERS = {(byte) 0x00, (byte) 0x09, (byte) 0x16, (byte) 0x00, (byte) 0x00, (byte) 0x17,
             (byte) 0x02, (byte) 0x2A, (byte) 0xFF, (byte) 0x6E, (byte) 0xB8, (byte) 0x82, (byte) 0xFE, (byte) 0x01,
             (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x50, (byte) 0x01};
-    private long mTunedFrequency = MINIMUM_SUPPORTED_FREQUENCY;
+    private long mTunedFrequency = MINIMUM_TUNABLE_FREQUENCY_HZ;
 
     /**
      * Constructs an instance
@@ -95,13 +95,13 @@ public class FC0013EmbeddedTuner extends EmbeddedTuner
     @Override
     public long getMinimumFrequencySupported()
     {
-        return MINIMUM_SUPPORTED_FREQUENCY;
+        return MINIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override
     public long getMaximumFrequencySupported()
     {
-        return MAXIMUM_SUPPORTED_FREQUENCY;
+        return MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013TunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013TunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,6 +36,7 @@ public class FC0013TunerConfiguration extends RTL2832TunerConfiguration
      */
     public FC0013TunerConfiguration()
     {
+        super(FC0013EmbeddedTuner.MINIMUM_TUNABLE_FREQUENCY_HZ, FC0013EmbeddedTuner.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     @JsonIgnore

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013TunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,6 +66,18 @@ public class FC0013TunerEditor extends TunerEditor<RTL2832Tuner, FC0013TunerConf
         super(userPreferences, tunerManager, discoveredTuner);
         init();
         tunerStatusUpdated();
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return FC0013EmbeddedTuner.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return FC0013EmbeddedTuner.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     /**
@@ -263,6 +275,8 @@ public class FC0013TunerEditor extends TunerEditor<RTL2832Tuner, FC0013TunerConf
                     try
                     {
                         getTuner().getController().setSampleRate(sampleRate);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate(sampleRate.getRate());
                         save();
                     }
                     catch(SourceException | LibUsbException eSampleRate)
@@ -390,6 +404,8 @@ public class FC0013TunerEditor extends TunerEditor<RTL2832Tuner, FC0013TunerConf
             FC0013TunerConfiguration config = getConfiguration();
             config.setBiasT(getTuner().getController().isBiasT());
             config.setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel)getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             config.setFrequencyCorrection(value);
             config.setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xEmbeddedTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xEmbeddedTuner.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,8 +38,8 @@ public abstract class R8xEmbeddedTuner extends EmbeddedTuner
     public static final byte[] BIT_REV_LOOKUP_TABLE = {(byte) 0x0, (byte) 0x8, (byte) 0x4, (byte) 0xC, (byte) 0x2,
             (byte) 0xA, (byte) 0x6, (byte) 0xE, (byte) 0x1, (byte) 0x9, (byte) 0x5, (byte) 0xD, (byte) 0x3, (byte) 0xB,
             (byte) 0x7, (byte) 0xF};
-    private static final long MINIMUM_SUPPORTED_FREQUENCY = 3180000;
-    private static final long MAXIMUM_SUPPORTED_FREQUENCY = 1782030000;
+    public static final long MINIMUM_TUNABLE_FREQUENCY_HZ = 3180000;
+    public static final long MAXIMUM_TUNABLE_FREQUENCY_HZ = 1782030000;
     private static final double USABLE_BANDWIDTH_PERCENT = 0.98;
     private static final int DC_SPIKE_AVOID_BUFFER = 5000;
     private static final byte VERSION = (byte) 49;
@@ -147,13 +147,13 @@ public abstract class R8xEmbeddedTuner extends EmbeddedTuner
     @Override
     public long getMinimumFrequencySupported()
     {
-        return MINIMUM_SUPPORTED_FREQUENCY;
+        return MINIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override
     public long getMaximumFrequencySupported()
     {
-        return MAXIMUM_SUPPORTED_FREQUENCY;
+        return MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,6 +36,7 @@ public abstract class R8xTunerConfiguration extends RTL2832TunerConfiguration
      */
     public R8xTunerConfiguration()
     {
+        super(R8xEmbeddedTuner.MINIMUM_TUNABLE_FREQUENCY_HZ, R8xEmbeddedTuner.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -67,6 +67,18 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
         super(userPreferences, tunerManager, discoveredTuner);
         init();
         tunerStatusUpdated();
+    }
+
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return R8xEmbeddedTuner.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return R8xEmbeddedTuner.MAXIMUM_TUNABLE_FREQUENCY_HZ;
     }
 
     /**
@@ -329,6 +341,8 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
                     try
                     {
                         getTuner().getController().setSampleRate(sampleRate);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate(sampleRate.getRate());
                         save();
                     }
                     catch(SourceException | LibUsbException eSampleRate)
@@ -521,6 +535,8 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
             R8xTunerConfiguration config = getConfiguration();
             config.setBiasT(getTuner().getController().isBiasT());
             config.setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel)getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             config.setFrequencyCorrection(value);
             config.setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerConfiguration.java
@@ -60,6 +60,7 @@ public abstract class RspTunerConfiguration extends TunerConfiguration
      */
     public RspTunerConfiguration()
     {
+        super(RspTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ, RspTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ);
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerController.java
@@ -45,8 +45,8 @@ public abstract class RspTunerController<I extends IControlRsp> extends TunerCon
         implements IDeviceEventListener, IStreamListener
 {
     private static final Logger mLog = LoggerFactory.getLogger(RspTunerController.class);
-    protected static final long MINIMUM_FREQUENCY = 100_000;
-    protected static final long MAXIMUM_FREQUENCY = 2_000_000_000;
+    protected static final long MINIMUM_TUNABLE_FREQUENCY_HZ = 100_000;
+    protected static final long MAXIMUM_TUNABLE_FREQUENCY_HZ = 2_000_000_000;
     protected static final int MIDDLE_UNUSABLE_BANDWIDTH = 0;
     private I mControlRsp;
     private RspNativeBufferFactory mNativeBufferFactory = new RspNativeBufferFactory(RspSampleRate.RATE_8_000);
@@ -66,8 +66,8 @@ public abstract class RspTunerController<I extends IControlRsp> extends TunerCon
         //Register this controller to receive device events and sample streams when startStream() is invoked.
         mControlRsp.resister(this, this);
 
-        setMinimumFrequency(MINIMUM_FREQUENCY);
-        setMaximumFrequency(MAXIMUM_FREQUENCY);
+        setMinimumFrequency(MINIMUM_TUNABLE_FREQUENCY_HZ);
+        setMaximumFrequency(MAXIMUM_TUNABLE_FREQUENCY_HZ);
         setMiddleUnusableHalfBandwidth(MIDDLE_UNUSABLE_BANDWIDTH);
         setUsableBandwidthPercentage(1.0); //Initial value
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerEditor.java
@@ -73,6 +73,18 @@ public abstract class RspTunerEditor<C extends RspTunerConfiguration> extends Tu
         return (RspTunerController) getTuner().getTunerController();
     }
 
+    @Override
+    public long getMinimumTunableFrequency()
+    {
+        return RspTunerController.MINIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
+    @Override
+    public long getMaximumTunableFrequency()
+    {
+        return RspTunerController.MAXIMUM_TUNABLE_FREQUENCY_HZ;
+    }
+
     /**
      * Gain controls panel
      * @return gain panel

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1/Rsp1TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1/Rsp1TunerEditor.java
@@ -156,6 +156,8 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -186,6 +188,8 @@ public class Rsp1TunerEditor extends RspTunerEditor<Rsp1TunerConfiguration>
                     try
                     {
                         getTunerController().setSampleRate(selected);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate((int)selected.getSampleRate());
                         save();
                     }
                     catch(SDRPlayException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1a/Rsp1aTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1a/Rsp1aTunerEditor.java
@@ -197,6 +197,8 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -230,6 +232,8 @@ public class Rsp1aTunerEditor extends RspTunerEditor<Rsp1aTunerConfiguration>
                     try
                     {
                         getTunerController().setSampleRate(selected);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate((int)selected.getSampleRate());
                         save();
                     }
                     catch(SDRPlayException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1b/Rsp1bTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp1b/Rsp1bTunerEditor.java
@@ -196,6 +196,8 @@ public class Rsp1bTunerEditor extends RspTunerEditor<Rsp1bTunerConfiguration>
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -229,6 +231,8 @@ public class Rsp1bTunerEditor extends RspTunerEditor<Rsp1bTunerConfiguration>
                     try
                     {
                         getTunerController().setSampleRate(selected);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate((int)selected.getSampleRate());
                         save();
                     }
                     catch(SDRPlayException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
@@ -211,6 +211,8 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -244,6 +246,8 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
                     try
                     {
                         getTunerController().setSampleRate(selected);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate((int)selected.getSampleRate());
                         save();
                     }
                     catch(SDRPlayException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner1Editor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner1Editor.java
@@ -239,6 +239,8 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -296,6 +298,8 @@ public class RspDuoTuner1Editor extends RspTunerEditor<RspDuoTuner1Configuration
                     try
                     {
                         getTunerController().setSampleRate(selected);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate((int)selected.getSampleRate());
                         save();
                     }
                     catch(SDRPlayException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner2Editor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDuo/RspDuoTuner2Editor.java
@@ -246,6 +246,8 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -308,6 +310,8 @@ public class RspDuoTuner2Editor extends RspTunerEditor<RspDuoTuner2Configuration
                     try
                     {
                         getTunerController().setSampleRate(selected);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate((int)selected.getSampleRate());
                         save();
                     }
                     catch(SDRPlayException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDx/RspDxTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rspDx/RspDxTunerEditor.java
@@ -230,6 +230,8 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
         if(hasConfiguration() && !isLoading())
         {
             getConfiguration().setFrequency(getFrequencyControl().getFrequency());
+            getConfiguration().setMinimumFrequency(getMinimumFrequencyTextField().getFrequency());
+            getConfiguration().setMaximumFrequency(getMaximumFrequencyTextField().getFrequency());
             double value = ((SpinnerNumberModel) getFrequencyCorrectionSpinner().getModel()).getNumber().doubleValue();
             getConfiguration().setFrequencyCorrection(value);
             getConfiguration().setAutoPPMCorrectionEnabled(getAutoPPMCheckBox().isSelected());
@@ -265,6 +267,8 @@ public class RspDxTunerEditor extends RspTunerEditor<RspDxTunerConfiguration>
                     try
                     {
                         getTunerController().setSampleRate(selected);
+                        //Adjust the min/max values for the sample rate.
+                        adjustForSampleRate((int)selected.getSampleRate());
                         save();
                     }
                     catch(SDRPlayException se)


### PR DESCRIPTION
Enhances tuner editors to allow users to specify minimum and maximum frequency values to more accurately control tuner behavior.

Closes #172