### PR TITLE
fix for 2198 null mTrafficChannelManager

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
@@ -1490,8 +1490,10 @@ public class DMRDecoderState extends TimeslotDecoderState
             {
                 sb.append("\n\n");
             }
-
-            sb.append(mTrafficChannelManager.getTalkerAliasManager().getAliasSummary());
+            if (mChannel.isTrafficChannel())
+            {
+                sb.append(mTrafficChannelManager.getTalkerAliasManager().getAliasSummary());
+            }
         }
 
         return sb.toString();


### PR DESCRIPTION
Check channel type first. Resolves https://github.com/DSheirer/sdrtrunk/issues/2198