### PR TITLE
Fix adding available channel to wrong queue

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -1799,7 +1799,7 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
                                     .findFirst()
                                     .ifPresent(rejectedFrequency -> {
                                         mAllocatedTrafficChannelMap.remove(rejectedFrequency);
-                                        mAvailablePhase1TrafficChannelQueue.add(channel);
+                                        mAvailablePhase2TrafficChannelQueue.add(channel);
 
                                         //Leave the tracked event in the map so that it doesn't get recreated.  The channel
                                         //processing manager set the 'tuner not available' in the details already


### PR DESCRIPTION
Available channel was added to P1 queue instead of P2 queue. Should close #2132.