### PR TITLE
#2234 Stream As Talkgroup Aliasing Feature

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/Alias.java
+++ b/src/main/java/io/github/dsheirer/alias/Alias.java
@@ -1,23 +1,20 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2020 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 package io.github.dsheirer.alias;
 
@@ -30,13 +27,22 @@ import io.github.dsheirer.alias.id.AliasIDType;
 import io.github.dsheirer.alias.id.broadcast.BroadcastChannel;
 import io.github.dsheirer.alias.id.priority.Priority;
 import io.github.dsheirer.alias.id.record.Record;
+import io.github.dsheirer.alias.id.talkgroup.StreamAsTalkgroup;
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
@@ -45,13 +51,6 @@ import javafx.collections.transformation.FilteredList;
 import javafx.util.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.awt.Color;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * Alias provides an aliasing (e.g. name, color, etc) container that is linked to multiple alias identifiers and
@@ -74,6 +73,7 @@ public class Alias
     private StringProperty mName = new SimpleStringProperty();
     private ObservableList<AliasID> mAliasIDs = FXCollections.observableArrayList();
     private ObservableList<AliasAction> mAliasActions = FXCollections.observableArrayList();
+    private ObjectProperty<StreamAsTalkgroup> mStreamTalkgroupAlias = new SimpleObjectProperty<>();
 
     /**
      * Constructs an instance and sets the specified name.
@@ -180,6 +180,12 @@ public class Alias
         return mColor;
     }
 
+    @JsonIgnore
+    public ObjectProperty streamTalkgroupAliasProperty()
+    {
+        return mStreamTalkgroupAlias;
+    }
+
     /**
      * Icon name property
      */
@@ -227,6 +233,24 @@ public class Alias
     public void setName(String name)
     {
         mName.set(name);
+    }
+
+    /**
+     * Alias name
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "stream_talkgroup_alias")
+    public StreamAsTalkgroup getStreamTalkgroupAlias()
+    {
+        return mStreamTalkgroupAlias.get();
+    }
+
+    /**
+     * Sets the stream as talkgroup value that will be used in the TO field for streamed audio calls.
+     * @param streamTalkgroupAlias with a talkgroup value.
+     */
+    public void setStreamTalkgroupAlias(StreamAsTalkgroup streamTalkgroupAlias)
+    {
+        mStreamTalkgroupAlias.set(streamTalkgroupAlias);
     }
 
     /**
@@ -710,6 +734,7 @@ public class Alias
     {
         return (Alias a) -> new Observable[] {a.recordableProperty(), a.streamableProperty(), a.colorProperty(),
             a.aliasListNameProperty(), a.groupProperty(), a.iconNameProperty(), a.nameProperty(), a.aliasIds(),
-            a.aliasActions(), a.nonAudioIdentifierCountProperty(), a.overlapProperty()};
+            a.aliasActions(), a.nonAudioIdentifierCountProperty(), a.overlapProperty(), a.priorityProperty(),
+                a.streamTalkgroupAliasProperty()};
     }
 }

--- a/src/main/java/io/github/dsheirer/alias/id/AliasID.java
+++ b/src/main/java/io/github/dsheirer/alias/id/AliasID.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,7 @@ import io.github.dsheirer.alias.id.record.Record;
 import io.github.dsheirer.alias.id.status.UnitStatusID;
 import io.github.dsheirer.alias.id.status.UserStatusID;
 import io.github.dsheirer.alias.id.talkgroup.P25FullyQualifiedTalkgroup;
+import io.github.dsheirer.alias.id.talkgroup.StreamAsTalkgroup;
 import io.github.dsheirer.alias.id.talkgroup.Talkgroup;
 import io.github.dsheirer.alias.id.talkgroup.TalkgroupRange;
 import io.github.dsheirer.alias.id.tone.TonesID;
@@ -70,6 +71,7 @@ import javafx.util.Callback;
     @JsonSubTypes.Type(value = RadioRange.class, name = "radioRange"),
     @JsonSubTypes.Type(value = Record.class, name = "record"),
     @JsonSubTypes.Type(value = SiteID.class, name = "siteID"),
+    @JsonSubTypes.Type(value = StreamAsTalkgroup.class, name = "streamAsTalkgroup"),
     @JsonSubTypes.Type(value = Talkgroup.class, name = "talkgroup"),
     @JsonSubTypes.Type(value = TalkgroupRange.class, name = "talkgroupRange"),
     @JsonSubTypes.Type(value = TonesID.class, name = "tones"),

--- a/src/main/java/io/github/dsheirer/alias/id/talkgroup/StreamAsTalkgroup.java
+++ b/src/main/java/io/github/dsheirer/alias/id/talkgroup/StreamAsTalkgroup.java
@@ -1,0 +1,40 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.alias.id.talkgroup;
+
+import io.github.dsheirer.protocol.Protocol;
+
+/**
+ * Streaming talkgroup alias.  For streamed audio metadata, this value is used to replace the decoded talkgroup or TO
+ * value with an alias value when there are talkgroup collisions resulting from streaming multiple channels to the
+ * same stream.  This is common in P25 conventional repeater setups where each radio channel is using talkgroup 1.
+ */
+public class StreamAsTalkgroup extends Talkgroup
+{
+    public StreamAsTalkgroup(int talkgroup)
+    {
+        super(Protocol.UNKNOWN, talkgroup);
+    }
+
+    public StreamAsTalkgroup()
+    {
+        //No arg JAXB constructor
+    }
+}

--- a/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastMetadata.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastMetadata.java
@@ -1,23 +1,20 @@
 /*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
- *  * ******************************************************************************
- *  * Copyright (C) 2014-2020 Dennis Sheirer
- *  *
- *  * This program is free software: you can redistribute it and/or modify
- *  * it under the terms of the GNU General Public License as published by
- *  * the Free Software Foundation, either version 3 of the License, or
- *  * (at your option) any later version.
- *  *
- *  * This program is distributed in the hope that it will be useful,
- *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  * GNU General Public License for more details.
- *  *
- *  * You should have received a copy of the GNU General Public License
- *  * along with this program.  If not, see <http://www.gnu.org/licenses/>
- *  * *****************************************************************************
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
  */
 package io.github.dsheirer.audio.broadcast.icecast;
 
@@ -25,20 +22,15 @@ import com.google.common.base.Joiner;
 import io.github.dsheirer.alias.Alias;
 import io.github.dsheirer.alias.AliasList;
 import io.github.dsheirer.alias.AliasModel;
-import io.github.dsheirer.audio.broadcast.icecast.IcecastConfiguration;
 import io.github.dsheirer.identifier.Form;
 import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.identifier.IdentifierClass;
 import io.github.dsheirer.identifier.IdentifierCollection;
 import io.github.dsheirer.identifier.Role;
-import io.github.dsheirer.properties.SystemProperties;
-import io.github.dsheirer.util.ThreadPool;
+import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.List;
 
 public class IcecastMetadata
 {
@@ -73,13 +65,23 @@ public class IcecastMetadata
 
             if(to != null)
             {
-                sb.append("TO:").append(to);
-
                 List<Alias> aliases = aliasList.getAliases(to);
 
-                if(aliases != null && !aliases.isEmpty())
+                //Check for 'Stream As Talkgroup' alias and use this instead of the decoded TO value.
+                Optional<Alias> streamAs = aliases.stream().filter(alias -> alias.getStreamTalkgroupAlias() != null).findFirst();
+
+                if(streamAs.isPresent())
                 {
-                    sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
+                    sb.append("TO:").append(streamAs.get().getStreamTalkgroupAlias().getValue());
+                }
+                else
+                {
+                    sb.append("TO:").append(to);
+
+                    if(!aliases.isEmpty())
+                    {
+                        sb.append(" ").append(Joiner.on(", ").skipNulls().join(aliases));
+                    }
                 }
             }
             else


### PR DESCRIPTION
Closes #2234 

Implements a new 'Stream As Talkgroup' feature that allows the user to assign a Pseudo-Talkgroup value to an alias to use as the TO identifier in any audio streaming.

This can be used when the user wants to stream multiple P25 conventional/repeater channels where each channel is configured for Talkgroup 1, causing TO identifier collisions in the stream.  

To use: 
1. Create a separately named alias list for each conventional channel.
2. In each alias list, setup an alias and add a talkgroup identifier that matches the talkgroup used on that conventional/repeater channel.
3. In the alias editor for this alias, in the 'Streaming' panel, add a 'Stream As Talkgroup' value to use for this talkgroup.

Any calls to the original talkgroup will be aliased using the 'Stream As Talkgroup' when they are streamed.