### PR TITLE
#2195 P25P1 NPE When AMBTC Network Status Message Null Data Block(s)

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/pdu/PDUSequence.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/pdu/PDUSequence.java
@@ -1,7 +1,6 @@
 /*
- * ******************************************************************************
- * sdrtrunk
- * Copyright (C) 2014-2019 Dennis Sheirer
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,13 +14,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- * *****************************************************************************
+ * ****************************************************************************
  */
 package io.github.dsheirer.module.decode.p25.phase1.message.pdu;
 
 import io.github.dsheirer.message.IBitErrorProvider;
 import io.github.dsheirer.module.decode.p25.phase1.message.pdu.block.DataBlock;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,7 +72,10 @@ public class PDUSequence implements IBitErrorProvider
      */
     public void addDataBlock(DataBlock dataBlock)
     {
-        mDataBlocks.add(dataBlock);
+        if(dataBlock != null)
+        {
+            mDataBlocks.add(dataBlock);
+        }
     }
 
     public boolean hasDataBlock(int index)

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/pdu/ambtc/AMBTCMessage.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/message/pdu/ambtc/AMBTCMessage.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,7 +60,7 @@ public abstract class AMBTCMessage extends P25P1Message implements IBitErrorProv
 
     public boolean hasDataBlock(int index)
     {
-        return index < getPDUSequence().getDataBlocks().size();
+        return index < getPDUSequence().getDataBlocks().size() && getDataBlock(index) != null;
     }
 
     public UnconfirmedDataBlock getDataBlock(int index)
@@ -69,9 +69,9 @@ public abstract class AMBTCMessage extends P25P1Message implements IBitErrorProv
         {
             DataBlock dataBlock = getPDUSequence().getDataBlocks().get(index);
 
-            if(dataBlock instanceof UnconfirmedDataBlock)
+            if(dataBlock instanceof UnconfirmedDataBlock udb)
             {
-                return (UnconfirmedDataBlock)dataBlock;
+                return udb;
             }
         }
 


### PR DESCRIPTION
Closes #2195 

Fix P25P1 NPE when accessing AMBTC network status message data blocks.
