### PR TITLE
#2055 MultiFrequencyTunerChannelSource Null Pointer Error On Channel …

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/channelizer/PolyphaseChannelManager.java
@@ -252,11 +252,16 @@ public class PolyphaseChannelManager implements ISourceEventProcessor
         synchronized(mBufferDispatcher)
         {
             mChannelSources.remove(channelSource);
-            mPolyphaseChannelizer.removeChannel(channelSource);
+
+            if(mPolyphaseChannelizer != null)
+            {
+                mPolyphaseChannelizer.removeChannel(channelSource);
+            }
+
             mSourceEventBroadcaster.broadcast(SourceEvent.channelCountChange(getTunerChannelCount()));
 
             //If this is the last/only channel, deregister to stop the sample buffers
-            if(mPolyphaseChannelizer.getRegisteredChannelCount() == 0)
+            if(mPolyphaseChannelizer != null && mPolyphaseChannelizer.getRegisteredChannelCount() == 0)
             {
                 mNativeBufferProvider.removeBufferListener(mBufferDispatcher);
                 mBufferDispatcher.stop();

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -1086,6 +1086,18 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
             startChannelRequest.addPreloadDataContent(new P25FrequencyBandPreloadDataContent(mFrequencyBandMap.values()));
             getInterModuleEventBus().post(startChannelRequest);
         }
+        else
+        {
+            //Return the channel to the traffic channel pool since we didn't start it.
+            if(mManagedPhase1TrafficChannels.contains(trafficChannel))
+            {
+                mAvailablePhase1TrafficChannelQueue.add(trafficChannel);
+            }
+            else if(mManagedPhase2TrafficChannels.contains(trafficChannel))
+            {
+                mAvailablePhase2TrafficChannelQueue.add(trafficChannel);
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/channel/MultiFrequencyTunerChannelSource.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/channel/MultiFrequencyTunerChannelSource.java
@@ -153,19 +153,13 @@ public class MultiFrequencyTunerChannelSource extends TunerChannelSource
     @Override
     public void stop()
     {
-        //Don't perform stop sequence if we haven't been started.  There can be a small window on startup where the
-        //channel rotation monitor can get ahead of the channel source and cause it to try to stop and rotate before
-        //it has even started, causing an error in the polyphase channel source.
-        if(mStarted)
-        {
-            mStarted = false;
+        mStarted = false;
 
-            if(mTunerChannelSource != null)
-            {
-                mTunerChannelSource.stop();
-                mTunerChannelSource.removeSourceEventListener();
-                mTunerChannelSource = null;
-            }
+        if(mTunerChannelSource != null)
+        {
+            mTunerChannelSource.stop();
+            mTunerChannelSource.removeSourceEventListener();
+            mTunerChannelSource = null;
         }
     }
 


### PR DESCRIPTION
#2055 Rework the MultiFrequencyTunerChannelSource Null Pointer Error that was happening on startup where the channel rotation monitor was causing the channel to rotate to the next frequency and invoke stop on the current channel source before the channel had started, on some systems where the startup sequence takes a bit longer than normal.

Different solution to resolve possible memory leak with previous solution.

Also resolves issue introduced with #2068 with P25 traffic channel manager where a zero frequency value channel doesn't get started and the traffic channel wasn't being returned to the queue.  This normally only impacts on startup when the P25 frequency bands hadn't yet been received.
