### PR TITLE
#2202 DMR Talker Aliases Now Show In Activity Summary & Add "TA-" As Talker Alias Prefix

### DIFF
--- a/src/main/java/io/github/dsheirer/identifier/alias/DmrTalkerAliasIdentifier.java
+++ b/src/main/java/io/github/dsheirer/identifier/alias/DmrTalkerAliasIdentifier.java
@@ -50,7 +50,7 @@ public class DmrTalkerAliasIdentifier extends TalkerAliasIdentifier
     @Override
     public String toString()
     {
-        return "A-" + super.toString();
+        return "TA-" + super.toString();
     }
 
     public static DmrTalkerAliasIdentifier create(String value)

--- a/src/main/java/io/github/dsheirer/identifier/alias/P25TalkerAliasIdentifier.java
+++ b/src/main/java/io/github/dsheirer/identifier/alias/P25TalkerAliasIdentifier.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,6 +45,12 @@ public class P25TalkerAliasIdentifier extends TalkerAliasIdentifier
     public Protocol getProtocol()
     {
         return Protocol.APCO25;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "TA-" + super.toString();
     }
 
     public static P25TalkerAliasIdentifier create(String value)

--- a/src/main/java/io/github/dsheirer/identifier/alias/TalkerAliasManager.java
+++ b/src/main/java/io/github/dsheirer/identifier/alias/TalkerAliasManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -123,6 +123,7 @@ public class TalkerAliasManager
     {
         StringBuilder sb = new StringBuilder();
         sb.append("Active System Radio Aliases\n");
+        sb.append("  Radio\tTalker Alias (TA-)\n");
         List<Integer> radios = new ArrayList<>(mAliasMap.keySet());
 
         if(radios.size() > 0)
@@ -131,7 +132,7 @@ public class TalkerAliasManager
             for(Integer radio : radios)
             {
                 sb.append("  ").append(radio);
-                sb.append("\t").append(mAliasMap.get(radio).getValue());
+                sb.append("\t").append(mAliasMap.get(radio));
                 sb.append("\n");
             }
         }

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoderState.java
@@ -35,6 +35,7 @@ import io.github.dsheirer.identifier.MutableIdentifierCollection;
 import io.github.dsheirer.identifier.Role;
 import io.github.dsheirer.identifier.alias.DmrTalkerAliasIdentifier;
 import io.github.dsheirer.identifier.integer.IntegerIdentifier;
+import io.github.dsheirer.identifier.radio.RadioIdentifier;
 import io.github.dsheirer.identifier.talkgroup.TalkgroupIdentifier;
 import io.github.dsheirer.log.LoggingSuppressor;
 import io.github.dsheirer.message.EmptyTimeslotPlaceholderMessage;
@@ -354,7 +355,7 @@ public class DMRDecoderState extends TimeslotDecoderState
         //Only respond if this is a standard/control channel (not a traffic channel).
         if(mChannel.isStandardChannel() && getCurrentFrequency() > 0 &&
             restChannel.getDownlinkFrequency() > 0 &&
-            restChannel.getDownlinkFrequency() != getCurrentFrequency() && mTrafficChannelManager != null)
+            restChannel.getDownlinkFrequency() != getCurrentFrequency() && hasTrafficChannelManager())
         {
             mTrafficChannelManager.convertToTrafficChannel(mChannel, getCurrentFrequency(), restChannel,
                 mNetworkConfigurationMonitor);
@@ -1206,6 +1207,13 @@ public class DMRDecoderState extends TimeslotDecoderState
                         DmrTalkerAliasIdentifier updated = DmrTalkerAliasIdentifier
                                 .create(alias.getTalkerAliasIdentifier().getValue() + talkerAlias.getValue());
                         getIdentifierCollection().update(updated);
+
+                        Identifier fromRadio = getIdentifierCollection().getFromIdentifier();
+
+                        if(hasTrafficChannelManager() && fromRadio instanceof RadioIdentifier radio)
+                        {
+                            mTrafficChannelManager.getTalkerAliasManager().update(radio, updated);
+                        }
                     }
                     else
                     {
@@ -1232,6 +1240,13 @@ public class DMRDecoderState extends TimeslotDecoderState
                         DmrTalkerAliasIdentifier updated = DmrTalkerAliasIdentifier.create(talkerAlias.getValue() +
                                 alias.getTalkerAliasIdentifier().getValue());
                         getIdentifierCollection().update(updated);
+
+                        Identifier fromRadio = getIdentifierCollection().getFromIdentifier();
+
+                        if(hasTrafficChannelManager() && fromRadio instanceof RadioIdentifier radio)
+                        {
+                            mTrafficChannelManager.getTalkerAliasManager().update(radio, updated);
+                        }
                     }
                     else
                     {
@@ -1492,10 +1507,13 @@ public class DMRDecoderState extends TimeslotDecoderState
         {
             if(networkAdded)
             {
-                sb.append("\n\n");
+                sb.append("\n");
             }
 
-            sb.append(mTrafficChannelManager.getTalkerAliasManager().getAliasSummary());
+            if(hasTrafficChannelManager())
+            {
+                sb.append(mTrafficChannelManager.getTalkerAliasManager().getAliasSummary());
+            }
         }
 
         return sb.toString();


### PR DESCRIPTION
Closes #2202 
* DMR talker aliases now show in channel activity summary.  
* Added 'TA-' prefix to talker aliases (DMR & P25) to visually highlight what the value represents.