### PR TITLE
#2120 DMR Decoder resolves index out of bounds error and also updates…

### DIFF
--- a/src/main/java/io/github/dsheirer/edac/Hamming16.java
+++ b/src/main/java/io/github/dsheirer/edac/Hamming16.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,6 +45,13 @@ public class Hamming16 implements IHamming
         if(syndrome == 0)
         {
             return NO_ERRORS;
+        }
+
+        //If the syndrome indicates the error is in the final parity bit position, and we already have odd parity, then
+        //flag it as invalid for multiple errors.
+        if(syndrome == 1 && message.getSubMessage(offset, offset + 16).cardinality() % 2 == 1) //check final parity bit
+        {
+            return MULTIPLE_ERRORS;
         }
 
         for(int index = 0; index < CHECKSUMS.length; index++)

--- a/src/main/java/io/github/dsheirer/edac/Hamming17.java
+++ b/src/main/java/io/github/dsheirer/edac/Hamming17.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -44,6 +44,13 @@ public class Hamming17 implements IHamming
         if(syndrome == 0)
         {
             return NO_ERRORS;
+        }
+
+        //If the syndrome indicates the error is in the final parity bit position, and we already have odd parity, then
+        //flag it as invalid for multiple errors.
+        if(syndrome == 1 && message.getSubMessage(offset, offset + 17).cardinality() % 2 == 1) //check final parity bit
+        {
+            return MULTIPLE_ERRORS;
         }
 
         for(int index = 0; index < CHECKSUMS.length; index++)


### PR DESCRIPTION
#2120 DMR Decoder resolves index out of bounds error that occurs when the symbol period is allowed to increase unchecked causing the optimization/scoring function to access samples outside of the buffer range.

* Updates Hamming 16/17 decoders to correctly identify multi-bit errors when the hamming parity bit is indicated as the syndrome error and flipping that bit causes the parity check to fail.
