### PR TITLE
#1974 P25 Unassigned Fully Qualified Talkgroup/Radio Value Handling

### DIFF
--- a/src/main/java/io/github/dsheirer/identifier/radio/FullyQualifiedRadioIdentifier.java
+++ b/src/main/java/io/github/dsheirer/identifier/radio/FullyQualifiedRadioIdentifier.java
@@ -41,7 +41,7 @@ public abstract class FullyQualifiedRadioIdentifier extends RadioIdentifier
      */
     public FullyQualifiedRadioIdentifier(int localAddress, int wacn, int system, int id, Role role)
     {
-        super(localAddress > 0 ? localAddress : id, role);
+        super(localAddress, role);
         mWacn = wacn;
         mSystem = system;
         mRadio = id;
@@ -91,5 +91,24 @@ public abstract class FullyQualifiedRadioIdentifier extends RadioIdentifier
         {
             return getFullyQualifiedRadioAddress();
         }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        //Attempt to match as a fully qualified radio match first
+        if(o instanceof FullyQualifiedRadioIdentifier fqri)
+        {
+            return getWacn() == fqri.getWacn() &&
+                    getSystem() == fqri.getSystem() &&
+                    getRadio() == fqri.getRadio();
+        }
+        //Attempt to match the local address against a simple radio version
+        else if(o instanceof RadioIdentifier ri)
+        {
+            return getValue() != 0 && ri.getValue() != 0 && getValue().equals(ri.getValue());
+        }
+
+        return super.equals(o);
     }
 }

--- a/src/main/java/io/github/dsheirer/identifier/talkgroup/FullyQualifiedTalkgroupIdentifier.java
+++ b/src/main/java/io/github/dsheirer/identifier/talkgroup/FullyQualifiedTalkgroupIdentifier.java
@@ -40,7 +40,7 @@ public abstract class FullyQualifiedTalkgroupIdentifier extends TalkgroupIdentif
      */
     public FullyQualifiedTalkgroupIdentifier(int localAddress, int wacn, int system, int id, Role role)
     {
-        super(localAddress > 0 ? localAddress : id, role);
+        super(localAddress, role);
         mWacn = wacn;
         mSystem = system;
         mTalkgroup = id;
@@ -90,5 +90,24 @@ public abstract class FullyQualifiedTalkgroupIdentifier extends TalkgroupIdentif
         {
             return getFullyQualifiedTalkgroupAddress();
         }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        //Attempt to match as a fully qualified talkgroup match first
+        if(o instanceof FullyQualifiedTalkgroupIdentifier fqti)
+        {
+            return getWacn() == fqti.getWacn() &&
+                    getSystem() == fqti.getSystem() &&
+                    getTalkgroup() == fqti.getTalkgroup();
+        }
+        //Attempt to match the local address against a simple talkgroup version
+        else if(o instanceof TalkgroupIdentifier ti)
+        {
+            return getValue() != 0 && ti.getValue() != 0 && getValue().equals(ti.getValue());
+        }
+
+        return super.equals(o);
     }
 }


### PR DESCRIPTION
#1974 P25 Fully Qualified Talkgroup/Radio values shouldn't replace the local ID/address when the value is zero with the fully qualified ID, because this causes incorrect aliasing.