### PR TITLE
#1926 Toolkit not initialized error when running headless during APCO…

### DIFF
--- a/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
+++ b/src/main/java/io/github/dsheirer/controller/channel/ChannelProcessingManager.java
@@ -395,7 +395,10 @@ public class ChannelProcessingManager implements Listener<ChannelEvent>
         if(source == null)
         {
             //This has to be done on the FX event thread when the playlist editor is constructed
-            Platform.runLater(() -> channel.setProcessing(false));
+            if(!GraphicsEnvironment.isHeadless())
+            {
+                Platform.runLater(() -> channel.setProcessing(false));
+            }
 
             mChannelEventBroadcaster.broadcast(new ChannelEvent(channel,
                 ChannelEvent.Event.NOTIFICATION_PROCESSING_START_REJECTED, TUNER_UNAVAILABLE_DESCRIPTION));


### PR DESCRIPTION
Closes #1926 
Toolkit not initialized error when running headless during APCO25 channel start processing request.
