### PR TITLE
#2064 Moto talker GPS event TO/FROM identifiers.

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -2055,7 +2055,10 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
                 if(lcw instanceof LCMotorolaUnitGPS gps)
                 {
                     mTrafficChannelManager.processP1TrafficCurrentUser(getCurrentFrequency(), gps.getLocation(), timestamp, lcw.toString());
-                    MutableIdentifierCollection mic = getMutableIdentifierCollection(gps.getIdentifiers(), timestamp);
+
+                    //We want to preserve the current TO/FROM and any other identifiers for the GPS event and add the GPS location
+                    MutableIdentifierCollection mic = new MutableIdentifierCollection(getIdentifierCollection().getIdentifiers());
+                    mic.update(gps.getIdentifiers());
 
                     PlottableDecodeEvent event = PlottableDecodeEvent.plottableBuilder(DecodeEventType.GPS, timestamp)
                             .location(gps.getGeoPosition())


### PR DESCRIPTION
Closes #2064 

Updates P25P1 decoder state to ensure TO/FROM identifiers are added to any Moto talker GPS event for correct plotting to the map.
