### PR TITLE
#2150 Adds AMBE audio tone aliasing support to DMR.

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -694,13 +694,15 @@ public class AliasItemEditor extends Editor<Alias>
             p25Menu.getItems().add(new AddUserStatusItem());
             p25Menu.getItems().add(new AddUnitStatusItem());
             p25Menu.getItems().add(new SeparatorMenuItem());
-            p25Menu.getItems().add(new AddTonesItem("Audio Tones (Phase 2 Only)"));
+            p25Menu.getItems().add(new AddTonesItem("AMBE Audio Tones (Phase 2 Only)"));
 
             Menu dmrMenu = new ProtocolMenu(Protocol.DMR);
             dmrMenu.getItems().add(new AddTalkgroupItem(Protocol.DMR));
             dmrMenu.getItems().add(new AddTalkgroupRangeItem(Protocol.DMR));
             dmrMenu.getItems().add(new AddRadioIdItem(Protocol.DMR));
             dmrMenu.getItems().add(new AddRadioIdRangeItem(Protocol.DMR));
+            dmrMenu.getItems().add(new AddTonesItem("AMBE Audio Tones"));
+
 
             Menu fleetsyncMenu = new ProtocolMenu(Protocol.FLEETSYNC);
             fleetsyncMenu.getItems().add(new AddTalkgroupItem(Protocol.FLEETSYNC));


### PR DESCRIPTION
Closes #2150 

Adds new menu item to playlist editor when creating an alias that allows the user to create an alias identifier for DMR AMBE audio tones.   

Note: this AMBE tone aliasing feature was already available for P25 Phase 2, but was not previously added to DMR, despite both DMR and P25 Phase 2 using the same AMBE audio codec.
