### PR TITLE
#1899 Radio Reference API V18 & Update Site Editor To Show TDMA CC Sites

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
-import java.text.SimpleDateFormat
-
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +16,10 @@ import java.text.SimpleDateFormat
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  * ****************************************************************************
  */
+
+import java.text.SimpleDateFormat
+
+
 
 /**
  * Instructions for building/compiling the sdrtrunk application.
@@ -103,7 +105,7 @@ dependencies {
     implementation 'com.mpatric:mp3agic:0.9.1'
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'eu.hansolo:charts:1.0.5'
-    implementation 'io.github.dsheirer:radio-reference-api:15.1.9'
+    implementation 'io.github.dsheirer:radio-reference-api:18.0.0'
     implementation 'javax.usb:usb-api:1.0.2'
     implementation 'net.coderazzi:tablefilter-swing:5.5.4'
     implementation 'org.apache.commons:commons-compress:1.21'

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/EnrichedSite.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/EnrichedSite.java
@@ -149,7 +149,7 @@ public class EnrichedSite implements Comparable<EnrichedSite>
     {
         if(mSite != null)
         {
-            return mSite.getDescription();
+            return mSite.getDescription() + (mSite.getTdmaControlChannel() > 0 ? " (TDMA CC)" : "");
         }
 
         return null;

--- a/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SiteEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/radioreference/SiteEditor.java
@@ -379,7 +379,8 @@ public class SiteEditor extends GridPane
                     getP25ControlLabel().setVisible(true);
                     getTdmaControlToggleButton().setVisible(true);
                     getFdmaControlToggleButton().setVisible(true);
-                    if(site.getSite().getModulation() != null && site.getSite().getModulation().contains(PHASE_2_TDMA_MODULATION))
+
+                    if(site.getSite().getTdmaControlChannel() > 0) //Value is 0 for FDMA or 1 for TDMA
                     {
                         getTdmaControlToggleButton().setSelected(true);
                     }


### PR DESCRIPTION
Closes #1899 

Uses radio reference API version 18 and updates site editor to use new 'tdma_cc' flag to distinguish P25 Phase 2 FDMA vs TDMA control channel sites.
