### PR TITLE
#2250 Logback Configuration & Suppress JDK24 Warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,8 @@ def jvmArgsWindows =
          '--add-modules=jdk.incubator.vector',   //Project Panama Vector API is still in incubator
          '--enable-preview', //Project Panama Vector API is still in incubator
          '--enable-native-access=ALL-UNNAMED', //Suppress unsafe warnings for FFM API Foreign Memory calls
+         '--enable-native-access=javafx.graphics', //JDK24 - suppress restricted java.lang.System calls
+         '--sun-misc-unsafe-memory-access=allow', //JDK24 - suppress sun.misc.Unsafe::allocateMemory warning
          '-Djava.library.path=c:\\Program Files\\SDRplay\\API\\x64'] //SDRPlay API library path
 
 /**
@@ -151,6 +153,8 @@ def jvmArgsLinux =
         ['--add-exports=javafx.base/com.sun.javafx.event=ALL-UNNAMED', //Needed for controls-fx.jar
          '--add-modules=jdk.incubator.vector',   //Needed while Project Panama API is still in incubator
          '--enable-preview', //Project Panama Vector & Foreign Function APIs remain in incubator
+         '--sun-misc-unsafe-memory-access=allow', //JDK24 - suppress sun.misc.Unsafe::allocateMemory warning
+         '--enable-native-access=javafx.graphics', //JDK24 - suppress restricted java.lang.System calls
          '--enable-native-access=ALL-UNNAMED'] //SDRPlay API library path
 
 application {

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <!--
   ~ ******************************************************************************
-  ~ Copyright (C) 2014-2022 Dennis Sheirer
+  ~ Copyright (C) 2014-2025 Dennis Sheirer
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -17,7 +17,7 @@
   ~ *****************************************************************************
   -->
 <configuration>
-  <conversionRule conversionWord="memory_usage" converterClass="io.github.dsheirer.util.MemoryUsageLogger" />
+  <conversionRule conversionWord="memory_usage" class="io.github.dsheirer.util.MemoryUsageLogger" />
 
   <timestamp key="appstart" datePattern="HHmmss"/>
 


### PR DESCRIPTION
Closes #2250 

* Resolves Logback configuration issue
* Suppresses JDK24 warnings for Unsafe Memory access and Native Access related to JavaFX libraries

Note: suppressed JVM warnings will eventually be resolved by the JavaFX team ... I hope