### PR TITLE
#2226 DMR Decoder now employs Equalizer to adjust symbol constellatio…

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/decimate/DecimationFilterFactory.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/decimate/DecimationFilterFactory.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2022 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ public class DecimationFilterFactory
         switch(decimationRate)
         {
             case 0:
+            case 1:
                 return new RealDecimateX0Filter();
             case 2:
                 return new RealDecimateX2Filter();

--- a/src/main/java/io/github/dsheirer/dsp/filter/interpolator/LinearInterpolator.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/interpolator/LinearInterpolator.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,13 +20,10 @@
 package io.github.dsheirer.dsp.filter.interpolator;
 
 /**
- * Linear interpolator for values in the range: -PI > 0 > PI with awareness of phase wrapping across the
- * (+/-) PI boundary.
+ * Linear interpolator.
  */
-public class PhaseAwareLinearInterpolator
+public class LinearInterpolator
 {
-    public static final float TWO_PI = (float)(Math.PI * 2.0);
-
     /**
      * Calculates an interpolated value between x1 and x2 at a linear position mu between 0.0 and 1.0
      * @param x1 first value
@@ -36,39 +33,16 @@ public class PhaseAwareLinearInterpolator
      */
     public static float calculate(float x1, float x2, float mu)
     {
-        //Detect phase wrap at the +PI/-PI boundary ... ignore opposite side of the unit circle at 0 axis
-        if(x1 * x2 < -Math.PI)
+        if(mu < 0 || mu > 1)
         {
-            if(x1 > 0)
-            {
-                float value = x1 + ((TWO_PI + x2 - x1) * mu);
-
-                if(value > Math.PI)
-                {
-                    return -TWO_PI + value;
-                }
-                else
-                {
-                    return value;
-                }
-            }
-            else
-            {
-                float value = x1 + ((-TWO_PI + x2 - x1) * mu);
-
-                if(value < -Math.PI)
-                {
-                    return TWO_PI + value;
-                }
-                else
-                {
-                    return value;
-                }
-            }
+            throw new IllegalArgumentException("mu [" + mu + "] must be between 0 and 1");
         }
-        else
-        {
-            return x1 + ((x2 - x1) * mu);
-        }
+
+        return x1 + ((x2 - x1) * mu);
+    }
+
+    public static float calculate(float x1, float x2, double mu)
+    {
+        return calculate(x1, x2, (float)mu);
     }
 }

--- a/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulator.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulator.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,16 +17,16 @@
  * ****************************************************************************
  */
 
-package io.github.dsheirer.dsp.psk.dqpsk;
+package io.github.dsheirer.dsp.psk.demod;
 
 import io.github.dsheirer.dsp.filter.interpolator.Interpolator;
 import io.github.dsheirer.dsp.filter.interpolator.InterpolatorFactory;
 import io.github.dsheirer.dsp.fm.IDemodulator;
 
 /**
- * DQPSK demodulator base class
+ * Differential demodulator base class
  */
-public abstract class DQPSKDemodulator implements IDemodulator
+public abstract class DifferentialDemodulator implements IDemodulator
 {
     private int mSymbolRate;
     private float mSampleRate;
@@ -43,7 +43,7 @@ public abstract class DQPSKDemodulator implements IDemodulator
      * @param sampleRate in Hertz
      * @param symbolRate symbols per second
      */
-    public DQPSKDemodulator(double sampleRate, int symbolRate)
+    public DifferentialDemodulator(double sampleRate, int symbolRate)
     {
         mSampleRate = (float) sampleRate;
         mSymbolRate = symbolRate;
@@ -51,6 +51,12 @@ public abstract class DQPSKDemodulator implements IDemodulator
         mMu = mSamplesPerSymbol % 1; //Fractional part of the samples per symbol rate
         mInterpolationOffset = (int) Math.floor(mSamplesPerSymbol) - 4; //Interpolate at the middle of 8x samples
         mBufferOverlap = (int) Math.floor(mSamplesPerSymbol) + 4;
+
+        while(mInterpolationOffset < 0)
+        {
+            mInterpolationOffset++;
+            mBufferOverlap++;
+        }
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorFactory.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorFactory.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
  * ****************************************************************************
  */
 
-package io.github.dsheirer.dsp.psk.dqpsk;
+package io.github.dsheirer.dsp.psk.demod;
 
 import io.github.dsheirer.vector.calibrate.CalibrationManager;
 import io.github.dsheirer.vector.calibrate.CalibrationType;
@@ -26,11 +26,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Factory for creating DQPSK demodulators
+ * Factory for creating PSK differential demodulators
  */
-public class DQPSKDemodulatorFactory
+public class DifferentialDemodulatorFactory
 {
-    private static final Logger mLog = LoggerFactory.getLogger(DQPSKDemodulatorFactory.class);
+    private static final Logger mLog = LoggerFactory.getLogger(DifferentialDemodulatorFactory.class);
 
     /**
      * Creates the optimal demodulator using calibration data to select the optimal implementation from scalar and
@@ -39,17 +39,17 @@ public class DQPSKDemodulatorFactory
      * @param symbolRate in Hertz
      * @return demodulator instance
      */
-    public static DQPSKDemodulator getDemodulator(double sampleRate, int symbolRate)
+    public static DifferentialDemodulator getDemodulator(double sampleRate, int symbolRate)
     {
-        Implementation implementation = CalibrationManager.getInstance().getImplementation(CalibrationType.DQPSK_DEMODULATOR);
+        Implementation implementation = CalibrationManager.getInstance().getImplementation(CalibrationType.DIFFERENTIAL_DEMODULATOR);
 
         return switch(implementation)
         {
-            case VECTOR_SIMD_64 -> new DQPSKDemodulatorVector64(sampleRate, symbolRate);
-            case VECTOR_SIMD_128 -> new DQPSKDemodulatorVector128(sampleRate, symbolRate);
-            case VECTOR_SIMD_256 -> new DQPSKDemodulatorVector256(sampleRate, symbolRate);
-            case VECTOR_SIMD_512 -> new DQPSKDemodulatorVector512(sampleRate, symbolRate);
-            default -> new DQPSKDemodulatorScalar(sampleRate, symbolRate); //Includes SCALAR case
+            case VECTOR_SIMD_64 -> new DifferentialDemodulatorVector64(sampleRate, symbolRate);
+            case VECTOR_SIMD_128 -> new DifferentialDemodulatorVector128(sampleRate, symbolRate);
+            case VECTOR_SIMD_256 -> new DifferentialDemodulatorVector256(sampleRate, symbolRate);
+            case VECTOR_SIMD_512 -> new DifferentialDemodulatorVector512(sampleRate, symbolRate);
+            default -> new DifferentialDemodulatorScalar(sampleRate, symbolRate); //Includes SCALAR case
         };
     }
 }

--- a/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector128.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector128.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,19 +17,22 @@
  * ****************************************************************************
  */
 
-package io.github.dsheirer.dsp.psk.dqpsk;
+package io.github.dsheirer.dsp.psk.demod;
 
 import java.util.Arrays;
 import jdk.incubator.vector.FloatVector;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * DQPSK demodulator that uses Vector SIMD calculations for demodulating the sample stream.
+ * Differential demodulator that uses Vector SIMD 128 calculations for demodulating the sample stream.
  */
-public class DQPSKDemodulatorVector256 extends DQPSKDemodulator
+public class DifferentialDemodulatorVector128 extends DifferentialDemodulator
 {
-    private static final VectorSpecies<Float> VECTOR_SPECIES = FloatVector.SPECIES_256;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DifferentialDemodulatorVector128.class);
+    private static final VectorSpecies<Float> VECTOR_SPECIES = FloatVector.SPECIES_128;
 
     /**
      * Constructor
@@ -37,7 +40,7 @@ public class DQPSKDemodulatorVector256 extends DQPSKDemodulator
      * @param sampleRate in Hertz
      * @param symbolRate symbols per second
      */
-    public DQPSKDemodulatorVector256(double sampleRate, int symbolRate)
+    public DifferentialDemodulatorVector128(double sampleRate, int symbolRate)
     {
         super(sampleRate, symbolRate);
     }
@@ -72,7 +75,7 @@ public class DQPSKDemodulatorVector256 extends DQPSKDemodulator
 
         float[] interpolatedI = new float[VECTOR_SPECIES.length()];
         float[] interpolatedQ = new float[VECTOR_SPECIES.length()];
-        float[] decodedPhases = new float[sampleLength];
+        float[] decodedPhases = new float[i.length];
         FloatVector iPrevious, qPreviousConjugate, iCurrent, qCurrent, differentialI, differentialQ;
 
         //Differential demodulation.

--- a/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector256.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector256.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,25 +17,27 @@
  * ****************************************************************************
  */
 
-package io.github.dsheirer.dsp.psk.dqpsk;
+package io.github.dsheirer.dsp.psk.demod;
 
 import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
 
 /**
- * DQPSK demodulator that uses scalar calculations for demodulating the sample stream.
+ * Differential demodulator that uses Vector SIMD calculations for demodulating the sample stream.
  */
-public class DQPSKDemodulatorScalar extends DQPSKDemodulator
+public class DifferentialDemodulatorVector256 extends DifferentialDemodulator
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DQPSKDemodulatorScalar.class);
+    private static final VectorSpecies<Float> VECTOR_SPECIES = FloatVector.SPECIES_256;
 
     /**
      * Constructor
      *
+     * @param sampleRate in Hertz
      * @param symbolRate symbols per second
      */
-    public DQPSKDemodulatorScalar(double sampleRate, int symbolRate)
+    public DifferentialDemodulatorVector256(double sampleRate, int symbolRate)
     {
         super(sampleRate, symbolRate);
     }
@@ -55,6 +57,10 @@ public class DQPSKDemodulatorScalar extends DQPSKDemodulator
         int requiredBufferLength = sampleLength + bufferOverlap;
         if(mIBuffer.length != requiredBufferLength)
         {
+            if(i.length % VECTOR_SPECIES.length() != 0)
+            {
+                throw new IllegalArgumentException("Buffer length must be a multiple of " + VECTOR_SPECIES.length());
+            }
             mIBuffer = Arrays.copyOf(mIBuffer, requiredBufferLength);
             mQBuffer = Arrays.copyOf(mQBuffer, requiredBufferLength);
         }
@@ -62,26 +68,35 @@ public class DQPSKDemodulatorScalar extends DQPSKDemodulator
         //Append new samples to the residual samples from the previous buffer.
         System.arraycopy(i, 0, mIBuffer, bufferOverlap, sampleLength);
         System.arraycopy(q, 0, mQBuffer, bufferOverlap, sampleLength);
-        //mIDecoded, mQDecoded and mPhase will be filled below during the decoding process.
 
-        float[] decodedPhases = new float[i.length];
-        float iPrevious, qPreviousConjugate, iCurrent, qCurrent, differentialI, differentialQ;
+        float[] interpolatedI = new float[VECTOR_SPECIES.length()];
+        float[] interpolatedQ = new float[VECTOR_SPECIES.length()];
+        float[] decodedPhases = new float[sampleLength];
+        FloatVector iPrevious, qPreviousConjugate, iCurrent, qCurrent, differentialI, differentialQ;
 
         //Differential demodulation.
-        for(int x = 0; x < sampleLength; x++)
+        for(int x = 0; x < sampleLength; x += VECTOR_SPECIES.length())
         {
-            iPrevious = mIBuffer[x];
-            qPreviousConjugate = -mQBuffer[x]; //Complex Conjugate
+            iPrevious = FloatVector.fromArray(VECTOR_SPECIES, mIBuffer, x);
+            qPreviousConjugate = FloatVector.fromArray(VECTOR_SPECIES, mQBuffer, x).neg(); //Complex Conjugate
 
             int offset = mInterpolationOffset + x;
-            iCurrent = mInterpolator.filter(mIBuffer, offset, mu);
-            qCurrent = mInterpolator.filter(mQBuffer, offset, mu);
+            int index;
+            for(int y = 0; y < VECTOR_SPECIES.length(); y++)
+            {
+                index = offset + y;
+                interpolatedI[y] = mInterpolator.filter(mIBuffer, index, mu);
+                interpolatedQ[y] = mInterpolator.filter(mQBuffer, index, mu);
+            }
+            iCurrent = FloatVector.fromArray(VECTOR_SPECIES, interpolatedI, 0);
+            qCurrent = FloatVector.fromArray(VECTOR_SPECIES, interpolatedQ, 0);
 
             //Multiply current complex sample by the complex conjugate of previous complex sample.
-            differentialI = (iPrevious * iCurrent) - (qPreviousConjugate * qCurrent);
-            differentialQ = (iPrevious * qCurrent) + (iCurrent * qPreviousConjugate);
+            differentialI = iPrevious.mul(iCurrent).sub(qPreviousConjugate.mul(qCurrent));
+            differentialQ = iPrevious.mul(qCurrent).add(iCurrent.mul(qPreviousConjugate));
 
-            decodedPhases[x] = (float)Math.atan2(differentialQ, differentialI);
+            //Calculate phase angles using Arc Tangent and export to the decoded phases array.
+            differentialQ.lanewise(VectorOperators.ATAN2, differentialI).intoArray(decodedPhases, x);
         }
 
         return decodedPhases;

--- a/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector512.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector512.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
  * ****************************************************************************
  */
 
-package io.github.dsheirer.dsp.psk.dqpsk;
+package io.github.dsheirer.dsp.psk.demod;
 
 import java.util.Arrays;
 import jdk.incubator.vector.FloatVector;
@@ -27,20 +27,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * DQPSK demodulator that uses Vector SIMD 64 calculations for demodulating the sample stream.
+ * Differential demodulator that uses Vector SIMD 512 calculations for demodulating the sample stream.
  */
-public class DQPSKDemodulatorVector64 extends DQPSKDemodulator
+public class DifferentialDemodulatorVector512 extends DifferentialDemodulator
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DQPSKDemodulatorVector64.class);
-    private static final VectorSpecies<Float> VECTOR_SPECIES = FloatVector.SPECIES_64;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DifferentialDemodulatorVector512.class);
+    private static final VectorSpecies<Float> VECTOR_SPECIES = FloatVector.SPECIES_512;
 
     /**
      * Constructor
      *
-     * @param sampleRate in Hertz
      * @param symbolRate symbols per second
      */
-    public DQPSKDemodulatorVector64(double sampleRate, int symbolRate)
+    public DifferentialDemodulatorVector512(double sampleRate, int symbolRate)
     {
         super(sampleRate, symbolRate);
     }
@@ -71,11 +70,10 @@ public class DQPSKDemodulatorVector64 extends DQPSKDemodulator
         //Append new samples to the residual samples from the previous buffer.
         System.arraycopy(i, 0, mIBuffer, bufferOverlap, sampleLength);
         System.arraycopy(q, 0, mQBuffer, bufferOverlap, sampleLength);
-        //mIDecoded, mQDecoded and mPhase will be filled below during the decoding process.
 
         float[] interpolatedI = new float[VECTOR_SPECIES.length()];
         float[] interpolatedQ = new float[VECTOR_SPECIES.length()];
-        float[] decodedPhases = new float[i.length];
+        float[] decodedPhases = new float[sampleLength];
         FloatVector iPrevious, qPreviousConjugate, iCurrent, qCurrent, differentialI, differentialQ;
 
         //Differential demodulation.

--- a/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector64.java
+++ b/src/main/java/io/github/dsheirer/dsp/psk/demod/DifferentialDemodulatorVector64.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
  * ****************************************************************************
  */
 
-package io.github.dsheirer.dsp.psk.dqpsk;
+package io.github.dsheirer.dsp.psk.demod;
 
 import java.util.Arrays;
 import jdk.incubator.vector.FloatVector;
@@ -27,19 +27,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * DQPSK demodulator that uses Vector SIMD 512 calculations for demodulating the sample stream.
+ * Differential demodulator that uses Vector SIMD 64 calculations for demodulating the sample stream.
  */
-public class DQPSKDemodulatorVector512 extends DQPSKDemodulator
+public class DifferentialDemodulatorVector64 extends DifferentialDemodulator
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DQPSKDemodulatorVector512.class);
-    private static final VectorSpecies<Float> VECTOR_SPECIES = FloatVector.SPECIES_512;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DifferentialDemodulatorVector64.class);
+    private static final VectorSpecies<Float> VECTOR_SPECIES = FloatVector.SPECIES_64;
 
     /**
      * Constructor
      *
+     * @param sampleRate in Hertz
      * @param symbolRate symbols per second
      */
-    public DQPSKDemodulatorVector512(double sampleRate, int symbolRate)
+    public DifferentialDemodulatorVector64(double sampleRate, int symbolRate)
     {
         super(sampleRate, symbolRate);
     }
@@ -70,10 +71,11 @@ public class DQPSKDemodulatorVector512 extends DQPSKDemodulator
         //Append new samples to the residual samples from the previous buffer.
         System.arraycopy(i, 0, mIBuffer, bufferOverlap, sampleLength);
         System.arraycopy(q, 0, mQBuffer, bufferOverlap, sampleLength);
+        //mIDecoded, mQDecoded and mPhase will be filled below during the decoding process.
 
         float[] interpolatedI = new float[VECTOR_SPECIES.length()];
         float[] interpolatedQ = new float[VECTOR_SPECIES.length()];
-        float[] decodedPhases = new float[sampleLength];
+        float[] decodedPhases = new float[i.length];
         FloatVector iPrevious, qPreviousConjugate, iCurrent, qCurrent, differentialI, differentialQ;
 
         //Differential demodulation.

--- a/src/main/java/io/github/dsheirer/dsp/symbol/Dibit.java
+++ b/src/main/java/io/github/dsheirer/dsp/symbol/Dibit.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,10 +21,10 @@ package io.github.dsheirer.dsp.symbol;
 
 public enum Dibit
 {
-    D01_PLUS_3(false, true, 1, 4, 1, (float)(Math.PI / 4 * 3), (float)-Math.sin(Math.toRadians(45)), (float)Math.sin(Math.toRadians(45))),
-    D00_PLUS_1(false, false, 0, 0, 0, (float)(Math.PI / 4.0), (float)Math.sin(Math.toRadians(45)), (float)Math.sin(Math.toRadians(45))),
-    D10_MINUS_1(true, false, 2, 8, 2, (float)(Math.PI / -4.0), (float)Math.sin(Math.toRadians(45)), (float)-Math.sin(Math.toRadians(45))),
-    D11_MINUS_3(true, true, 3, 12, 3, (float)(Math.PI / 4 * -3), (float)-Math.sin(Math.toRadians(45)), (float)-Math.sin(Math.toRadians(45)));
+    D01_PLUS_3(false, true, 1, 4, 1, (float)((Math.PI / 4) * 3)),
+    D00_PLUS_1(false, false, 0, 0, 0, (float)(Math.PI / 4)),
+    D10_MINUS_1(true, false, 2, 8, 2, (float)(Math.PI / -4)),
+    D11_MINUS_3(true, true, 3, 12, 3, (float)((Math.PI / 4) * -3));
 
     private boolean mBit1;
     private boolean mBit2;
@@ -32,8 +32,6 @@ public enum Dibit
     private int mHighValue;
     private int mValue;
     private float mPhase;
-    private float mIdealI;
-    private float mIdealQ;
 
     /**
      * Dibit constructor.
@@ -43,10 +41,8 @@ public enum Dibit
      * @param highValue integer value of the high order bit
      * @param value integer value combined of both bits.
      * @param phase optimal phase value for this symbol when transmitted.
-     * @param idealI ideal inphase value for this symbol when transmitted.
-     * @param idealQ ideal quadrature value for this symbol when transmitted.
      */
-    Dibit(boolean bit1, boolean bit2, int lowValue, int highValue, int value, float phase, float idealI, float idealQ)
+    Dibit(boolean bit1, boolean bit2, int lowValue, int highValue, int value, float phase)
     {
         mBit1 = bit1;
         mBit2 = bit2;
@@ -54,8 +50,6 @@ public enum Dibit
         mHighValue = highValue;
         mValue = value;
         mPhase = phase;
-        mIdealI = idealI;
-        mIdealQ = idealQ;
     }
 
     /**
@@ -73,24 +67,6 @@ public enum Dibit
     public float getIdealPhase()
     {
         return mPhase;
-    }
-
-    /**
-     * Ideal inphase value when this symbol is transmitted.
-     * @return ideal I
-     */
-    public float getIdealI()
-    {
-        return mIdealI;
-    }
-
-    /**
-     * Ideal quadrature value when this symbol is transmitted.
-     * @return ideal Q
-     */
-    public float getIdealQ()
-    {
-        return mIdealQ;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
+++ b/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -609,14 +609,14 @@ public class SDRTrunk implements Listener<TunerEvent>
 
                 final Path captureFile = mUserPreferences.getDirectoryPreference().getDirectoryScreenCapture().resolve(filename);
 
-                EventQueue.invokeLater(() -> {
+                ThreadPool.CACHED.submit(() -> {
                     try
                     {
                         ImageIO.write(image, "png", captureFile.toFile());
                     }
                     catch(IOException e)
                     {
-                        mLog.error("Couldn't write screen capture to file [" + captureFile.toString() + "]", e);
+                        mLog.error("Couldn't write screen capture to file [" + captureFile + "]", e);
                     }
                 });
             }

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRDecoder.java
@@ -21,10 +21,13 @@ package io.github.dsheirer.module.decode.dmr;
 
 import io.github.dsheirer.alias.AliasList;
 import io.github.dsheirer.dsp.filter.FilterFactory;
+import io.github.dsheirer.dsp.filter.decimate.DecimationFilterFactory;
+import io.github.dsheirer.dsp.filter.decimate.IRealDecimationFilter;
 import io.github.dsheirer.dsp.filter.fir.FIRFilterSpecification;
 import io.github.dsheirer.dsp.filter.fir.real.IRealFilter;
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulator;
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulatorFactory;
+import io.github.dsheirer.dsp.filter.fir.real.RealFIRFilter;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulator;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulatorFactory;
 import io.github.dsheirer.dsp.squelch.PowerMonitor;
 import io.github.dsheirer.message.IMessage;
 import io.github.dsheirer.message.SyncLossMessage;
@@ -87,12 +90,16 @@ public class DMRDecoder extends Decoder implements IByteBufferProvider, IComplex
     private static final int SYMBOL_RATE = 4800;
     private static final float MAXIMUM_CARRIER_OFFSET = 5000.0f; //Threshold for retuning the signal.
     private static final Map<Double,float[]> BASEBAND_FILTERS = new HashMap<>();
-    private DQPSKDemodulator mDemodulator;
+    private DifferentialDemodulator mDemodulator;
     private final DMRMessageFramer mMessageFramer;
     private final DMRSoftSymbolProcessor mSymbolProcessor;
     private final DMRMessageProcessor mMessageProcessor;
     private IRealFilter mIBasebandFilter;
     private IRealFilter mQBasebandFilter;
+    private IRealDecimationFilter mDecimationFilterI;
+    private IRealDecimationFilter mDecimationFilterQ;
+    private RealFIRFilter mRRCFilterI;
+    private RealFIRFilter mRRCFilterQ;
     private final PowerMonitor mPowerMonitor = new PowerMonitor();
     private final CarrierOffsetProcessor mCarrierOffsetProcessor = new CarrierOffsetProcessor();
 
@@ -134,13 +141,40 @@ public class DMRDecoder extends Decoder implements IByteBufferProvider, IComplex
         }
 
         mPowerMonitor.setSampleRate((int)sampleRate);
+        mCarrierOffsetProcessor.setSampleRate(sampleRate);
+
         mIBasebandFilter = FilterFactory.getRealFilter(getBasebandFilter(sampleRate));
         mQBasebandFilter = FilterFactory.getRealFilter(getBasebandFilter(sampleRate));
-        mDemodulator = DQPSKDemodulatorFactory.getDemodulator(sampleRate, SYMBOL_RATE);
+
+        int decimation = 1;
+
+        //Identify decimation that gets us as close to 4.0 Samples Per Symbol as possible (19.2 kHz)
+        while((sampleRate / decimation) >= 38400)
+        {
+            decimation *= 2;
+        }
+
+        mDecimationFilterI = DecimationFilterFactory.getRealDecimationFilter(decimation);
+        mDecimationFilterQ = DecimationFilterFactory.getRealDecimationFilter(decimation);
+
+        float decimatedSampleRate = (float)sampleRate / decimation;
+        float rrcAlpha = Math.abs((float)(5760.0 / decimatedSampleRate));
+        int symbolLength = (int)Math.floor((-44 * rrcAlpha) + 33);
+        symbolLength += symbolLength % 2; //Make the symbol length even
+
+        if(symbolLength < 0)
+        {
+            symbolLength = 2;
+        }
+
+        float[] taps = FilterFactory.getRootRaisedCosine(decimatedSampleRate / SYMBOL_RATE, symbolLength, rrcAlpha);
+        mRRCFilterI = new RealFIRFilter(taps);
+        mRRCFilterQ = new RealFIRFilter(taps);
+
+        mDemodulator = DifferentialDemodulatorFactory.getDemodulator(decimatedSampleRate, SYMBOL_RATE);
         mSymbolProcessor.setSamplesPerSymbol(mDemodulator.getSamplesPerSymbol());
         mMessageFramer.setListener(mMessageProcessor);
         mMessageProcessor.setMessageListener(getMessageListener());
-        mCarrierOffsetProcessor.setSampleRate(sampleRate);
     }
 
     /**
@@ -150,6 +184,7 @@ public class DMRDecoder extends Decoder implements IByteBufferProvider, IComplex
     @Override
     public void receive(ComplexSamples samples)
     {
+
         mMessageFramer.setTimestamp(samples.timestamp());
 
         float[] i = mIBasebandFilter.filter(samples.i());
@@ -157,6 +192,12 @@ public class DMRDecoder extends Decoder implements IByteBufferProvider, IComplex
 
         //Process buffer for power measurements
         mPowerMonitor.process(i, q);
+
+        i = mDecimationFilterI.decimateReal(i);
+        q = mDecimationFilterQ.decimateReal(q);
+
+        i = mRRCFilterI.filter(i);
+        q = mRRCFilterQ.filter(q);
 
         float[] demodulated = mDemodulator.demodulate(i, q);
         mSymbolProcessor.receive(demodulated);
@@ -312,19 +353,21 @@ public class DMRDecoder extends Decoder implements IByteBufferProvider, IComplex
 
         //        String directory = "D:\\DQPSK Equalizer Research\\"; //Windows
         String directory = "/media/denny/T9/DQPSK Equalizer Research/"; //Linux
-//        String file = directory + "DMR_1_CAPPLUS.wav";
+        String file = directory + "DMR_1_CAPPLUS.wav";
 //        String file = directory + "DMR_2_CAPPLUS.wav";
 //        String file = directory + "DMR_3_CAPPLUS.wav";
 //        String file = directory + "20230819_064211_451250000_SaiaNet_Syracuse_Control_29_baseband.wav";
 //        String file = directory + "20230819_064344_454575000_JPJ_Communications_(DMR)_Madison_Control_28_baseband.wav";
-//        String file = directory + "DMR_DCDM_4_4_baseband_20220318_142716.wav";
 //        String file = directory + "DMR_4_20241213_Saianet.wav";
-        String file = directory + "DMR_5_20241217_031219_451425000_SaiaNet_Onondaga_SaiaNet_Control_1_baseband.wav";
+//        String file = directory + "DMR_5_20241217_031219_451425000_SaiaNet_Onondaga_SaiaNet_Control_1_baseband.wav";
 //        String file = directory + "DMR_6_20241217_031511_451425000_SaiaNet_Onondaga_SaiaNet_Control_50_baseband.wav";
 //        String file = directory + "DMR_7_20241217_031651_451250000_SaiaNet_Onondaga_SaiaNet_Control_50_baseband.wav";
 //        String file = directory + "DMR_8_20241217_031845_461662500_SaiaNet_(Tier_III)_Onondaga_Control_25_baseband.wav";
 //        String file = directory + "DMR_9_CAPPLUS_encrypted_American_Airlines_Maricopa_Control_29_baseband.wav";
 //        String file = directory + "DMR_10_CAP_ENCRYPTED_20241222_035408_935487500_American_Airlines_Maricopa_Control_1_baseband.wav";
+//        String file = directory + "DMR_12_20250420_061639_451250000_SaiaNet_Onondaga_SaiaNet-Control_1_baseband.wav";
+//        String file = directory + "DMR_17_20250516_053150_451425000_SaiaNet_Onondaga_SaiaNet-Control_1_baseband.wav";
+//        String file = directory + "DMR_19_POLY_2CHAN_20250611_032038_451250000_SaiaNet_Onondaga_SaiaNet-Control_1_baseband.wav";
 
         boolean autoReplay = false;
 
@@ -386,6 +429,11 @@ public class DMRDecoder extends Decoder implements IByteBufferProvider, IComplex
                 boolean logCACH = false;
                 boolean logIdles = false;
                 boolean logEverything = true;
+
+                if(iMessage instanceof SyncLossMessage)
+                {
+                    int a = 0;
+                }
 
                 if(!logEverything && logFLC)
                 {

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRHardSymbolProcessor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRHardSymbolProcessor.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -54,7 +54,7 @@ public class DMRHardSymbolProcessor
         Dibit ejected = mDibitDelayLine.insert(dibit);
         mMessageFramer.receive(ejected);
 
-        if(mSyncDetector.process(dibit))
+        if(mSyncDetector.processAndDetect(dibit))
         {
             mMessageFramer.syncDetected(mSyncDetector.getDetectedPattern());
         }

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRMessageFramer.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRMessageFramer.java
@@ -112,6 +112,15 @@ public class DMRMessageFramer implements Listener<Dibit>
         }
     }
 
+    /**
+     * Indicates if the framer is assembling a burst and the active timeslot is assembling a voice superframe.
+     */
+    public boolean isVoiceSuperFrame()
+    {
+        return mAssemblingBurst && ((mBufferAActive && mBufferAPattern.isVoicePattern()) ||
+                                    (!mBufferAActive && mBufferBPattern.isVoicePattern()));
+    }
+
     private void dispatchBufferA()
     {
         mDibitCounter -= 144;

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DibitDelayLine.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DibitDelayLine.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -74,5 +74,24 @@ public class DibitDelayLine
             mDelayLine[mPointer++] = dibit;
             mPointer %= mLength;
         }
+    }
+
+    public void log()
+    {
+        StringBuilder sb = new StringBuilder();
+
+        int pointer = mPointer;
+        for(int i = 0; i < mDelayLine.length; i++)
+        {
+            Dibit dibit = mDelayLine[pointer];
+            sb.append(dibit.getBit1() ? "1" : "0");
+            sb.append(dibit.getBit2() ? "1" : "0");
+            sb.append(" ");
+
+            pointer++;
+            pointer = pointer % mLength;
+        }
+
+        System.out.println(sb);
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/DMRDataMessageFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/message/data/DMRDataMessageFactory.java
@@ -302,8 +302,8 @@ public class DMRDataMessageFactory
      */
     private static CorrectedBinaryMessage getPayload(CorrectedBinaryMessage message)
     {
-        CorrectedBinaryMessage descrambled = extract(message);
-        return BPTC_196_96.extract(descrambled);
+        CorrectedBinaryMessage extracted = extract(message);
+        return BPTC_196_96.extract(extracted);
     }
 
     /**
@@ -321,7 +321,7 @@ public class DMRDataMessageFactory
             {
                 extracted.add(message.get(i));
             }
-            for(int i = 190; i < 190 + 98; i++)
+            for(int i = 190; i < 288; i++)
             {
                 extracted.add(message.get(i));
             }

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/sync/DMRSoftSyncDetector.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/sync/DMRSoftSyncDetector.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,29 +65,32 @@ public abstract class DMRSoftSyncDetector extends DMRSyncDetector
 
     /**
      * Worker method to be implemented by the subclass implementation.
-     * @return best sync correlation score where the best detected pattern is available at
-     * @see DmrSyncDetector#getDetectedPattern() method.
+     * @return best sync correlation score where the best detected pattern is available at getDetectedPattern().
      */
-    protected abstract float calculate();
+    public abstract float calculate();
 
     /**
      * Processes the demodulated soft symbol value and returns a correlation value against the preceding 24 soft
      * symbols that include this recent soft symbol.
      *
      * @param dibitSymbol to process that represents the soft demodulated symbol value in phase angle/radians.
-     * @return correlation score.
      */
-    public float process(float dibitSymbol)
+    public void process(float dibitSymbol)
     {
-        //Constrain symbol to maximum positive or negative value to limit noisy symbols.
-        dibitSymbol = Math.min(dibitSymbol, MAX_POSITIVE);
-        dibitSymbol = Math.max(dibitSymbol, MAX_NEGATIVE);
-
         mSymbols[mSymbolPointer] = dibitSymbol;
         mSymbols[mSymbolPointer + 24] = dibitSymbol;
         mSymbolPointer++;
         mSymbolPointer %= 24;
+    }
 
+    /**
+     * Process the symbol and calculate the sync detection score.
+     * @param symbol to process
+     * @return sync detection score.
+     */
+    public float processAndCalculate(float symbol)
+    {
+        process(symbol);
         return calculate();
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/sync/DMRSoftSyncDetectorVector256.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/sync/DMRSoftSyncDetectorVector256.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/sync/visualizer/ISyncResultsListener.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/sync/visualizer/ISyncResultsListener.java
@@ -1,0 +1,39 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.dmr.sync.visualizer;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Interface for receiving sync detection results from a demodulated I/Q stream
+ */
+public interface ISyncResultsListener
+{
+    /**
+     * Receive results
+     * @param symbols for the detected sync
+     * @param sync pattern symbols (ideal)
+     * @param samples demodulated samples
+     * @param syncIntervals for timing of each symbol in the samples array
+     * @param label to display in the UI
+     * @param release that pauses execution until the user acknowledges the displayed sync results.  Decrement the latch to release.
+     */
+    void receive(float[] symbols, float[] sync, float[] samples, float[] syncIntervals, String label, CountDownLatch release);
+}

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/sync/visualizer/SyncResultsViewer.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/sync/visualizer/SyncResultsViewer.java
@@ -1,0 +1,97 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.dmr.sync.visualizer;
+
+import io.github.dsheirer.util.SwingUtils;
+import java.util.concurrent.CountDownLatch;
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.Scene;
+
+import javax.swing.JFrame;
+
+/**
+ * Utility for viewing sync detection results
+ */
+public class SyncResultsViewer implements ISyncResultsListener
+{
+    private ISyncResultsListener mListener;
+
+    public SyncResultsViewer()
+    {
+        initUI();
+    }
+
+    /**
+     * View sync detection results.
+     * @param symbols that were detected
+     * @param samples for the symbols
+     * @param sync that was detected
+     * @param syncIntervals symbol timing interval pointers into the I/Q sample arrays
+     * @param label to display to the user
+     * @param release latch to release via the UI when done viewing these results
+     */
+    @Override
+    public void receive(float[] symbols, float[] sync, float[] samples, float[] syncIntervals, String label, CountDownLatch release)
+    {
+        if(mListener != null)
+        {
+            mListener.receive(symbols, samples, sync, syncIntervals, label, release);
+        }
+    }
+
+    /**
+     * Initializes the viewer UI
+     */
+    private void initUI()
+    {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        final JFXPanel fxPanel = new JFXPanel();
+        Platform.runLater(() -> {
+            Platform.setImplicitExit(false);
+            SyncVisualizer syncVisualizer = new SyncVisualizer();
+            mListener = syncVisualizer;
+            Scene scene = new Scene(syncVisualizer, 1400, 1000);
+            fxPanel.setScene(scene);
+            fxPanel.setVisible(true);
+
+            JFrame frame = new JFrame();
+            frame.setTitle("Sync Results Viewer");
+            frame.setContentPane(fxPanel);
+            frame.setSize(1400, 1000);
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.setLocationRelativeTo(null);
+            SwingUtils.run(() -> {
+                frame.setVisible(true);
+                latch.countDown();
+            });
+        });
+
+        try
+        {
+            latch.await();
+        }
+        catch(InterruptedException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/sync/visualizer/SyncVisualizer.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/sync/visualizer/SyncVisualizer.java
@@ -1,0 +1,144 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.dmr.sync.visualizer;
+
+import java.util.concurrent.CountDownLatch;
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.ScatterChart;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+/**
+ * JavaFX viewer application for visualizing sample buffers and detected sync patterns
+ */
+public class SyncVisualizer extends VBox implements ISyncResultsListener
+{
+    private static final float SYMBOL = (float)(Math.PI / 4.0);
+    private final NumberAxis mConstellationI = new NumberAxis();
+    private final NumberAxis mConstellationQ = new NumberAxis();
+    private final NumberAxis mSampleTiming = new NumberAxis();
+    private final NumberAxis mSamplePhase = new NumberAxis();
+    private final ScatterChart<Number,Number> mConstellationChart = new ScatterChart<>(mConstellationI, mConstellationQ);
+    private final LineChart<Number,Number> mSampleChart = new LineChart<>(mSampleTiming, mSamplePhase);
+    private final Button mReleaseButton = new Button("Next Sync");
+    private final Label mPatternLabel = new Label();
+    private CountDownLatch mRelease;
+
+    /**
+     * Constructs an instance
+     */
+    public SyncVisualizer()
+    {
+        setPadding(new Insets(5));
+        mConstellationI.setLabel("Inphase");
+        mConstellationQ.setLabel("Quadrature");
+        mSampleTiming.setLabel("Sample Timing");
+        mSamplePhase.setLabel("Sample Phase (+/- PI)");
+
+        mReleaseButton.setOnAction(e ->
+        {
+            if(mRelease != null)
+            {
+                mRelease.countDown();
+                mReleaseButton.setDisable(true);
+            }
+        });
+
+        mConstellationChart.setPrefSize(400, 400);
+        HBox hbox = new HBox();
+        hbox.getChildren().add(mConstellationChart);
+//        VBox.setVgrow(hbox, Priority.ALWAYS);
+        VBox.setVgrow(mSampleChart, Priority.ALWAYS);
+
+        HBox buttons = new HBox();
+        buttons.setAlignment(Pos.BASELINE_CENTER);
+        buttons.setSpacing(10);
+        buttons.getChildren().addAll(mReleaseButton, mPatternLabel);
+        VBox.setVgrow(buttons, Priority.NEVER);
+
+        getChildren().addAll(hbox, mSampleChart, buttons);
+    }
+
+    @Override
+    public void receive(float[] symbols, float[] samples, float[] sync, float[] syncIntervals, String label, CountDownLatch latch)
+    {
+        mRelease = latch;
+        mReleaseButton.setDisable(latch == null);
+
+        Platform.runLater(() -> {
+            XYChart.Series<Number,Number> constellationIdeal = new XYChart.Series<>();
+            constellationIdeal.setName("Constellation Ideal");
+            float PI_4 = (float)(Math.PI / 4);
+            constellationIdeal.getData().add(new XYChart.Data<>(PI_4, PI_4));
+            constellationIdeal.getData().add(new XYChart.Data<>(PI_4, -PI_4));
+            constellationIdeal.getData().add(new XYChart.Data<>(-PI_4, PI_4));
+            constellationIdeal.getData().add(new XYChart.Data<>(-PI_4, -PI_4));
+            constellationIdeal.getData().add(new XYChart.Data<>(1, 0));
+            constellationIdeal.getData().add(new XYChart.Data<>(-1, 0));
+            constellationIdeal.getData().add(new XYChart.Data<>(0, 1));
+            constellationIdeal.getData().add(new XYChart.Data<>(0, -1));
+
+            mConstellationChart.getData().clear();
+            mConstellationChart.getData().add(constellationIdeal);
+
+            XYChart.Series<Number,Number> constellation = new XYChart.Series<>();
+            constellation.setName("Constellation");
+
+            for(int x = 0; x < symbols.length; x++)
+            {
+                constellation.getData().add(new XYChart.Data<>(Math.cos(symbols[x]), Math.sin(symbols[x])));
+            }
+
+            mConstellationChart.getData().add(constellation);
+
+
+            XYChart.Series<Number,Number> sampleSeries = new XYChart.Series<>();
+            sampleSeries.setName("Demodulated Samples");
+
+            for(int x = 0; x < samples.length; x++)
+            {
+                sampleSeries.getData().add(new XYChart.Data<>(x, samples[x]));
+            }
+
+            mSampleChart.getData().clear();
+            mSampleChart.getData().add(sampleSeries);
+
+            XYChart.Series<Number,Number> patternSeries = new XYChart.Series<>();
+            patternSeries.setName("Ideal Sync Pattern");
+
+            for(int x = 0; x < sync.length; x++)
+            {
+                patternSeries.getData().add(new XYChart.Data<>(syncIntervals[x], sync[x]));
+            }
+
+            mSampleChart.getData().add(patternSeries);
+
+            mPatternLabel.setText(label);
+        });
+    }
+}

--- a/src/main/java/io/github/dsheirer/vector/calibrate/CalibrationManager.java
+++ b/src/main/java/io/github/dsheirer/vector/calibrate/CalibrationManager.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +25,7 @@ import io.github.dsheirer.preference.calibration.VectorCalibrationPreference;
 import io.github.dsheirer.vector.calibrate.airspy.AirspySampleConverterCalibration;
 import io.github.dsheirer.vector.calibrate.airspy.AirspyUnpackedCalibration;
 import io.github.dsheirer.vector.calibrate.airspy.AirspyUnpackedInterleavedCalibration;
-import io.github.dsheirer.vector.calibrate.demodulator.DqpskDemodulatorCalibration;
+import io.github.dsheirer.vector.calibrate.demodulator.DifferentialDemodulatorCalibration;
 import io.github.dsheirer.vector.calibrate.demodulator.FmDemodulatorCalibration;
 import io.github.dsheirer.vector.calibrate.filter.FirFilterCalibration;
 import io.github.dsheirer.vector.calibrate.filter.RealDcRemovalCalibration;
@@ -108,7 +108,7 @@ public class CalibrationManager
             sInstance.add(new ComplexOscillatorCalibration());
             sInstance.add(new ComplexMixerCalibration());
             sInstance.add(new DMRSoftSyncCalibration());
-            sInstance.add(new DqpskDemodulatorCalibration());
+            sInstance.add(new DifferentialDemodulatorCalibration());
             sInstance.add(new FirFilterCalibration());
             sInstance.add(new FmDemodulatorCalibration());
             sInstance.add(new InterpolatorCalibration());
@@ -281,7 +281,7 @@ public class CalibrationManager
     {
         CalibrationManager manager = getInstance();
 //        manager.reset();
-        manager.reset(CalibrationType.DQPSK_DEMODULATOR);
+        manager.reset(CalibrationType.DIFFERENTIAL_DEMODULATOR);
 
         if(!manager.isCalibrated())
         {

--- a/src/main/java/io/github/dsheirer/vector/calibrate/CalibrationType.java
+++ b/src/main/java/io/github/dsheirer/vector/calibrate/CalibrationType.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,7 +38,7 @@ public enum CalibrationType
     AM_DEMODULATOR("AM Demodulator", 1),
     DC_REMOVAL_REAL("Real DC Removal Filter", 1),
     DMR_SOFT_SYNC_DETECTOR("DMR Soft Sync Detector", 1),
-    DQPSK_DEMODULATOR("DQPSK Demodulator", 1),
+    DIFFERENTIAL_DEMODULATOR("DQPSK Demodulator", 1),
     FILTER_FIR("FIR Filter", 1),
     FILTER_HALF_BAND_REAL_11_TAP("Real Half-Band Decimation Filter - 11 Tap", 1),
     FILTER_HALF_BAND_REAL_15_TAP("Real Half-Band Decimation Filter - 15 Tap", 1),

--- a/src/main/java/io/github/dsheirer/vector/calibrate/demodulator/DifferentialDemodulatorCalibration.java
+++ b/src/main/java/io/github/dsheirer/vector/calibrate/demodulator/DifferentialDemodulatorCalibration.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,12 +19,12 @@
 
 package io.github.dsheirer.vector.calibrate.demodulator;
 
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulator;
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulatorScalar;
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulatorVector128;
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulatorVector256;
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulatorVector512;
-import io.github.dsheirer.dsp.psk.dqpsk.DQPSKDemodulatorVector64;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulator;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulatorScalar;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulatorVector128;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulatorVector256;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulatorVector512;
+import io.github.dsheirer.dsp.psk.demod.DifferentialDemodulatorVector64;
 import io.github.dsheirer.vector.calibrate.Calibration;
 import io.github.dsheirer.vector.calibrate.CalibrationException;
 import io.github.dsheirer.vector.calibrate.CalibrationType;
@@ -32,26 +32,26 @@ import io.github.dsheirer.vector.calibrate.Implementation;
 import org.apache.commons.math3.stat.descriptive.moment.Mean;
 
 /**
- * Calibrates DQPSK demodulator options
+ * Calibrates differential demodulator options
  */
-public class DqpskDemodulatorCalibration extends Calibration
+public class DifferentialDemodulatorCalibration extends Calibration
 {
     private static final int BUFFER_SIZE = 2048;
     private static final int ITERATION_DURATION_MS = 1000;
     private static final int WARMUP_ITERATIONS = 5;
     private static final int TEST_ITERATIONS = 5;
-    private DQPSKDemodulator mScalarDemodulator = new DQPSKDemodulatorScalar(50000.0, 4800);
-    private final DQPSKDemodulator mVectorDemodulator64 = new DQPSKDemodulatorVector64(50000.0, 4800);
-    private final DQPSKDemodulator mVectorDemodulator128 = new DQPSKDemodulatorVector128(50000.0, 4800);
-    private final DQPSKDemodulator mVectorDemodulator256 = new DQPSKDemodulatorVector256(50000.0, 4800);
-    private final DQPSKDemodulator mVectorDemodulator512 = new DQPSKDemodulatorVector512(50000.0, 4800);
+    private DifferentialDemodulator mScalarDemodulator = new DifferentialDemodulatorScalar(50000.0, 4800);
+    private final DifferentialDemodulator mVectorDemodulator64 = new DifferentialDemodulatorVector64(50000.0, 4800);
+    private final DifferentialDemodulator mVectorDemodulator128 = new DifferentialDemodulatorVector128(50000.0, 4800);
+    private final DifferentialDemodulator mVectorDemodulator256 = new DifferentialDemodulatorVector256(50000.0, 4800);
+    private final DifferentialDemodulator mVectorDemodulator512 = new DifferentialDemodulatorVector512(50000.0, 4800);
 
     /**
      * Constructs an instance
      */
-    public DqpskDemodulatorCalibration()
+    public DifferentialDemodulatorCalibration()
     {
-        super(CalibrationType.DQPSK_DEMODULATOR);
+        super(CalibrationType.DIFFERENTIAL_DEMODULATOR);
     }
 
     @Override public void calibrate() throws CalibrationException
@@ -273,7 +273,7 @@ public class DqpskDemodulatorCalibration extends Calibration
 
     public static void main(String[] args)
     {
-        DqpskDemodulatorCalibration calibration = new DqpskDemodulatorCalibration();
+        DifferentialDemodulatorCalibration calibration = new DifferentialDemodulatorCalibration();
 
         try
         {

--- a/src/test/java/io/github/dsheirer/dsp/psk/demod/DmrSoftSyncDetectorTest.java
+++ b/src/test/java/io/github/dsheirer/dsp/psk/demod/DmrSoftSyncDetectorTest.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
  * ****************************************************************************
  */
 
-package io.github.dsheirer.dsp.psk.dqpsk;
+package io.github.dsheirer.dsp.psk.demod;
 
 import io.github.dsheirer.dsp.symbol.Dibit;
 import io.github.dsheirer.module.decode.dmr.sync.DMRSoftSyncDetector;
@@ -60,11 +60,11 @@ public class DmrSoftSyncDetectorTest
             for(Dibit dibit: pattern.toDibits())
             {
                 symbol = toSymbol(dibit);
-                scalar.process(symbol);
-                vector64.process(symbol);
-                vector128.process(symbol);
-                vector256.process(symbol);
-                vector512.process(symbol);
+                scalar.processAndCalculate(symbol);
+                vector64.processAndCalculate(symbol);
+                vector128.processAndCalculate(symbol);
+                vector256.processAndCalculate(symbol);
+                vector512.processAndCalculate(symbol);
             }
 
             assertSame(scalar.getDetectedPattern(), pattern, "Scalar Detector Did Not Correctly Detect Pattern: " + pattern);


### PR DESCRIPTION
Closes #2226 

Resolves issue with symbol constellation skew and imbalance that was originally reported as possible (additional) PI/4 symbol rotation during demodulation. 

DMR Decoder employs a new equalizer to adjust symbol constellation balance/skew and gain to optimize symbol quadrant alignment.  Equalizer is updated at each sync detect.  Reduces sync detectors from 3 to 2 and sets minimum objective channel sample rate to 4x the symbol rate (ie 19.2 kHz).  Enhances sync detection to employ fine/coarse sync modes where the sync detector is only active during anticipated sync periods when in fine sync mode.
