### PR TITLE
#2037 JavaFX Windows Can't Be Shrunken

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/JavaFxWindowManager.java
+++ b/src/main/java/io/github/dsheirer/gui/JavaFxWindowManager.java
@@ -460,9 +460,6 @@ public class JavaFxWindowManager extends Application
         stage.show();
         stage.requestFocus();
         stage.toFront();
-        stage.setMinHeight(stage.getHeight());
-        stage.setMinWidth(stage.getWidth());
-        // System.out.println("Stage [" + stage.getTitle() + "] restored - width[" + stage.getWidth() + "] height [" + stage.getHeight() + "]");
     }
 
     @Override


### PR DESCRIPTION
Closes #2037 
JavaFX Windows Can't Be Shrunk.  

Reverts changes made under #1619 that was applying a min width and height to the window based on the last time that the user resized the window.  This had the effect of allowing windows to get bigger, but never allowing windows to get smaller than the last width/height values on previous application shutdown.
