### PR TITLE
#1912 P25 Patch Group Details Missing In Now Playing and Streaming/Recording Metadata

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -2218,7 +2218,6 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
     public void start()
     {
         super.start();
-        mPatchGroupManager.clear();
 
         //Change the default (45-second) traffic channel timeout to 1 second
         if(mChannel.isTrafficChannel())
@@ -2230,12 +2229,5 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
     @Override
     public void init()
     {
-    }
-
-    @Override
-    public void stop()
-    {
-        super.stop();
-        mPatchGroupManager.clear();
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
@@ -1959,7 +1959,6 @@ public class P25P2DecoderState extends TimeslotDecoderState implements Identifie
     public void start()
     {
         super.start();
-        mPatchGroupManager.clear();
 
         //Change the default (45-second) traffic channel timeout to 1 second
         if(mChannel.isTrafficChannel())
@@ -1971,12 +1970,5 @@ public class P25P2DecoderState extends TimeslotDecoderState implements Identifie
     @Override
     public void init()
     {
-    }
-
-    @Override
-    public void stop()
-    {
-        super.stop();
-        mPatchGroupManager.clear();
     }
 }


### PR DESCRIPTION
Closes #1912 

P25 Patch Group details (ie the patched talkgroups or patched radios) no longer missing from Now Playing and recording and streaming metadata.
