### PR TITLE
#2040 Reset AMBE/IMBE Audio Codec After Each Call

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/codec/mbe/JmbeAudioModule.java
+++ b/src/main/java/io/github/dsheirer/audio/codec/mbe/JmbeAudioModule.java
@@ -63,6 +63,18 @@ public abstract class JmbeAudioModule extends AbstractAudioModule implements Lis
     }
 
     @Override
+    protected void closeAudioSegment()
+    {
+        super.closeAudioSegment();
+
+        //Reset the audio codec to clear any leftover frame data from the previous call.
+        if(mAudioCodec != null)
+        {
+            mAudioCodec.reset();
+        }
+    }
+
+    @Override
     public void dispose()
     {
         super.dispose();


### PR DESCRIPTION
Closes #2040 

Resets AMBE/IMBE audio codec after each call to prevent carryover of last audio frame from previous call.
