### PR TITLE
#2081 Windows aarch64 libusb support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'eu.hansolo:charts:1.0.5'
     implementation 'io.github.dsheirer:radio-reference-api:18.0.0'
+    implementation 'io.github.dsheirer:usb4java-native-libraries:1.3.0' //OSX & Windows aarch64 native libs
     implementation 'javax.usb:usb-api:1.0.2'
     implementation 'net.coderazzi:tablefilter-swing:5.5.4'
     implementation 'org.apache.commons:commons-compress:1.26.0'
@@ -119,7 +120,6 @@ dependencies {
     implementation 'org.usb4java:libusb4java:1.3.0'
     implementation 'org.usb4java:usb4java:1.3.0'
     implementation 'org.usb4java:usb4java-javax:1.3.0'
-    implementation 'io.github.dsheirer:libusb4java-darwin-aarch64:1.3.1' //usb4java native lib for OSX M1 cpu
     implementation 'pl.edu.icm:JLargeArrays:1.6'
 }
 


### PR DESCRIPTION
Closes #2081 
Adds libusb native libraries to support Windows aarch64 platforms.

Note: the new library bundles both the Windows and OSX native libraries for aarch64 where previously the OSX library was bundled in a separate jar.