### PR TITLE
Fix saved decode.event.panel column widths prefs to restore on launch

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
@@ -96,7 +96,6 @@ public class DecodeEventPanel extends JPanel implements Listener<ProcessingChain
         mTableRowSorter = new TableRowSorter<>(mEventModel);
         mTableRowSorter.setRowFilter(new EventRowFilter());
         mTable.setRowSorter(mTableRowSorter);
-        mTable.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
         mTableColumnWidthMonitor = new JTableColumnWidthMonitor(mUserPreferences, mTable, TABLE_PREFERENCE_KEY);
         updateCellRenderers();
         mHistoryManagementPanel = new HistoryManagementPanel<>(mEventModel, "Event Filter Editor");

--- a/src/main/java/io/github/dsheirer/preference/swing/JTableColumnWidthMonitor.java
+++ b/src/main/java/io/github/dsheirer/preference/swing/JTableColumnWidthMonitor.java
@@ -25,6 +25,7 @@ import io.github.dsheirer.util.ThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.awt.EventQueue;
 import javax.swing.JTable;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ListSelectionEvent;
@@ -60,7 +61,12 @@ public class JTableColumnWidthMonitor
         mTable = table;
         mKey = key;
 
-        restoreColumnWidths();
+        mTable.setAutoResizeMode(JTable.AUTO_RESIZE_SUBSEQUENT_COLUMNS);
+
+        // Wait until the UI is realized to set preferred column widths
+        EventQueue.invokeLater(this::restoreColumnWidths);
+
+        // Keep listening for drag-resizes so you can re-save new widths
         mTable.getColumnModel().addColumnModelListener(mColumnResizeListener);
     }
 


### PR DESCRIPTION
Attempting to get saved column width preferences to reload properly. That part now works but I've been having a heck of a time combining that with allowing the last column to autosize appropriately. As is this is not currently working, resulting in a too-narrow last column or a horizontal scroller if it's too wide.

