### PR TITLE
#1960 Application Root Directory  Not Found On Fresh Install

### DIFF
--- a/src/main/java/io/github/dsheirer/properties/SystemProperties.java
+++ b/src/main/java/io/github/dsheirer/properties/SystemProperties.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -125,12 +125,24 @@ public class SystemProperties
 
         if(root.equalsIgnoreCase(DEFAULT_APP_ROOT))
         {
-            retVal = Paths.get(
-                System.getProperty("user.home"), DEFAULT_APP_ROOT);
+            retVal = Paths.get(System.getProperty("user.home"), DEFAULT_APP_ROOT);
         }
         else
         {
             retVal = Paths.get(root);
+        }
+
+        if(!Files.exists(retVal))
+        {
+            try
+            {
+                mLog.info("Creating application root folder: " + retVal);
+                Files.createDirectory(retVal);
+            }
+            catch(IOException e)
+            {
+                mLog.error("Error creating sdrtrunk application root folder", e);
+            }
         }
 
         return retVal;


### PR DESCRIPTION
Closes #1960.

Creates the application root folder (SDRTrunk) when it doesn't exist or on a fresh install.