### PR TITLE
#2105 P25 P1/2 Motorola Talker Alias CRC Check

### DIFF
--- a/src/main/java/io/github/dsheirer/edac/CRC16.java
+++ b/src/main/java/io/github/dsheirer/edac/CRC16.java
@@ -1,0 +1,53 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2024 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.edac;
+
+import io.github.dsheirer.bits.BinaryMessage;
+import io.github.dsheirer.bits.IntField;
+
+/**
+ * Utility for calculating the CRC checksum for CRC-16 using polynomial 0x1021 and Initial Fill/Residual of 0xFFFF
+ */
+public class CRC16
+{
+    /**
+     * Calculates the 16-bit CRC checksum for the message using polynomial 0x1021 and residual 0xFFFF
+     * @param message with transmitted 16-bit checksum at the end.
+     * @return true if the check is correct or false if it fails the CRC check.
+     */
+    public static boolean check(BinaryMessage message)
+    {
+        BinaryMessage copy = message.copy();
+        BinaryMessage polynomial = BinaryMessage.loadHex("11021");
+        polynomial.rotateLeft(3, 0, 20);
+        polynomial.setSize(message.size());
+
+        int previousX = 0;
+        for(int x = copy.nextSetBit(0); x < copy.size() - 16; x = copy.nextSetBit(x + 1))
+        {
+            polynomial.rotateRight(x - previousX, previousX, 17 + x);
+            previousX = x;
+            copy.xor(polynomial);
+        }
+
+        IntField crc = IntField.length16(copy.size() - 16);
+        return copy.getInt(crc) == 0xFFFF;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -317,7 +317,7 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
                     break;
             }
         }
-        else if(iMessage instanceof MotorolaTalkerAliasComplete tac)
+        else if(iMessage instanceof MotorolaTalkerAliasComplete tac && tac.isValid())
         {
             mTrafficChannelManager.getTalkerAliasManager().update(tac.getRadio(), tac.getAlias());
         }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderState.java
@@ -262,7 +262,7 @@ public class P25P2DecoderState extends TimeslotDecoderState implements Identifie
                     continueState(State.CALL);
                 }
             }
-            else if(message instanceof MotorolaTalkerAliasComplete tac)
+            else if(message instanceof MotorolaTalkerAliasComplete tac && tac.isValid())
             {
                 mTrafficChannelManager.getTalkerAliasManager().update(tac.getRadio(), tac.getAlias());
             }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/message/mac/structure/motorola/MotorolaTalkerAliasAssembler.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/message/mac/structure/motorola/MotorolaTalkerAliasAssembler.java
@@ -19,7 +19,9 @@
 
 package io.github.dsheirer.module.decode.p25.phase2.message.mac.structure.motorola;
 
+import io.github.dsheirer.bits.BinaryMessage;
 import io.github.dsheirer.bits.CorrectedBinaryMessage;
+import io.github.dsheirer.edac.CRC16;
 import io.github.dsheirer.module.decode.p25.phase1.message.lc.motorola.MotorolaTalkerAliasComplete;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.structure.MacStructure;
 import io.github.dsheirer.protocol.Protocol;
@@ -142,11 +144,36 @@ public class MotorolaTalkerAliasAssembler
             offset += DATA_BLOCK_FRAGMENT_LENGTH;
         }
 
+        trimTalkerAliasLength(reassembled);
         MotorolaTalkerAliasComplete complete = new MotorolaTalkerAliasComplete(reassembled, mHeader.getTalkgroup(),
                 mHeader.getSequence(), mTimeslot, mMostRecentTimestamp, Protocol.APCO25_PHASE2);
+
+        //   Data:  wwwww sss iiiiii aaaa...aaaa cccc
+        //
+        //   - w = WACN
+        //   - s = system
+        //   - i = id
+        //   - a = encoded alias
+        //   - c = CRC-16/GSM of the previous bytes
+        complete.setValid(CRC16.check(reassembled));
 
         mHeader = null;
         mDataBlocks.clear();
         return complete;
+    }
+
+    /**
+     * Trims the message length to exclude pad zeros so that the CRC calculation knows where to finish.
+     * @param message containing an encoded talker alias.
+     */
+    public static void trimTalkerAliasLength(BinaryMessage message)
+    {
+        int x = 72; //Minimum bit size WACN + SYS + RADIO + 1 CHARACTER = 18 Hex Characters * 4 Bits Each
+        while(message.nextSetBit(x) > 0 && x < message.size())
+        {
+            x += 8;
+        }
+
+        message.setSize(x);
     }
 }


### PR DESCRIPTION
Closes #2105.

Adds CRC check to P25 talker aliases to ignore bad alias decodes.