### PR TITLE
#2007 P25 Call events tracking.  P25 Traffic channel manager now uses…

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/viewer/P25P2Viewer.java
+++ b/src/main/java/io/github/dsheirer/gui/viewer/P25P2Viewer.java
@@ -222,7 +222,7 @@ public class P25P2Viewer extends VBox
 
             ThreadPool.CACHED.submit(() -> {
                 List<MessagePackage> messages = new ArrayList<>();
-                P25P2MessageFramer messageFramer = new P25P2MessageFramer(null, 9600);
+                P25P2MessageFramer messageFramer = new P25P2MessageFramer(null);
                 messageFramer.setScrambleParameters(scrambleParameters);
                 P25P2MessageProcessor messageProcessor = new P25P2MessageProcessor();
                 messageFramer.setListener(messageProcessor);

--- a/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
+++ b/src/main/java/io/github/dsheirer/identifier/IdentifierCollection.java
@@ -363,6 +363,15 @@ public class IdentifierCollection
         return to;
     }
 
+    /**
+     * Returns an encryption key identiier or null.
+     * @return key or null.
+     */
+    public Identifier getEncryptionIdentifier()
+    {
+        return getIdentifier(IdentifierClass.USER, Form.ENCRYPTION_KEY, Role.ANY);
+    }
+
     @Override
     public String toString()
     {

--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventType.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventType.java
@@ -95,7 +95,7 @@ public enum DecodeEventType
     /**
      * Voice call event types for filtering
      */
-    public static final EnumSet<DecodeEventType> VOICE_CALLS = EnumSet.of(DecodeEventType.CALL_GROUP,
+    public static final EnumSet<DecodeEventType> VOICE_CALLS = EnumSet.of(DecodeEventType.CALL, DecodeEventType.CALL_GROUP,
             DecodeEventType.CALL_PATCH_GROUP, DecodeEventType.CALL_ALERT, DecodeEventType.CALL_DETECT,
             DecodeEventType.CALL_DO_NOT_MONITOR, DecodeEventType.CALL_END, DecodeEventType.CALL_INTERCONNECT,
             DecodeEventType.CALL_UNIQUE_ID, DecodeEventType.CALL_UNIT_TO_UNIT, DecodeEventType.CALL_NO_TUNER,

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25ChannelGrantEvent.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25ChannelGrantEvent.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -80,6 +80,7 @@ public class P25ChannelGrantEvent extends P25DecodeEvent
         protected IChannelDescriptor mChannelDescriptor;
         protected String mDetails;
         private ServiceOptions mServiceOptions;
+        private int mTimeslot = -1;
 
         /**
          * Constructs a builder instance with the specified start time in milliseconds
@@ -145,6 +146,16 @@ public class P25ChannelGrantEvent extends P25DecodeEvent
         }
 
         /**
+         * Sets the timeslot for the event
+         * @param timeslot
+         */
+        public P25ChannelGrantDecodeEventBuilder timeslot(int timeslot)
+        {
+            mTimeslot = timeslot;
+            return this;
+        }
+
+        /**
          * Builds the decode event
          */
         public P25ChannelGrantEvent build()
@@ -156,6 +167,7 @@ public class P25ChannelGrantEvent extends P25DecodeEvent
             decodeEvent.setDuration(mDuration);
             decodeEvent.setIdentifierCollection(mIdentifierCollection);
             decodeEvent.setServiceOptions(mServiceOptions);
+            decodeEvent.setTimeslot(mTimeslot);
             return decodeEvent;
         }
     }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelEventTracker.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelEventTracker.java
@@ -1,0 +1,284 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.p25;
+
+import io.github.dsheirer.channel.IChannelDescriptor;
+import io.github.dsheirer.identifier.Form;
+import io.github.dsheirer.identifier.Identifier;
+import io.github.dsheirer.identifier.IdentifierCollection;
+import io.github.dsheirer.identifier.MutableIdentifierCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wrapper to track the state of a traffic channel event to manage updates from the control channel and the traffic
+ * channel and to assist in determining when the communicants of a traffic channel have changed, indicating the need
+ * for a new event.
+ */
+public class P25TrafficChannelEventTracker
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(P25TrafficChannelEventTracker.class);
+    private static final long STALE_EVENT_THRESHOLD_MS = 2000;
+    private P25ChannelGrantEvent mEvent;
+    private boolean mStarted = false;
+    private boolean mComplete = false;
+
+    /**
+     * Constructs an instance
+     * @param event to track for the traffic channel.
+     */
+    public P25TrafficChannelEventTracker(P25ChannelGrantEvent event)
+    {
+        mEvent = event;
+    }
+
+    /**
+     * Access the underlying traffic channel event that is being tracked.
+     * @return event.
+     */
+    public P25ChannelGrantEvent getEvent()
+    {
+        return mEvent;
+    }
+
+    /**
+     * Indicates if this event is stale relative to the provided timestamp.  Staleness is determined by the time delta
+     * between the event's end time and timestamp argument.
+     * @param timestamp to check for staleness
+     * @return true if the delta time exceeds a threshold.
+     */
+    public boolean isStale(long timestamp)
+    {
+        if(getEvent().getTimeEnd() > 0)
+        {
+            return timestamp - getEvent().getTimeEnd() > STALE_EVENT_THRESHOLD_MS;
+        }
+
+        return timestamp - getEvent().getTimeStart() > STALE_EVENT_THRESHOLD_MS;
+    }
+
+    /**
+     * Adds the identifier to the tracked event if the event's identifier collection does not already have it.
+     * @param identifier to add
+     */
+    public void addIdentifierIfMissing(Identifier identifier)
+    {
+        if(identifier != null && !getEvent().getIdentifierCollection().hasIdentifier(identifier))
+        {
+            MutableIdentifierCollection mic = new MutableIdentifierCollection(getEvent().getIdentifierCollection()
+                    .getIdentifiers());
+            mic.update(identifier);
+            getEvent().setIdentifierCollection(mic);
+        }
+    }
+
+    /**
+     * Adds the additional details to the tracked event if the current event details are null or if they do not contain
+     * the additional details.
+     * @param additionalDetails
+     */
+    public void addDetailsIfMissing(String additionalDetails)
+    {
+        if(additionalDetails != null && !additionalDetails.isEmpty())
+        {
+            if(getEvent().getDetails() == null)
+            {
+                getEvent().setDetails(additionalDetails);
+            }
+            else if(!getEvent().getDetails().endsWith(additionalDetails))
+            {
+                getEvent().setDetails(getEvent().getDetails() + " " + additionalDetails);
+            }
+        }
+    }
+
+    /**
+     * Compares the TO role identifier(s) from the tracked event and the identifier collection argument for equality
+     * and also checks this event for staleness.
+     *
+     * @param toCompare containing a TO identifier
+     * @param timestamp to check for staleness
+     * @return true if both collections contain a TO identifier and the TO identifiers are the same value
+     */
+    public boolean isSameCallCheckingToOnly(IdentifierCollection toCompare, long timestamp)
+    {
+        Identifier currentTO = getEvent().getIdentifierCollection().getToIdentifier();
+        Identifier nextTO = toCompare.getToIdentifier();
+        return currentTO != null && currentTO.equals(nextTO) && !isStale(timestamp);
+    }
+
+    /**
+     * Indicates if the tracked event from identifier is non null and that it is different to the from argument.
+     * @param fromToCompare against the current event from identifier.
+     * @return true if they are different.
+     */
+    public boolean isDifferentTalker(Identifier fromToCompare)
+    {
+        if(fromToCompare == null)
+        {
+            return false;
+        }
+
+        Identifier fromCurrent = getEvent().getIdentifierCollection().getFromIdentifier();
+        return fromCurrent != null && !fromCurrent.equals(fromToCompare);
+    }
+
+
+    /**
+     * Checks the call for staleness and verifies that the call event TO identifier is equal to the TO identifier
+     * in the provided identifier collection.
+     * @param toCompareIC containing a TO and optionally a FROM identifier to compare.
+     * @param timestamp to check for staleness
+     * @return true if the call identifiers are the same and the call is not stale.
+     */
+    public boolean isSameCallCheckingToAndFrom(IdentifierCollection toCompareIC, long timestamp)
+    {
+        if(!isStale(timestamp))
+        {
+            Identifier currentTO = getEvent().getIdentifierCollection().getToIdentifier();
+            Identifier nextTO = toCompareIC.getToIdentifier();
+
+            if(currentTO != null && currentTO.equals(nextTO))
+            {
+                Identifier existingFROM = getEvent().getIdentifierCollection().getFromIdentifier();
+
+                //If the FROM identifier hasn't yet been established, then this is the same call.  We also ignore the
+                //talker alias as a call identifier since on L3Harris systems they can transmit the talker alias before
+                //they transmit the radio ID.
+                if(existingFROM == null || existingFROM.getForm() == Form.TALKER_ALIAS)
+                {
+                    return true;
+                }
+
+                Identifier nextFROM = toCompareIC.getFromIdentifier();
+
+                //Sometime the GROUP_VOICE_CHANNEL_USER has a zero valued FROM address which is not valid, so if the
+                //nextFROM is null, we consider the call to be the same.  Likewise, if the nextFROM is a talker alias,
+                //that's also the same call.
+                if(nextFROM == null || (nextFROM != null && nextFROM.getForm() == Form.TALKER_ALIAS))
+                {
+                    return true;
+                }
+
+                return existingFROM.equals(nextFROM);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Indicates if the event has been marked as complete by traffic channel signalling.
+     * @return complete status.
+     */
+    public boolean isComplete()
+    {
+        return mComplete;
+    }
+
+    /**
+     * Indicates if the event has been marked as started by the traffic channel for HDU or LDU signalling.
+     * @return started status.
+     */
+    public boolean isStarted()
+    {
+        return mStarted;
+    }
+
+    /**
+     * Updates the event duration using signalling from the control channel.
+     *
+     * Note: once the traffic channel starts updating the event timing, attempts to update timing from the control
+     * channel are ignored.
+     *
+     * @param timestamp to use as the current end timestamp for the event.
+     * @return true if the timestamp was updated.
+     */
+    public boolean updateDurationControl(long timestamp)
+    {
+        if(!isStarted())
+        {
+            getEvent().update(timestamp);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Updates the event duration using signalling from the traffic channel.
+     *
+     * Note: once the event is being updated from the traffic channel, any attempts to update from the control channel
+     * are ignored.
+     * @param timestamp to assign.
+     */
+    public void updateDurationTraffic(long timestamp)
+    {
+        if(!isComplete())
+        {
+            mStarted = true;
+            getEvent().update(timestamp);
+        }
+        else
+        {
+            LOGGER.warn("Attempt to update event call event duration from traffic channel against an event that is marked as complete");
+        }
+    }
+
+    /**
+     * Mark the event as complete and assign final end timestamp to the event.
+     *
+     * Note: further attempts to complete an already complete event are ignored.
+     * @param timestamp to assign.
+     * @return true if the timestamp was updated
+     */
+    public boolean completeTraffic(long timestamp)
+    {
+        if(!isComplete())
+        {
+            mComplete = true;
+            getEvent().end(timestamp);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Updates the details for the tracked event.
+     * @param details to update
+     */
+    public void setDetails(String details)
+    {
+        getEvent().setDetails(details);
+    }
+
+    /**
+     * Updates the channel descriptor for the tracked event.
+     * @param channelDescriptor to update.
+     */
+    public void addChannelDescriptorIfMissing(IChannelDescriptor channelDescriptor)
+    {
+        if(channelDescriptor != null && getEvent().getChannelDescriptor() == null)
+        {
+            getEvent().setChannelDescriptor(channelDescriptor);
+        }
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/APCO25Channel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/APCO25Channel.java
@@ -1,23 +1,20 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2019 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 package io.github.dsheirer.module.decode.p25.identifier.channel;
 
@@ -110,6 +107,36 @@ public class APCO25Channel extends Identifier<P25Channel> implements IChannelDes
     public static APCO25Channel create(int frequencyBand, int channelNumber)
     {
         return new APCO25Channel(new P25Channel(frequencyBand, channelNumber));
+    }
+
+    /**
+     * Creates a new APCO-25 identifier with the same frequencyBand, and a different channelNumber representing the
+     * requested timeslot.
+     * @param requestedTimeslot to decorate as.
+     * @return decorated channel.
+     */
+    public APCO25Channel decorateAs(int requestedTimeslot)
+    {
+        if(getTimeslot() == requestedTimeslot)
+        {
+            return this;
+        }
+
+        P25Channel existing = getValue();
+
+        int channelNumber = existing.getChannelNumber();
+        if(requestedTimeslot == 1)
+        {
+            channelNumber--;
+        }
+        else
+        {
+            channelNumber++;
+        }
+
+        P25Channel decoratedChannel = new P25Channel(existing.getBandIdentifier(), channelNumber);
+        decoratedChannel.setFrequencyBand(existing.getFrequencyBand());
+        return new APCO25Channel(decoratedChannel);
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/P25Channel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/P25Channel.java
@@ -43,6 +43,22 @@ public class P25Channel implements IChannelDescriptor
     }
 
     /**
+     * Band identifier for this channel.
+     */
+    public int getBandIdentifier()
+    {
+        return mBandIdentifier;
+    }
+
+    /**
+     * Channel number for this channel.
+     */
+    public int getChannelNumber()
+    {
+        return mChannelNumber;
+    }
+
+    /**
      * Frequency band information that backs this channel
      */
     public IFrequencyBand getFrequencyBand()

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/lc/standard/LCGroupVoiceChannelUser.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/lc/standard/LCGroupVoiceChannelUser.java
@@ -151,7 +151,7 @@ public class LCGroupVoiceChannelUser extends VoiceLinkControlMessage implements 
     {
         if(mSourceAddress == null)
         {
-            if(isExtensionRequired() && mSourceIdExtension != null)
+            if(isExtensionRequired() && mSourceIdExtension != null && mSourceIdExtension.isValidExtendedSource())
             {
                 mSourceAddress = APCO25FullyQualifiedRadioIdentifier.createFrom(getInt(SOURCE_ADDRESS),
                         mSourceIdExtension.getWACN(), mSourceIdExtension.getSystem(), mSourceIdExtension.getId());

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/lc/standard/LCSourceIDExtension.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/lc/standard/LCSourceIDExtension.java
@@ -65,6 +65,16 @@ public class LCSourceIDExtension extends LinkControlWord implements IExtendedSou
         return sb.toString();
     }
 
+    /**
+     * Indicates that at least one of the WACN, System, or ID values are non-zero.
+     * @return
+     */
+    public boolean isValidExtendedSource()
+    {
+        return getWACN() != 0 && getSystem() != 0 && getId() != 0;
+    }
+
+
     @Override
     public boolean isTerminator()
     {

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSK.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSK.java
@@ -38,7 +38,6 @@ import io.github.dsheirer.identifier.IdentifierUpdateListener;
 import io.github.dsheirer.identifier.IdentifierUpdateNotification;
 import io.github.dsheirer.identifier.patch.PatchGroupManager;
 import io.github.dsheirer.module.ProcessingChain;
-import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.p25.P25TrafficChannelManager;
 import io.github.dsheirer.module.decode.p25.audio.P25P2AudioModule;
 import io.github.dsheirer.module.decode.p25.phase2.enumeration.ScrambleParameters;
@@ -123,7 +122,7 @@ public class P25P2DecoderHDQPSK extends P25P2Decoder implements IdentifierUpdate
 
         //The Costas Loop receives symbol-inversion correction requests when detected.
         //The PLL gain monitor receives sync detect/loss signals from the message framer
-        mMessageFramer = new P25P2MessageFramer(mCostasLoop, DecoderType.P25_PHASE2.getProtocol().getBitRate());
+        mMessageFramer = new P25P2MessageFramer(mCostasLoop);
 
         if(mDecodeConfigP25Phase2 !=null)
         {
@@ -146,8 +145,6 @@ public class P25P2DecoderHDQPSK extends P25P2Decoder implements IdentifierUpdate
     @Override
     public void receive(ComplexSamples samples)
     {
-        mMessageFramer.setCurrentTime(System.currentTimeMillis());
-
         float[] i = mIBasebandFilter.filter(samples.i());
         float[] q = mQBasebandFilter.filter(samples.q());
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSKInstrumented.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSKInstrumented.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,8 +58,6 @@ public class P25P2DecoderHDQPSKInstrumented extends P25P2DecoderHDQPSK
     @Override
     public void receive(ComplexSamples samples)
     {
-        mMessageFramer.setCurrentTime(System.currentTimeMillis());
-
         float[] i = mIBasebandFilter.filter(samples.i());
         float[] q = mQBasebandFilter.filter(samples.q());
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/reference/ServiceOptions.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/reference/ServiceOptions.java
@@ -25,7 +25,7 @@ package io.github.dsheirer.module.decode.p25.reference;
 public abstract class ServiceOptions
 {
     protected static final int EMERGENCY_FLAG = 0x80;
-    protected static final int ENCRYPTION_FLAG = 0x40;
+    public static final int ENCRYPTION_FLAG = 0x40;
     protected static final int DUPLEX = 0x20;
     protected static final int SESSION_MODE = 0x10;
     protected int mServiceOptions;


### PR DESCRIPTION
#2007 P25 Call events tracking and removing duplicate events.

P25 Traffic channel manager now uses event trackers to deconflict between control channel and traffic channel event updates.  

Protects against Motorola ISSI FQSUID that's all zeros.  

Resolves issue with running out of traffic channels after losing the control channel and going into CC hunt mode a few times.