### PR TITLE
#1939 Duplicate Call Detector Enhancements & Unit Tests

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/encryption/APCO25EncryptionKey.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/encryption/APCO25EncryptionKey.java
@@ -1,23 +1,20 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 package io.github.dsheirer.module.decode.p25.identifier.encryption;
 
@@ -74,5 +71,13 @@ public class APCO25EncryptionKey extends EncryptionKey
     public static APCO25EncryptionKey create(int algorithm, int keyId)
     {
         return new APCO25EncryptionKey(algorithm, keyId);
+    }
+
+    /**
+     * Creates a new APCO-25 encryption algorithm
+     */
+    public static APCO25EncryptionKey create(Encryption encryption, int keyId)
+    {
+        return create(encryption.getValue(), keyId);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/reference/Encryption.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/reference/Encryption.java
@@ -78,6 +78,20 @@ public enum Encryption
         return mLabel;
     }
 
+    /**
+     * Encryption type value.
+     * @return value.
+     */
+    public int getValue()
+    {
+        return mValue;
+    }
+
+    /**
+     * Utility method to lookup the encryption type from the value.
+     * @param value of the encryption type.
+     * @return enumeration entry or UNKNOWN.
+     */
     public static Encryption fromValue(int value)
     {
         switch(value)

--- a/src/main/java/io/github/dsheirer/preference/duplicate/CallManagementPreference.java
+++ b/src/main/java/io/github/dsheirer/preference/duplicate/CallManagementPreference.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * User preferences for call management
  */
-public class CallManagementPreference extends Preference
+public class CallManagementPreference extends Preference implements ICallManagementProvider
 {
     private static final String PREFERENCE_KEY_DETECT_DUPLICATE_TALKGROUP = "duplicate.call.detect.talkgroup";
     private static final String PREFERENCE_KEY_DETECT_DUPLICATE_RADIO = "duplicate.call.detect.radio";

--- a/src/main/java/io/github/dsheirer/preference/duplicate/ICallManagementProvider.java
+++ b/src/main/java/io/github/dsheirer/preference/duplicate/ICallManagementProvider.java
@@ -1,0 +1,30 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.preference.duplicate;
+
+/**
+ * Interface for a call management value provider.
+ */
+public interface ICallManagementProvider
+{
+    boolean isDuplicateCallDetectionEnabled();
+    boolean isDuplicateCallDetectionByTalkgroupEnabled();
+    boolean isDuplicateCallDetectionByRadioEnabled();
+}

--- a/src/main/java/io/github/dsheirer/preference/duplicate/TestCallManagementProvider.java
+++ b/src/main/java/io/github/dsheirer/preference/duplicate/TestCallManagementProvider.java
@@ -1,0 +1,58 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.preference.duplicate;
+
+/**
+ * Test implementation of duplicate call detection preferences.
+ */
+public class TestCallManagementProvider implements ICallManagementProvider
+{
+    private final boolean mByTalkgroup;
+    private final boolean mByRadio;
+
+    /**
+     * Constructs an instance
+     * @param byTalkgroup to enable duplicate detection by talkgroup
+     * @param byRadio to enable duplicate detection by radio
+     */
+    public TestCallManagementProvider(boolean byTalkgroup, boolean byRadio)
+    {
+        mByTalkgroup = byTalkgroup;
+        mByRadio = byRadio;
+    }
+
+    @Override
+    public boolean isDuplicateCallDetectionEnabled()
+    {
+        return mByTalkgroup || mByRadio;
+    }
+
+    @Override
+    public boolean isDuplicateCallDetectionByTalkgroupEnabled()
+    {
+        return mByTalkgroup;
+    }
+
+    @Override
+    public boolean isDuplicateCallDetectionByRadioEnabled()
+    {
+        return mByRadio;
+    }
+}

--- a/src/test/java/io/github/dsheirer/audio/DuplicateCallDetectionTest.java
+++ b/src/test/java/io/github/dsheirer/audio/DuplicateCallDetectionTest.java
@@ -1,0 +1,217 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.audio;
+
+import io.github.dsheirer.alias.AliasList;
+import io.github.dsheirer.identifier.configuration.SiteConfigurationIdentifier;
+import io.github.dsheirer.identifier.configuration.SystemConfigurationIdentifier;
+import io.github.dsheirer.identifier.encryption.EncryptionKeyIdentifier;
+import io.github.dsheirer.module.decode.p25.identifier.encryption.APCO25EncryptionKey;
+import io.github.dsheirer.module.decode.p25.identifier.radio.APCO25RadioIdentifier;
+import io.github.dsheirer.module.decode.p25.identifier.talkgroup.APCO25Talkgroup;
+import io.github.dsheirer.module.decode.p25.reference.Encryption;
+import io.github.dsheirer.preference.duplicate.ICallManagementProvider;
+import io.github.dsheirer.preference.duplicate.TestCallManagementProvider;
+import io.github.dsheirer.sample.Listener;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * JUnit tests for the duplicate call detector.
+ */
+public class DuplicateCallDetectionTest
+{
+    /**
+     * Test: same source radio to two different talkgroups on the same site where one call is encrytped and the other
+     * call is not.
+     *
+     * Success Criteria: neither call gets flagged as duplicate.
+     */
+    @Test
+    void sameCallOnDifferentSites()
+    {
+        AliasList aliasList = new AliasList("test");
+        AudioSegment audioSegment1 = new AudioSegment(aliasList, 1);
+        audioSegment1.addIdentifier(SystemConfigurationIdentifier.create("Test System"));
+        audioSegment1.addIdentifier(SiteConfigurationIdentifier.create("Test Site 1"));
+        audioSegment1.addIdentifier(APCO25Talkgroup.create(1));
+        audioSegment1.addIdentifier(APCO25RadioIdentifier.createFrom(2));
+        audioSegment1.addAudio(new float[2]);
+
+        AudioSegment audioSegment2 = new AudioSegment(aliasList, 2);
+        audioSegment2.addIdentifier(SystemConfigurationIdentifier.create("Test System"));
+        audioSegment2.addIdentifier(SiteConfigurationIdentifier.create("Test Site 2"));
+        audioSegment2.addIdentifier(APCO25Talkgroup.create(1));
+        audioSegment2.addIdentifier(APCO25RadioIdentifier.createFrom(2));
+        audioSegment1.addAudio(new float[2]);
+
+        boolean testByTalkgroup = true;
+        boolean testByRadio = false;
+
+        ICallManagementProvider provider = new TestCallManagementProvider(testByTalkgroup, testByRadio);
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        Listener<AudioSegment> callback = audioSegment -> countDownLatch.countDown();
+
+        DuplicateCallDetector duplicateCallDetector = new DuplicateCallDetector(provider);
+        duplicateCallDetector.setDuplicateCallDetectionListener(callback);
+
+        duplicateCallDetector.receive(audioSegment1);
+        duplicateCallDetector.receive(audioSegment2);
+
+        try
+        {
+            //Wait up to 100 ms, but the duplicate detector should fire within 25 ms.
+            countDownLatch.await(100, TimeUnit.MILLISECONDS);
+        }
+        catch(InterruptedException e)
+        {
+            e.printStackTrace();
+        }
+
+        audioSegment1.completeProperty().set(true);
+        audioSegment2.completeProperty().set(true);
+
+        //Test that at least one of the audio segments was marked as duplicate.
+        assertTrue(audioSegment1.isDuplicate() || audioSegment2.isDuplicate(),
+                "At least one audio segment should have been flagged as duplicate");
+    }
+
+    /**
+     * Test: same call, same site, same source radio, simulcasting to two different talkgroups.
+     *
+     * Success Criteria: one audio segment is flagged as duplicate.
+     */
+    @Test
+    void sameCallSameSiteSameRadioSimulcastToDifferentTalkgroups()
+    {
+        AliasList aliasList = new AliasList("test");
+
+        AudioSegment audioSegment1 = new AudioSegment(aliasList, 1);
+        audioSegment1.addIdentifier(SystemConfigurationIdentifier.create("Test System"));
+        audioSegment1.addIdentifier(SiteConfigurationIdentifier.create("Test Site 1"));
+        audioSegment1.addIdentifier(APCO25Talkgroup.create(1));
+        audioSegment1.addIdentifier(APCO25RadioIdentifier.createFrom(2));
+        audioSegment1.addAudio(new float[2]);
+
+        AudioSegment audioSegment2 = new AudioSegment(aliasList, 2);
+        audioSegment2.addIdentifier(SystemConfigurationIdentifier.create("Test System"));
+        audioSegment2.addIdentifier(SiteConfigurationIdentifier.create("Test Site 1"));
+        audioSegment2.addIdentifier(APCO25Talkgroup.create(2));
+        audioSegment2.addIdentifier(APCO25RadioIdentifier.createFrom(2));
+        audioSegment1.addAudio(new float[2]);
+
+        boolean testByTalkgroup = true;
+        boolean testByRadio = true;
+        ICallManagementProvider provider = new TestCallManagementProvider(testByTalkgroup, testByRadio);
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        Listener<AudioSegment> callback = audioSegment -> countDownLatch.countDown();
+
+        DuplicateCallDetector duplicateCallDetector = new DuplicateCallDetector(provider);
+        duplicateCallDetector.setDuplicateCallDetectionListener(callback);
+
+        duplicateCallDetector.receive(audioSegment1);
+        duplicateCallDetector.receive(audioSegment2);
+
+        try
+        {
+            //Wait up to 100 ms, but the duplicate detector should fire within 25 ms.
+            countDownLatch.await(100, TimeUnit.MILLISECONDS);
+        }
+        catch(InterruptedException e)
+        {
+            e.printStackTrace();
+        }
+
+        audioSegment1.completeProperty().set(true);
+        audioSegment2.completeProperty().set(true);
+
+        //Test that at least one of the audio segments was marked as duplicate.
+        assertTrue(audioSegment1.isDuplicate() || audioSegment2.isDuplicate(),
+                "At least one audio segment should have been flagged as duplicate");
+    }
+
+    /**
+     * Test: same source radio to two different talkgroups on the same site where one call is encrypted and the other
+     * call is not.
+     *
+     * Success Criteria: neither call gets flagged as duplicate.
+     */
+    @Test
+    void sameCallSameSiteSameRadioSimulcastToDifferentTalkgroupsOneIsEncrypted()
+    {
+        AliasList aliasList = new AliasList("test");
+
+        AudioSegment audioSegment1 = new AudioSegment(aliasList, 1);
+        audioSegment1.addIdentifier(SystemConfigurationIdentifier.create("Test System"));
+        audioSegment1.addIdentifier(SiteConfigurationIdentifier.create("Test Site 1"));
+        audioSegment1.addIdentifier(APCO25Talkgroup.create(1));
+        audioSegment1.addIdentifier(APCO25RadioIdentifier.createFrom(2));
+        EncryptionKeyIdentifier eki1 = EncryptionKeyIdentifier.create(APCO25EncryptionKey.create(Encryption.AES_256, 1));
+        audioSegment1.addIdentifier(eki1);
+        audioSegment1.addAudio(new float[2]);
+
+        AudioSegment audioSegment2 = new AudioSegment(aliasList, 2);
+        audioSegment2.addIdentifier(SystemConfigurationIdentifier.create("Test System"));
+        audioSegment2.addIdentifier(SiteConfigurationIdentifier.create("Test Site 1"));
+        audioSegment2.addIdentifier(APCO25Talkgroup.create(2));
+        audioSegment2.addIdentifier(APCO25RadioIdentifier.createFrom(2));
+        EncryptionKeyIdentifier eki2 = EncryptionKeyIdentifier.create(APCO25EncryptionKey.create(Encryption.UNENCRYPTED, 1));
+        audioSegment2.addIdentifier(eki2);
+        audioSegment1.addAudio(new float[2]);
+
+        boolean testByTalkgroup = true;
+        boolean testByRadio = true;
+        ICallManagementProvider provider = new TestCallManagementProvider(testByTalkgroup, testByRadio);
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        Listener<AudioSegment> callback = audioSegment -> countDownLatch.countDown();
+
+        DuplicateCallDetector duplicateCallDetector = new DuplicateCallDetector(provider);
+        duplicateCallDetector.setDuplicateCallDetectionListener(callback);
+
+        duplicateCallDetector.receive(audioSegment1);
+        duplicateCallDetector.receive(audioSegment2);
+
+        try
+        {
+            //Wait up to 100 ms, but the duplicate detector should fire within 25 ms.
+            countDownLatch.await(100, TimeUnit.MILLISECONDS);
+        }
+        catch(InterruptedException e)
+        {
+            //Don't log the exception ... it's expected
+        }
+
+        audioSegment1.completeProperty().set(true);
+        audioSegment2.completeProperty().set(true);
+
+        //Test that neither audio segment was flagged as duplicate and audio segment 1 is flagged as encrypted.
+        assertTrue(audioSegment1.isEncrypted(), "Audio segment 1 should be flagged as encrypted");
+        assertFalse(audioSegment2.isEncrypted(), "Audio segment 1 should be flagged as unencrypted");
+        assertFalse(audioSegment1.isDuplicate(), "Audio segment should not be flagged as duplicate.");
+        assertFalse(audioSegment2.isDuplicate(), "Audio segment should not be flagged as duplicate.");
+    }
+}


### PR DESCRIPTION
Closes #1939 

Enhances thread safety in the duplicate call detector.

Adds unit testing to test for common scenarios.

Adds checks for encrypted audio to remove audio segments that initially have decoded audio and then get flagged as encrypted with an encryption key to protect against scenarios where a call is simulcast with one call encrypted and the other call unencrypted, to avoid flagging as duplicate the unencrypted call audio.