### PR TITLE
#2117 DMR simplex transmissions now frame correctly and added additio…

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRMessageFramer.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRMessageFramer.java
@@ -146,6 +146,15 @@ public class DMRMessageFramer implements Listener<Dibit>
             mBufferATimeslot = cach.getTimeslot();
             mBufferBTimeslot = (mBufferATimeslot == 1 ? 2 : 1);
         }
+        else if(mBufferAPattern.isMobileStationSyncPattern())
+        {
+            mBufferATimeslot = 1;
+            mBufferBTimeslot = 2;
+            if(mBufferBPattern == DMRSyncPattern.UNKNOWN)
+            {
+                mBufferBPattern = DMRSyncPattern.DIRECT_EMPTY_TIMESLOT;
+            }
+        }
 
         dispatch(DMRMessageFactory.create(mBufferAPattern, message, cach, getTimestamp(), mBufferATimeslot));
 
@@ -156,8 +165,8 @@ public class DMRMessageFramer implements Listener<Dibit>
             mBufferAPattern = DMRSyncPattern.getNextVoice(mBufferAPattern);
         }
 
-        //Automatically trigger buffer B burst collection if it is collecting a voice super frame.
-        if(mBufferBPattern.isVoicePattern())
+        //Automatically trigger buffer B burst collection if it is collecting a voice super frame or mobile direct.
+        if(mBufferBPattern.isVoicePattern() || mBufferBPattern == DMRSyncPattern.DIRECT_EMPTY_TIMESLOT)
         {
             mAssemblingBurst = true;
             mBufferAActive = false;
@@ -205,6 +214,16 @@ public class DMRMessageFramer implements Listener<Dibit>
             mBufferBTimeslot = cach.getTimeslot();
             mBufferATimeslot = (mBufferBTimeslot == 1 ? 2 : 1);
         }
+        else if(mBufferBPattern.isMobileStationSyncPattern())
+        {
+            mBufferBTimeslot = 1;
+            mBufferATimeslot = 2;
+
+            if(mBufferAPattern == DMRSyncPattern.UNKNOWN)
+            {
+                mBufferAPattern = DMRSyncPattern.DIRECT_EMPTY_TIMESLOT;
+            }
+        }
 
         dispatch(DMRMessageFactory.create(mBufferBPattern, burst, cach, getTimestamp(), mBufferBTimeslot));
 
@@ -215,8 +234,8 @@ public class DMRMessageFramer implements Listener<Dibit>
             mBufferBPattern = DMRSyncPattern.getNextVoice(mBufferBPattern);
         }
 
-        //Automatically trigger buffer A burst collection if it is collecting a voice super frame.
-        if(mBufferAPattern.isVoicePattern())
+        //Automatically trigger buffer A burst collection if it is collecting a voice super frame or mobile direct.
+        if(mBufferAPattern.isVoicePattern() || mBufferAPattern == DMRSyncPattern.DIRECT_EMPTY_TIMESLOT)
         {
             mAssemblingBurst = true;
             mBufferAActive = true;

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/bptc/BPTC_128_77.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/bptc/BPTC_128_77.java
@@ -35,6 +35,15 @@ public class BPTC_128_77 extends BPTCBase
     }
 
     /**
+     * Allow the base class to attempt to correct multiple rows of 2-bit errors each
+     */
+    @Override
+    protected boolean canCorrectMultiRow2BitErrors()
+    {
+        return true;
+    }
+
+    /**
      * Performs error detection and correction and extracts the payload from the BPTC encoded message.
      * @param message with BPTC encoding.
      * @return decoded message.
@@ -93,15 +102,15 @@ public class BPTC_128_77 extends BPTCBase
     public static void main(String[] args)
     {
         BPTC_128_77 bptc = new BPTC_128_77();
-        String deinterleavedRaw = "00000000000000000000000000000000001000000010010101011001001000010000000000000000000000000110101000010110111100010000111110011111";
+        String deinterleavedRaw = "00000100000101010000001000111000100000000001001101000010001001000000000010101000111100000000001000011000100010110010100100100000";
+        CorrectedBinaryMessage deinterleaved = new CorrectedBinaryMessage(BinaryMessage.load(deinterleavedRaw));
 
-        String deinterleavedReference = "00000000000000000000000000000000000000000010011100011001001000110000000000000000000000000110101000010110111100010000111110011111"; //No errors
+        String deinterleavedReference = "00000100000101010000011000111001100000000001001101000010001101100000000110101000111100000000101000011000100010110010100100100000"; //No errors
         CorrectedBinaryMessage deinterleavedReferenceMessage = new CorrectedBinaryMessage(BinaryMessage.load(deinterleavedReference));
 
-        String interleaved = "00000000000000000000000000010010000100010000001000000010000100010000001100000110001101100000001100000101001000010010010100110011"; //Under test
-        CorrectedBinaryMessage interleavedMessage = new CorrectedBinaryMessage(BinaryMessage.load(interleaved));
+//        String interleaved = "00000000000000000000000000010010000100010000001000000010000100010000001100000110001101100000001100000101001000010010010100110011"; //Under test
+//        CorrectedBinaryMessage interleavedMessage = new CorrectedBinaryMessage(BinaryMessage.load(interleaved));
 //        CorrectedBinaryMessage deinterleaved = deinterleave(interleavedMessage);
-        CorrectedBinaryMessage deinterleaved = new CorrectedBinaryMessage(BinaryMessage.load(deinterleavedRaw));
 
 
         String deinterleavedUncorrected = deinterleaved.toString();
@@ -120,6 +129,7 @@ public class BPTC_128_77 extends BPTCBase
             System.out.println("--------------------------------");
             System.out.println("Residual Error Map:");
             bptc.logErrorMap(deinterleaved);
+            System.out.println("Columns:" + bptc.getColumnErrors(deinterleaved) + " Rows:" + bptc.getRowErrors(deinterleaved));
             System.out.println("--------------------------------");
         }
         else

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/lc/full/FLCAssembler.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/lc/full/FLCAssembler.java
@@ -129,7 +129,12 @@ public class FLCAssembler
         {
             CorrectedBinaryMessage extractedMessage = mBPTC.extract(message);
             FullLCMessage flco = LCMessageFactory.createFull(extractedMessage, timestamp, timeslot, false);
-            flco.setValid(extractedMessage.getCorrectedBitCount() >= 0);
+
+            if(extractedMessage.getCorrectedBitCount() < 0)
+            {
+                flco.setValid(false);
+            }
+
             return flco;
         }
 


### PR DESCRIPTION
Closes #2117 

Resolves issue where the DMR message framer was not correctly handling simplex transmissions from Mobile Subscriber (not Direct mode).  Updated BPTC(128,77) to handle additional error case for FLC messags.
