### PR TITLE
#2193 Removes "Log Settings" Button In Channel View

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/power/ChannelPowerPanel.java
+++ b/src/main/java/io/github/dsheirer/gui/power/ChannelPowerPanel.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -223,7 +223,8 @@ public class ChannelPowerPanel extends JPanel implements Listener<ProcessingChai
                 }
             }
         });
-        labelPanel.add(mLogIndexesButton);
+        //This is a debug button to log the current settings to the app log.
+//        labelPanel.add(mLogIndexesButton);
 
         fftPanel.add(labelPanel, "wrap");
 


### PR DESCRIPTION
Closes #2193 

Removes "Log Settings" button from the channel view.  This is a debug button.
