### PR TITLE
#2032 Audio Output Logs Failed Attempt To Update Gain/Mute Controls

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/playback/AudioOutput.java
+++ b/src/main/java/io/github/dsheirer/audio/playback/AudioOutput.java
@@ -140,8 +140,9 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
                     }
                     catch(IllegalArgumentException iae)
                     {
-                        mLog.warn("Couldn't obtain MASTER GAIN control for stereo line [" +
-                            mixer.getMixerInfo().getName() + " | " + getChannelName() + "]");
+                        LOGGING_SUPPRESSOR.error("no gain control", 5, "Couldn't obtain " +
+                            "MASTER GAIN control for stereo line [" + mixer.getMixerInfo().getName() + " | " +
+                                getChannelName() + "]");
                     }
 
                     try
@@ -151,8 +152,9 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
                     }
                     catch(IllegalArgumentException iae)
                     {
-                        mLog.warn("Couldn't obtain MUTE control for stereo line [" +
-                            mixer.getMixerInfo().getName() + " | " + getChannelName() + "]");
+                        LOGGING_SUPPRESSOR.error("no mute control", 5, "Couldn't obtain " +
+                            "MUTE control for stereo line [" + mixer.getMixerInfo().getName() + " | " +
+                            getChannelName() + "]");
                     }
 
 					//Run the queue processor task every 100 milliseconds or 10 times a second


### PR DESCRIPTION
Closes #2032 

Audio output suppresses logging after 5 times when app can't get gain or mute controls for current audio output.

Note: this doesn't resolve the underlying issue of why is Java unable to get Gain/Mute controls from the reacquired audio output.  It's possible that those features are not supported on the audio output.  