### PR TITLE
#2055 Multi-Frequency channel source with channel rotation monitor st…

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/channel/MultiFrequencyTunerChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/MultiFrequencyTunerChannelSource.java
@@ -153,13 +153,19 @@ public class MultiFrequencyTunerChannelSource extends TunerChannelSource
     @Override
     public void stop()
     {
-        mStarted = false;
-
-        if(mTunerChannelSource != null)
+        //Don't perform stop sequence if we haven't been started.  There can be a small window on startup where the
+        //channel rotation monitor can get ahead of the channel source and cause it to try to stop and rotate before
+        //it has even started, causing an error in the polyphase channel source.
+        if(mStarted)
         {
-            mTunerChannelSource.stop();
-            mTunerChannelSource.removeSourceEventListener();
-            mTunerChannelSource = null;
+            mStarted = false;
+
+            if(mTunerChannelSource != null)
+            {
+                mTunerChannelSource.stop();
+                mTunerChannelSource.removeSourceEventListener();
+                mTunerChannelSource = null;
+            }
         }
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/rotation/ChannelRotationMonitor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/rotation/ChannelRotationMonitor.java
@@ -68,9 +68,13 @@ public class ChannelRotationMonitor extends Module implements ISourceEventProvid
         mRotationDelay = rotationDelay;
         mUserPreferences = userPreferences;
 
-        if(mRotationDelay == 0)
+        if(mRotationDelay < CHANNEL_ROTATION_DELAY_MINIMUM)
         {
-            mRotationDelay = 200;
+            mRotationDelay = CHANNEL_ROTATION_DELAY_MINIMUM;
+        }
+        else if(mRotationDelay > CHANNEL_ROTATION_DELAY_MAXIMUM)
+        {
+            mRotationDelay = CHANNEL_ROTATION_DELAY_MAXIMUM;
         }
     }
 
@@ -184,7 +188,7 @@ public class ChannelRotationMonitor extends Module implements ISourceEventProvid
                 }
             };
 
-            mScheduledFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(runnable, mRotationDelay,
+            mScheduledFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(runnable, mRotationDelay * 2,
                 mRotationDelay / 2, TimeUnit.MILLISECONDS);
         }
     }


### PR DESCRIPTION
Closes #2055 

On startup, the channel rotation monitor can get ahead of the tuner channel source and cause an NPE when the source has been allocated but not yet started.
