### PR TITLE
#2066 P25 Phase 1 Frequency Band Link Control Messages Checked For Valid CRC

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageProcessor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageProcessor.java
@@ -236,13 +236,13 @@ public class P25P1MessageProcessor implements Listener<IMessage>
         processForFrequencyBands(message);
 
         //Also process the link control messages for frequency bands.
-        if(message instanceof LDU1Message ldu1)
+        if(message instanceof LDU1Message ldu1 && ldu1.getLinkControlWord() instanceof LinkControlWord lcw && lcw.isValid())
         {
-            processForFrequencyBands(ldu1.getLinkControlWord());
+            processForFrequencyBands(lcw);
         }
-        else if(message instanceof TDULCMessage tdulc)
+        else if(message instanceof TDULCMessage tdulc && tdulc.getLinkControlWord() instanceof LinkControlWord lcw && lcw.isValid())
         {
-            processForFrequencyBands(tdulc.getLinkControlWord());
+            processForFrequencyBands(lcw);
         }
 
         if(mMessageListener != null)


### PR DESCRIPTION
Closes #2066 

P25 Phase 1 frequency band link control messages are now checked for valid CRC before being used.  This corrects an issue where the now playing channel metadata for simplex channels or manually entered traffic channels were showing wild/bad frequency values.
