### PR TITLE
Fixes #2239 by adding the `jdk.incubator.vector` module, ignoring missing tags and malformed HTML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,11 @@ idea {
     }
 }
 
+javadoc {
+    options.addStringOption('-add-modules', 'jdk.incubator.vector')
+    options.addStringOption('Xdoclint:none', '-quiet')
+}
+
 /**
  * Runtime target OS and CPU image names.  We append version here so that version details are at end of zip filename.
  */


### PR DESCRIPTION
Fixes #2239 by adding the `jdk.incubator.vector` module, ignoring missing tags and malformed HTML.