### PR TITLE
#2045 P25 Phase 1 Data channels are now ignored if the channel config…

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -1163,16 +1163,20 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
             return;
         }
 
-        if(mIgnoreDataCalls && isDataChannelGrant && tracker == null)
+        if(mIgnoreDataCalls && isDataChannelGrant)
         {
-            P25ChannelGrantEvent event = P25ChannelGrantEvent.builder(decodeEventType, timestamp, serviceOptions)
-                .channelDescriptor(apco25Channel)
-                .details("IGNORED: PHASE 1 DATA CALL " + (serviceOptions != null ? serviceOptions : ""))
-                .identifiers(ic)
-                .build();
-            tracker = new P25TrafficChannelEventTracker(event);
-            addTracker(tracker, frequency, P25P1Message.TIMESLOT_1);
-            broadcast(tracker);
+            if(tracker == null)
+            {
+                P25ChannelGrantEvent event = P25ChannelGrantEvent.builder(decodeEventType, timestamp, serviceOptions)
+                        .channelDescriptor(apco25Channel)
+                        .details("IGNORED: PHASE 1 DATA CALL " + (serviceOptions != null ? serviceOptions : ""))
+                        .identifiers(ic)
+                        .build();
+                tracker = new P25TrafficChannelEventTracker(event);
+                addTracker(tracker, frequency, P25P1Message.TIMESLOT_1);
+                broadcast(tracker);
+            }
+
             return;
         }
 


### PR DESCRIPTION
Closes #2045 

P25 Phase 1 Data channels are now ignored if the channel config calls for it.  Fixes a code regression from recent changes to the P25 traffic channel manager.
