### PR TITLE
#1992 Traffic channels stuck in teardown.

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/playback/AudioOutput.java
+++ b/src/main/java/io/github/dsheirer/audio/playback/AudioOutput.java
@@ -140,7 +140,7 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
                     }
                     catch(IllegalArgumentException iae)
                     {
-                        LOGGING_SUPPRESSOR.error("no gain control", 5, "Couldn't obtain " +
+                        LOGGING_SUPPRESSOR.error("no gain control", 2, "Couldn't obtain " +
                             "MASTER GAIN control for stereo line [" + mixer.getMixerInfo().getName() + " | " +
                                 getChannelName() + "]");
                     }
@@ -152,7 +152,7 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
                     }
                     catch(IllegalArgumentException iae)
                     {
-                        LOGGING_SUPPRESSOR.error("no mute control", 5, "Couldn't obtain " +
+                        LOGGING_SUPPRESSOR.error("no mute control", 2, "Couldn't obtain " +
                             "MUTE control for stereo line [" + mixer.getMixerInfo().getName() + " | " +
                             getChannelName() + "]");
                     }
@@ -278,7 +278,7 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
     {
         if(mOutput == null)
         {
-            LOGGING_SUPPRESSOR.error("null output", 5, "Audio Output is null - ignoring audio playback request");
+            LOGGING_SUPPRESSOR.error("null output", 2, "Audio Output is null - ignoring audio playback request");
             return;
         }
 
@@ -323,8 +323,9 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
                             }
                             catch(IllegalArgumentException iae)
                             {
-                                mLog.warn("Couldn't obtain MASTER GAIN control for stereo line [" +
-                                        mMixer.getMixerInfo().getName() + " | " + getChannelName() + "]");
+                                LOGGING_SUPPRESSOR.error("no gain control", 2, "Couldn't obtain " +
+                                        "MASTER GAIN control for stereo line [" + mMixer.getMixerInfo().getName() + " | " +
+                                        getChannelName() + "]");
                             }
 
                             try
@@ -334,23 +335,24 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
                             }
                             catch(IllegalArgumentException iae)
                             {
-                                mLog.warn("Couldn't obtain MUTE control for stereo line [" +
-                                        mMixer.getMixerInfo().getName() + " | " + getChannelName() + "]");
+                                LOGGING_SUPPRESSOR.error("no mute control", 2, "Couldn't obtain " +
+                                        "MASTER MUTE control for stereo line [" + mMixer.getMixerInfo().getName() + " | " +
+                                        getChannelName() + "]");
                             }
 
-                            LOGGING_SUPPRESSOR.info("reopen audio output success", 5,
+                            LOGGING_SUPPRESSOR.info("reopen audio output success", 2,
                                     "Closed and reopened audio output - success - mOutput is not null");
                         }
                         else
                         {
-                            LOGGING_SUPPRESSOR.info("reopen audio output fail", 5,
+                            LOGGING_SUPPRESSOR.info("reopen audio output fail", 2,
                                     "Closed and reopened audio output - fail - mOutput is null");
                             return;
                         }
                     }
                     catch(LineUnavailableException lue)
                     {
-                        LOGGING_SUPPRESSOR.error("reopen fail for lua", 3, "Attempt to reopen " +
+                        LOGGING_SUPPRESSOR.error("reopen fail for lua", 2, "Attempt to reopen " +
                                 "audio source data line failed", lue);
                         return;
                     }
@@ -393,7 +395,7 @@ public abstract class AudioOutput implements LineListener, Listener<IdentifierUp
                     }
                     catch(LineUnavailableException e)
                     {
-                        LOGGING_SUPPRESSOR.error("failed reopen source data line lua", 3,
+                        LOGGING_SUPPRESSOR.error("failed reopen source data line lua", 2,
                                 "Failed to (re)open the source data line for audio output - mixer [" +
                                 mMixer.getMixerInfo().getName() + "]");
                         return;

--- a/src/main/java/io/github/dsheirer/channel/state/AbstractChannelState.java
+++ b/src/main/java/io/github/dsheirer/channel/state/AbstractChannelState.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,10 +35,9 @@ import io.github.dsheirer.source.ISourceEventProvider;
 import io.github.dsheirer.source.SourceEvent;
 import io.github.dsheirer.source.heartbeat.Heartbeat;
 import io.github.dsheirer.source.heartbeat.IHeartbeatListener;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 public abstract class AbstractChannelState extends Module implements IChannelEventProvider, IDecodeEventProvider,
     IDecoderStateEventProvider, ISourceEventProvider, IHeartbeatListener, ISquelchStateProvider,
@@ -53,7 +52,8 @@ public abstract class AbstractChannelState extends Module implements IChannelEve
     private Channel mChannel;
     protected boolean mSourceOverflow = false;
     private HeartbeatReceiver mHeartbeatReceiver = new HeartbeatReceiver();
-
+    protected boolean mTeardownSequenceStarted = false;
+    protected boolean mTeardownSequenceCompleted = false;
 
     //TODO: remove the IOverflowListener code from this class
 
@@ -64,6 +64,22 @@ public abstract class AbstractChannelState extends Module implements IChannelEve
     public AbstractChannelState(Channel channel)
     {
         mChannel = channel;
+    }
+
+    /**
+     * Indicates if the teardown sequence was started.
+     */
+    public boolean isTeardownSequenceCompleted()
+    {
+        return mTeardownSequenceCompleted;
+    }
+
+    /**
+     * Indicates if the teardown sequence was completed, meaning that the request disable channel event was dispatched.
+     */
+    public boolean isTeardownSequenceStarted()
+    {
+        return mTeardownSequenceStarted;
     }
 
     /**
@@ -88,6 +104,11 @@ public abstract class AbstractChannelState extends Module implements IChannelEve
      * messages so that channel state is not entirely dependent on a continuous decoded message stream.
      */
     protected abstract void checkState();
+
+    /**
+     * Indicates if any timeslot is currently in a TEARDOWN state.
+     */
+    public abstract boolean isTeardownState();
 
     public abstract List<ChannelMetadata> getChannelMetadata();
 

--- a/src/main/java/io/github/dsheirer/channel/state/SingleChannelState.java
+++ b/src/main/java/io/github/dsheirer/channel/state/SingleChannelState.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2024 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,11 +46,10 @@ import io.github.dsheirer.source.SourceEvent;
 import io.github.dsheirer.source.SourceType;
 import io.github.dsheirer.source.config.SourceConfigTuner;
 import io.github.dsheirer.source.config.SourceConfigTunerMultipleFrequency;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Channel state tracks the overall state of all processing modules and decoders configured for the channel and
@@ -163,9 +162,11 @@ public class SingleChannelState extends AbstractChannelState implements IDecoder
                 mStateMachine.setState(State.IDLE);
                 break;
             case TEARDOWN:
+                mTeardownSequenceStarted = true;
                 if(getChannel().isTrafficChannel())
                 {
                     broadcast(new ChannelEvent(getChannel(), ChannelEvent.Event.REQUEST_DISABLE));
+                    mTeardownSequenceCompleted = true;
                 }
                 else
                 {
@@ -173,6 +174,12 @@ public class SingleChannelState extends AbstractChannelState implements IDecoder
                 }
                 break;
         }
+    }
+
+    @Override
+    public boolean isTeardownState()
+    {
+        return mStateMachine.getState() == State.TEARDOWN;
     }
 
     @Override


### PR DESCRIPTION
Closes #1992 

Resolves issue that was causing channels to be stuck in TEARDOWN state.

Issue appears to be that the Channel's processing flag was not being set during start processing and the request to shutdown the channel was checking the flag was set before proceeding with shutdown.
