### PR TITLE
#1856 DMR Channel - Threading Deadlock

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRTrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRTrafficChannelManager.java
@@ -805,7 +805,7 @@ public class DMRTrafficChannelManager extends TrafficChannelManager implements I
          * @param channelEvent to process
          */
         @Override
-        public synchronized void receive(ChannelEvent channelEvent)
+        public void receive(ChannelEvent channelEvent)
         {
             Channel channel = channelEvent.getChannel();
 


### PR DESCRIPTION
Resolves issue in DMR traffic channel manager that allowed a threading dead-lock to occur.  Removes synchronized method access since this method is already protected by the reentrant lock.