### PR TITLE
#2020 P25 channel null frequency band error.

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/APCO25Channel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/APCO25Channel.java
@@ -135,7 +135,12 @@ public class APCO25Channel extends Identifier<P25Channel> implements IChannelDes
         }
 
         P25Channel decoratedChannel = new P25Channel(existing.getBandIdentifier(), channelNumber);
-        decoratedChannel.setFrequencyBand(existing.getFrequencyBand());
+
+        if(existing.getFrequencyBand() != null)
+        {
+            decoratedChannel.setFrequencyBand(existing.getFrequencyBand());
+        }
+
         return new APCO25Channel(decoratedChannel);
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/P25Channel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/identifier/channel/P25Channel.java
@@ -134,7 +134,7 @@ public class P25Channel implements IChannelDescriptor
     @Override
     public void setFrequencyBand(IFrequencyBand frequencyBand)
     {
-        if(frequencyBand.getIdentifier() == getDownlinkBandIdentifier())
+        if(frequencyBand != null && frequencyBand.getIdentifier() == getDownlinkBandIdentifier())
         {
             mFrequencyBand = frequencyBand;
         }


### PR DESCRIPTION
Closes #2020 

Resolves issue where P25 channel throws NPE when applying a null frequency band.
