### PR TITLE
#1916 SDRPlay API 3.15 and RSPdxR2 support.

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
@@ -162,6 +162,7 @@ public class TunerFactory
                 tuners.add(new DiscoveredRsp2Tuner(deviceInfo, channelizerType));
                 break;
             case RSPdx:
+            case RSPdxR2:
                 tuners.add(new DiscoveredRspDxTuner(deviceInfo, channelizerType));
                 break;
             case RSPduo:
@@ -255,6 +256,7 @@ public class TunerFactory
                     }
                     break;
                 case RSPdx:
+                case RSPdxR2:
                     if(device instanceof RspDxDevice rspDxDevice)
                     {
                         IControlRspDx controlRspDx = new ControlRspDx(rspDxDevice);
@@ -476,6 +478,7 @@ public class TunerFactory
                         case RSP2:
                             return new Rsp2TunerEditor(userPreferences, tunerManager, discoveredRspTuner);
                         case RSPdx:
+                        case RSPdxR2:
                             return new RspDxTunerEditor(userPreferences, tunerManager, discoveredRspTuner);
                         case RSPduo:
                             if(discoveredRspTuner instanceof DiscoveredRspDuoTuner1 duoTuner1)

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/Version.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/Version.java
@@ -35,7 +35,8 @@ public enum Version
     V3_11(3.11f, true),
     V3_12(3.12f, true),
     V3_13(3.13f, true), //No changes - OSX build only.
-    V3_14(3.14f, true);
+    V3_14(3.14f, true),
+    V3_15(3.15f, true);
 
     private float mValue;
     private boolean mSupported;
@@ -57,6 +58,7 @@ public enum Version
 
     /**
      * Indicates if this version is greater than or equal to the specified version.
+     *
      * @param version to compare
      * @return true if this version is greater than or equal to
      */
@@ -75,13 +77,14 @@ public enum Version
 
     /**
      * Lookup the version from the specified value.
+     *
      * @param value to lookup
      * @return version or UNKNOWN
      */
     public static Version fromValue(float value)
     {
 
-        for(Version version: values())
+        for(Version version : values())
         {
             if(version.mValue == value)
             {

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/device/DeviceFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/device/DeviceFactory.java
@@ -134,7 +134,7 @@ public class DeviceFactory
             case RSPduo -> {
                 return new RspDuoDevice(sdrPlay, deviceStruct);
             }
-            case RSPdx -> {
+            case RSPdx, RSPdxR2 -> {
                 return new RspDxDevice(sdrPlay, deviceStruct);
             }
             default -> {

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/device/DeviceType.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/device/DeviceType.java
@@ -19,7 +19,7 @@
 
 package io.github.dsheirer.source.tuner.sdrplay.api.device;
 
-import io.github.dsheirer.source.tuner.sdrplay.api.v3_07.sdrplay_api_h;
+import io.github.dsheirer.source.tuner.sdrplay.api.v3_14.sdrplay_api_h;
 
 /**
  * RSP Device type
@@ -28,10 +28,11 @@ public enum DeviceType
 {
     RSP1(sdrplay_api_h.SDRPLAY_RSP1_ID(), "RSP1"),
     RSP1A(sdrplay_api_h.SDRPLAY_RSP1A_ID(), "RSP1A"),
-    RSP1B(io.github.dsheirer.source.tuner.sdrplay.api.v3_14.sdrplay_api_h.SDRPLAY_RSP1B_ID(), "RSP1B"),
+    RSP1B(sdrplay_api_h.SDRPLAY_RSP1B_ID(), "RSP1B"),
     RSP2(sdrplay_api_h.SDRPLAY_RSP2_ID(), "RSP2"),
     RSPduo(sdrplay_api_h.SDRPLAY_RSPduo_ID(), "RSPduo"),
     RSPdx(sdrplay_api_h.SDRPLAY_RSPdx_ID(), "RSPdx"),
+    RSPdxR2(sdrplay_api_h.SDRPLAY_RSPdx_R2_ID(), "RSPdxR2"),
     UNKNOWN(Integer.MIN_VALUE, "UNKNOWN");
 
     private int mValue;

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/composite/CompositeParametersFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/composite/CompositeParametersFactory.java
@@ -57,7 +57,7 @@ public class CompositeParametersFactory
             case RSPduo -> {
                 return new RspDuoCompositeParameters(version, memorySegment, arena);
             }
-            case RSPdx -> {
+            case RSPdx, RSPdxR2 -> {
                 return new RspDxCompositeParameters(version, memorySegment, arena);
             }
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/device/DeviceParametersFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/device/DeviceParametersFactory.java
@@ -50,7 +50,7 @@ public class DeviceParametersFactory
             case RSPduo -> {
                 return new RspDuoDeviceParameters(memorySegment);
             }
-            case RSPdx -> {
+            case RSPdx, RSPdxR2 -> {
                 return new RspDxDeviceParameters(memorySegment);
             }
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/tuner/TunerParametersFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/parameter/tuner/TunerParametersFactory.java
@@ -69,7 +69,7 @@ public class TunerParametersFactory
                     throw new IllegalArgumentException("Unrecognized API version: " + version);
                 }
             }
-            case RSPdx -> {
+            case RSPdx, RSPdxR2 -> {
                 MemorySegment rspDxMemorySegment = sdrplay_api_RxChannelParamsT.rspDxTunerParams$slice(memorySegment);
                 return new RspDxTunerParameters(memorySegment, rspDxMemorySegment);
             }

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/v3_14/sdrplay_api_h.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/v3_14/sdrplay_api_h.java
@@ -1719,6 +1719,17 @@ public class sdrplay_api_h  {
     public static int SDRPLAY_RSP1B_ID() {
         return (int)6L;
     }
+
+    //Note: RSPdx_R2 manually edited for API version 3.15
+
+    /**
+     * {@snippet :
+     * #define SDRPLAY_RSPdx_R2_ID 7
+     * }
+     */
+    public static int SDRPLAY_RSPdx_R2_ID() {
+        return (int)7L;
+    }
 }
 
 


### PR DESCRIPTION
Updates SDRPlay to support API version 3.15 and the new RSPdxR2 tuner.

Note: R2 tuner support (re)uses the existing RSPdx base classes.