### PR TITLE
P25 P1 MBE ESS order

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/codec/mbe/MBECallSequence.java
+++ b/src/main/java/io/github/dsheirer/audio/codec/mbe/MBECallSequence.java
@@ -36,7 +36,7 @@ import java.util.List;
  * radio identifiers.
  */
 @JsonRootName("mbe_call")
-@JsonPropertyOrder({"protocol", "call_type", "from", "to", "encrypted", "frames"})
+@JsonPropertyOrder({"protocol", "version", "call_type", "from", "to", "encrypted", "system", "site", "frames"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MBECallSequence
 {
@@ -77,6 +77,15 @@ public class MBECallSequence
         mProtocol = protocol;
     }
 
+    /**
+     * Gets the version number for the mbe file structure.
+     * Should be incremented only on breaking structural changes, not minor additions.
+     */
+    @JsonProperty("version")
+    public Integer getVersion()
+    {
+        return 2;
+    }
 
     /**
      * Indicates if this sequences contains any audio frames

--- a/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P1CallSequenceRecorder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P1CallSequenceRecorder.java
@@ -152,10 +152,6 @@ public class P25P1CallSequenceRecorder extends MBECallSequenceRecorder
         {
             process((LDU1Message)lduMessage);
         }
-        else if(lduMessage instanceof LDU2Message)
-        {
-            process((LDU2Message)lduMessage);
-        }
 
         List<byte[]> voiceFrames = lduMessage.getIMBEFrames();
 
@@ -170,6 +166,10 @@ public class P25P1CallSequenceRecorder extends MBECallSequenceRecorder
             baseTimestamp += 20;
         }
 
+        if(lduMessage instanceof LDU2Message)
+        {
+            process((LDU2Message)lduMessage);
+        }
     }
 
     private void process(LinkControlWord lcw)


### PR DESCRIPTION
In the recorded MBE files ESS was populated at the beginning of LDU2, but doesn't take effect until after LDU2 is processed. This increases complexity of post processing.

- Corrected to now populate ESS after LDU2
- Also added 'version' field to MBE file and set it to '2' to signify a breaking change in the ESS order
- This partially satisfies items pointed out in both
  - #2243
  - lwvmobile/dsd-fme#298

I should have caught this in #1792, my bad.