### PR TITLE
#2016 Playback Preferences Null Error

### DIFF
--- a/src/main/java/io/github/dsheirer/preference/UserPreferences.java
+++ b/src/main/java/io/github/dsheirer/preference/UserPreferences.java
@@ -225,6 +225,7 @@ public class UserPreferences implements Listener<PreferenceType>
         mCallManagementPreference = new CallManagementPreference(this::receive);
         mJmbeLibraryPreference = new JmbeLibraryPreference(this::receive);
         mMP3Preference = new MP3Preference(this::receive);
+        mPlaybackPreference = new PlaybackPreference(this::receive);
         mPlaylistPreference = new PlaylistPreference(this::receive, mDirectoryPreference);
         mRadioReferencePreference = new RadioReferencePreference(this::receive);
         mRecordPreference = new RecordPreference(this::receive);


### PR DESCRIPTION
Closes #2016 Fixes code regression introduced in #1973 with null playback preferences.
