### PR TITLE
#2074 DMR CapMax LRRP GPS Alias List

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
@@ -526,10 +526,11 @@ public class DMRDecoderState extends TimeslotDecoderState
 
         GeoPosition geoPosition = PacketUtil.extractGeoPosition(packet.getPacket());
 
-        if (geoPosition != null) {
+        if (geoPosition != null)
+        {
             PlottableDecodeEvent plottableDecodeEvent = PlottableDecodeEvent.plottableBuilder(DecodeEventType.GPS, packet.getTimestamp())
                     .channel(getCurrentChannel())
-                    .identifiers(new IdentifierCollection(packet.getIdentifiers()))
+                    .identifiers(getMergedIdentifierCollection(packet.getIdentifiers()))
                     .protocol(Protocol.LRRP)
                     .location(geoPosition)
                     .build();


### PR DESCRIPTION
Closes #2074 

DMR Capacity Max LRRP GPS positions sent to map now contain channel identifiers (alias list and system name).
