### PR TITLE
#2219 Byte native buffers now use 8192 (vs 2096) for complex buffer s…

### DIFF
--- a/src/main/java/io/github/dsheirer/buffer/ByteNativeBuffer.java
+++ b/src/main/java/io/github/dsheirer/buffer/ByteNativeBuffer.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ import java.util.Iterator;
  */
 public class ByteNativeBuffer extends AbstractNativeBuffer
 {
-    private static final int FRAGMENT_SIZE = 2048;
+    private static final int FRAGMENT_SIZE = 8192;
     private final static float[] LOOKUP_VALUES;
     private float mAverageDc;
 


### PR DESCRIPTION
Closes #2219 

Byte native buffers now use 8192 (vs 2096) for complex buffer sample size so that the heterodyne channel buffer size is large enough to use with the carrier offset processor that reequires 128 sample buffers.