### PR TITLE
#2171 OpenJDK Version 23.0.2+9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -218,7 +218,7 @@ String jdk_windows_aarch64 = jdk_base + 'windows-arm64/jdk-22.0.2-full'
 /**
  * Download URLs to download the JDK as part of the gradle build packaging process
  */
-def jdk_download_base = "https://download.bell-sw.com/java/23.0.1+13/bellsoft-jdk23.0.1+13-"
+def jdk_download_base = "https://download.bell-sw.com/java/23.0.2+9/bellsoft-jdk23.0.2+9-"
 def jdk_download_suffix = "-full.tar.gz"
 def jdk_download_linux_aarch64 = jdk_download_base + "linux-aarch64" + jdk_download_suffix
 def jdk_download_linux_x86_64 = jdk_download_base + "linux-amd64" + jdk_download_suffix


### PR DESCRIPTION
Closes #2171 Updates OpenJDK to version 23.0.2+9 release for the build system.
