### PR TITLE
#1983 Revert Aliasing of Fully Qualified Identifiers Against Local ID

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/AliasList.java
+++ b/src/main/java/io/github/dsheirer/alias/AliasList.java
@@ -663,18 +663,13 @@ public class AliasList
 
         public Alias getAlias(TalkgroupIdentifier identifier)
         {
-            //Attempt to do a fully qualified identifier match first.
+            //Attempt to do a fully qualified identifier match only
             if(identifier instanceof FullyQualifiedTalkgroupIdentifier fqti)
             {
-                Alias fullyQualifiedAlias = mFullyQualifiedTalkgroupAliasMap.get(fqti.getFullyQualifiedTalkgroupAddress());
-
-                if(fullyQualifiedAlias != null)
-                {
-                    return fullyQualifiedAlias;
-                }
+                return mFullyQualifiedTalkgroupAliasMap.get(fqti.getFullyQualifiedTalkgroupAddress());
             }
 
-            //Next, attempt to match against the locally assigned (temporary) address
+            //Attempt to match the talkgroup value
             int value = identifier.getValue();
 
             Alias mapValue = mTalkgroupAliasMap.get(value);
@@ -683,7 +678,7 @@ public class AliasList
                 return mapValue;
             }
 
-            //Finally, match the locally assigned address against any talkgroup ranges
+            //Alternatively, match the talkgroup to any talkgroup ranges
             for(Map.Entry<TalkgroupRange, Alias> entry : mTalkgroupRangeAliasMap.entrySet())
             {
                 if(entry.getKey().contains(value))
@@ -788,18 +783,13 @@ public class AliasList
 
         public Alias getAlias(RadioIdentifier identifier)
         {
-            //Attempt to do a fully qualified identifier match first.
+            //Match fully qualified identifier only.
             if(identifier instanceof FullyQualifiedRadioIdentifier fqri)
             {
-                Alias fullyQualifiedRadioAlias =  mFullyQualifiedRadioAliasMap.get(fqri.getFullyQualifiedRadioAddress());
-
-                if(fullyQualifiedRadioAlias != null)
-                {
-                    return fullyQualifiedRadioAlias;
-                }
+                return mFullyQualifiedRadioAliasMap.get(fqri.getFullyQualifiedRadioAddress());
             }
 
-            //Next, attempt to match against the locally assigned (temporary) address
+            //Attempt to match against the radio identifier
             int value = identifier.getValue();
 
             Alias mapValue = mRadioAliasMap.get(value);
@@ -808,7 +798,7 @@ public class AliasList
                 return mapValue;
             }
 
-            //Finally, attempt to match the locally assigned (temporary) address against any radio ranges.
+            //Alternatively, attempt to match the radio address against any radio ranges.
             for(Map.Entry<RadioRange, Alias> entry : mRadioRangeAliasMap.entrySet())
             {
                 if(entry.getKey().contains(value))

--- a/src/test/java/io/github/dsheirer/alias/P25AliasTest.java
+++ b/src/test/java/io/github/dsheirer/alias/P25AliasTest.java
@@ -120,8 +120,7 @@ public class P25AliasTest
         APCO25FullyQualifiedTalkgroupIdentifier p25FQTG1 = APCO25FullyQualifiedTalkgroupIdentifier.createTo(aliasGroup, wacn, system, originalGroup);
 
         List<Alias> aliases = aliasList.getAliases(p25FQTG1);
-        assertEquals(1, aliases.size(), "Expected 1 matching alias");
-        assertEquals(correctAliasName, aliases.getFirst().getName(), "Unexpected alias name");
+        assertEquals(0, aliases.size(), "Expected 0 matching alias");
     }
 
     /**
@@ -148,8 +147,7 @@ public class P25AliasTest
         APCO25FullyQualifiedTalkgroupIdentifier p25FQTG1 = APCO25FullyQualifiedTalkgroupIdentifier.createTo(aliasGroup, wacn, system, originalGroup);
 
         List<Alias> aliases = aliasList.getAliases(p25FQTG1);
-        assertEquals(1, aliases.size(), "Expected 1 matching alias");
-        assertEquals(correctAliasName, aliases.getFirst().getName(), "Unexpected alias name");
+        assertEquals(0, aliases.size(), "Expected 0 matching aliases");
     }
 
     @Test
@@ -233,8 +231,7 @@ public class P25AliasTest
         APCO25FullyQualifiedRadioIdentifier p25FQTG1 = APCO25FullyQualifiedRadioIdentifier.createFrom(aliasRadio, wacn, system, originalRadio);
 
         List<Alias> aliases = aliasList.getAliases(p25FQTG1);
-        assertEquals(1, aliases.size(), "Expected 1 matching alias");
-        assertEquals(correctAliasName, aliases.getFirst().getName(), "Unexpected alias name");
+        assertEquals(0, aliases.size(), "Expected 0 matching aliases");
     }
 
     /**
@@ -261,7 +258,6 @@ public class P25AliasTest
         APCO25FullyQualifiedRadioIdentifier p25FQTG1 = APCO25FullyQualifiedRadioIdentifier.createFrom(aliasRadio, wacn, system, originalRadio);
 
         List<Alias> aliases = aliasList.getAliases(p25FQTG1);
-        assertEquals(1, aliases.size(), "Expected 1 matching alias");
-        assertEquals(correctAliasName, aliases.getFirst().getName(), "Unexpected alias name");
+        assertEquals(0, aliases.size(), "Expected 0 matching aliases");
     }
 }


### PR DESCRIPTION
#1983 Reverts aliasing of fully qualified identifiers against locally assign ID or address values - must be an exact match to the fully qualified identifier.