### PR TITLE
#1994 P25 Phase1 Missing Subsequent Calls Audio When Multiple Conversants On Same Traffic Channel

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/viewer/MessagePackage.java
+++ b/src/main/java/io/github/dsheirer/gui/viewer/MessagePackage.java
@@ -19,11 +19,11 @@
 
 package io.github.dsheirer.gui.viewer;
 
+import io.github.dsheirer.audio.AudioSegment;
 import io.github.dsheirer.channel.state.DecoderStateEvent;
 import io.github.dsheirer.controller.channel.event.ChannelStartProcessingRequest;
 import io.github.dsheirer.message.IMessage;
 import io.github.dsheirer.module.decode.event.DecodeEventSnapshot;
-import io.github.dsheirer.module.decode.event.IDecodeEvent;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,6 +37,7 @@ public class MessagePackage
     private List<DecoderStateEvent> mDecoderStateEvents = new ArrayList<>();
     private List<DecodeEventSnapshot> mDecodeEvents = new ArrayList<>();
     private ChannelStartProcessingRequest mChannelStartProcessingRequest;
+    private AudioSegment mAudioSegment;
 
     /**
      * Constructs an instance
@@ -152,8 +153,39 @@ public class MessagePackage
         return mChannelStartProcessingRequest == null ? 0 : 1;
     }
 
+    /**
+     * Count (0 or 1) of audio segment.
+     */
+    public int getAudioSegmentCount()
+    {
+        return mAudioSegment == null ? 0 : 1;
+    }
+
     public ChannelStartProcessingRequest getChannelStartProcessingRequest()
     {
         return mChannelStartProcessingRequest;
+    }
+
+    /**
+     * Generated audio segment.
+     * @return segment or null.
+     */
+    public AudioSegment getAudioSegment()
+    {
+        return mAudioSegment;
+    }
+
+    /**
+     * Adds the audio segment to the package
+     * @param audioSegment to add
+     */
+    public void add(AudioSegment audioSegment)
+    {
+        if(mAudioSegment != null)
+        {
+            throw new IllegalStateException("AudioSegment already set");
+        }
+
+        mAudioSegment = audioSegment;
     }
 }

--- a/src/main/java/io/github/dsheirer/gui/viewer/MessagePackageViewer.java
+++ b/src/main/java/io/github/dsheirer/gui/viewer/MessagePackageViewer.java
@@ -22,6 +22,8 @@ package io.github.dsheirer.gui.viewer;
 import io.github.dsheirer.channel.state.DecoderStateEvent;
 import io.github.dsheirer.module.decode.event.DecodeEventSnapshot;
 import javafx.scene.control.Label;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
@@ -38,6 +40,7 @@ public class MessagePackageViewer extends VBox
     private TableView<DecoderStateEvent> mDecoderStateEventTableView;
     private TableView<DecodeEventSnapshot> mDecodeEventTableView;
     private IdentifierCollectionViewer mIdentifierCollectionViewer;
+    private IdentifierCollectionViewer mAudioSegmentIdCollectionViewer;
     private ChannelStartProcessingRequestViewer mChannelStartProcessingRequestViewer;
 
     /**
@@ -63,8 +66,14 @@ public class MessagePackageViewer extends VBox
         GridPane.setHgrow(getDecodeEventTableView(), Priority.ALWAYS);
         gridPane.add(getDecodeEventTableView(), 1, 2);
 
-        gridPane.add(new Label("Channel Start Processing Request"), 0, 3);
-        gridPane.add(getChannelStartProcessingRequestViewer(), 0, 4);
+        TabPane tabPane = new TabPane();
+        Tab startTab = new Tab("Channel Start Processing Request");
+        startTab.setContent(getChannelStartProcessingRequestViewer());
+        Tab audioTab = new Tab("Audio Segment");
+        audioTab.setContent(getAudioSegmentIdCollectionViewer());
+        tabPane.getTabs().addAll(audioTab, startTab);
+
+        gridPane.add(tabPane, 0, 4);
 
         getIdentifierCollectionViewer().setPrefHeight(120);
         gridPane.add(new Label("Selected Decode Event Identifiers"), 1, 3);
@@ -96,6 +105,15 @@ public class MessagePackageViewer extends VBox
             {
                 getDecodeEventTableView().getSelectionModel().select(0);
             }
+
+            if(messagePackage.getAudioSegment() != null)
+            {
+                getAudioSegmentIdCollectionViewer().set(messagePackage.getAudioSegment().getIdentifierCollection());
+            }
+            else
+            {
+                getAudioSegmentIdCollectionViewer().set(null);
+            }
         }
     }
 
@@ -107,6 +125,16 @@ public class MessagePackageViewer extends VBox
         }
 
         return mIdentifierCollectionViewer;
+    }
+
+    private IdentifierCollectionViewer getAudioSegmentIdCollectionViewer()
+    {
+        if(mAudioSegmentIdCollectionViewer == null)
+        {
+            mAudioSegmentIdCollectionViewer = new IdentifierCollectionViewer();
+        }
+
+        return mAudioSegmentIdCollectionViewer;
     }
 
     private Label getMessageLabel()

--- a/src/main/java/io/github/dsheirer/gui/viewer/MessagePackager.java
+++ b/src/main/java/io/github/dsheirer/gui/viewer/MessagePackager.java
@@ -20,13 +20,13 @@
 package io.github.dsheirer.gui.viewer;
 
 import com.google.common.eventbus.Subscribe;
+import io.github.dsheirer.audio.AudioSegment;
 import io.github.dsheirer.channel.state.DecoderStateEvent;
 import io.github.dsheirer.controller.channel.event.ChannelStartProcessingRequest;
 import io.github.dsheirer.message.IMessage;
 import io.github.dsheirer.module.decode.event.DecodeEvent;
 import io.github.dsheirer.module.decode.event.DecodeEventSnapshot;
 import io.github.dsheirer.module.decode.event.IDecodeEvent;
-import io.github.dsheirer.module.decode.event.IDecodeEventListener;
 
 /**
  * Utility for combining a message and decoder state events.
@@ -40,6 +40,18 @@ public class MessagePackager
      */
     public MessagePackager()
     {
+    }
+
+    /**
+     * Adds an audio segment.
+     * @param audioSegment to add
+     */
+    public void add(AudioSegment audioSegment)
+    {
+        if(mMessagePackage != null)
+        {
+            mMessagePackage.add(audioSegment);
+        }
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/gui/viewer/MessageRecordingViewer.java
+++ b/src/main/java/io/github/dsheirer/gui/viewer/MessageRecordingViewer.java
@@ -19,6 +19,7 @@
 
 package io.github.dsheirer.gui.viewer;
 
+import io.github.dsheirer.preference.UserPreferences;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Node;
@@ -51,6 +52,7 @@ public class MessageRecordingViewer extends VBox
     private int mTabCounterDmr = 1;
     private int mTabCounterP25P1 = 1;
     private int mTabCounterP25P2 = 1;
+    private UserPreferences mUserPreferences = new UserPreferences();
 
     /**
      * Constructs an instance
@@ -77,7 +79,7 @@ public class MessageRecordingViewer extends VBox
             });
             MenuItem p25p1MenuItem = new MenuItem("P25 Phase 1");
             p25p1MenuItem.onActionProperty().set(event -> {
-                Tab tab = new LabeledTab("P25P1-" + mTabCounterP25P1++, new P25P1Viewer());
+                Tab tab = new LabeledTab("P25P1-" + mTabCounterP25P1++, new P25P1Viewer(mUserPreferences));
                 getTabPane().getTabs().add(tab);
                 getTabPane().getSelectionModel().select(tab);
             });
@@ -108,7 +110,7 @@ public class MessageRecordingViewer extends VBox
             mTabPane = new TabPane();
             mTabPane.setMaxHeight(Double.MAX_VALUE);
             mTabPane.getTabs().add(new LabeledTab("DMR-" + mTabCounterDmr++, new DmrViewer()));
-            mTabPane.getTabs().add(new LabeledTab("P25P1-" + mTabCounterP25P1++, new P25P1Viewer()));
+            mTabPane.getTabs().add(new LabeledTab("P25P1-" + mTabCounterP25P1++, new P25P1Viewer(mUserPreferences)));
             mTabPane.getTabs().add(new LabeledTab("P25P2-" + mTabCounterP25P2++, new P25P2Viewer()));
         }
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -60,7 +60,6 @@ import io.github.dsheirer.module.decode.p25.phase1.message.IFrequencyBand;
 import io.github.dsheirer.module.decode.p25.phase1.message.P25P1Message;
 import io.github.dsheirer.module.decode.p25.phase1.message.hdu.HDUMessage;
 import io.github.dsheirer.module.decode.p25.phase1.message.hdu.HeaderData;
-import io.github.dsheirer.module.decode.p25.phase1.message.lc.LinkControlOpcode;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.LinkControlWord;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.l3harris.LCHarrisReturnToControlChannel;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.motorola.LCMotorolaEmergencyAlarmActivation;
@@ -891,15 +890,9 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
 
             if(lcw != null && lcw.isValid())
             {
-                //Send an ACTIVE decoder state event for everything except the CALL TERMINATION opcode which is
-                //handled by the processLC() method.
-                if(lcw.getOpcode() != LinkControlOpcode.CALL_TERMINATION_OR_CANCELLATION)
-                {
-                    //Set the state to ACTIVE while the call continues in hangtime.  The processLC() method will signal
-                    // the channel teardown.
-                    broadcast(new DecoderStateEvent(this, Event.DECODE, State.ACTIVE));
-                }
-
+                //Set the state to ACTIVE while the call continues in hangtime.  The processLC() method will signal
+                // the channel teardown when that happens.
+                broadcast(new DecoderStateEvent(this, Event.DECODE, State.ACTIVE));
                 processLC(lcw, message.getTimestamp(), true);
             }
         }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/hdu/HDUMessage.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/hdu/HDUMessage.java
@@ -184,7 +184,11 @@ public class HDUMessage extends P25P1Message
 
         if(irrecoverableErrors)
         {
+            //Set the header data as invalid
             mHeaderData.setValid(false);
+
+            //Est the whole HDU message as invalid.
+            setValid(false);
         }
         else
         {


### PR DESCRIPTION
Closes #1994 

P25 Phase1 missing subsequent calls audio when multiple conversations on the same traffic channel.

Fixed issue where sdrtrunk was not checking HDU and LDU2 encryption sequences as valid before assessing the encryption state of a call.  Updated P25P1 audio module to check the valid flag for both the HDU and the LDU2 encryption segment before assigning encryption state.  Now caches all LDU messages until encryption state is determined.

This was happening on at least Harris VHF systems due to what sdrtrunk was interpreting to be a partial/malformed Header Data Unit (HDU) being transmitted at the end of the first call audio, where the decoded HDU indicated an encrypted call.