### PR TITLE
#1892 Icecast 2.4+: Fix retries after network disruption

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastHTTPAudioBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/icecast/IcecastHTTPAudioBroadcaster.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 public class IcecastHTTPAudioBroadcaster extends IcecastAudioBroadcaster
 {
     private static final Logger mLog = LoggerFactory.getLogger(IcecastHTTPAudioBroadcaster.class);
+    private static final long CONNECTION_ATTEMPT_TIMEOUT_MILLISECONDS = 5000; // 5 seconds
     private static final long RECONNECT_INTERVAL_MILLISECONDS = 30000; //30 seconds
     private static final String HTTP_1_0_OK_HEX_DUMP = "48 54 54 50 2F 31 2E 30 20 32 30 30 20 4F 4B";
 
@@ -141,7 +142,8 @@ public class IcecastHTTPAudioBroadcaster extends IcecastAudioBroadcaster
             if(mSocketConnector == null)
             {
                 mSocketConnector = new NioSocketConnector();
-                mSocketConnector.setConnectTimeoutCheckInterval(10000);
+                mSocketConnector.setConnectTimeoutMillis(CONNECTION_ATTEMPT_TIMEOUT_MILLISECONDS);
+                mSocketConnector.setConnectTimeoutCheckInterval(1000);
 
 //                LoggingFilter loggingFilter = new LoggingFilter(IcecastHTTPAudioBroadcaster.class);
 //                loggingFilter.setMessageReceivedLogLevel(LogLevel.DEBUG);
@@ -160,37 +162,51 @@ public class IcecastHTTPAudioBroadcaster extends IcecastAudioBroadcaster
                 {
                     setBroadcastState(BroadcastState.CONNECTING);
 
-                    try
-                    {
+                    try {
                         ConnectFuture future = mSocketConnector
                             .connect(new InetSocketAddress(getBroadcastConfiguration().getHost(),
                                 getBroadcastConfiguration().getPort()));
-                        future.awaitUninterruptibly();
-                        mStreamingSession = future.getSession();
-                    }
-                    catch(RuntimeIoException rie)
-                    {
-                        Throwable throwableCause = rie.getCause();
 
-                        if(throwableCause instanceof ConnectException)
-                        {
-                            setBroadcastState(BroadcastState.NO_SERVER);
-                        }
-                        else if(throwableCause != null)
-                        {
+                        boolean connected;
+                        try {
+                            connected = future.await(CONNECTION_ATTEMPT_TIMEOUT_MILLISECONDS);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                            mLog.debug("HTTP connect attempt interrupted");
                             setBroadcastState(BroadcastState.DISCONNECTED);
+                            mLastConnectionAttempt = System.currentTimeMillis();
+                            future.cancel();
+                            disconnect();
+                            return;
+                        }
+
+                        if (connected && future.isConnected()) {
+                            mStreamingSession = future.getSession();
+                            mConnecting.set(false);
+                            return;
+                        } else {
+                            mLog.debug("HTTP connect attempt timed out ({} ms) or not connected",
+                                       CONNECTION_ATTEMPT_TIMEOUT_MILLISECONDS);
+                            setBroadcastState(BroadcastState.DISCONNECTED);
+                            mLastConnectionAttempt = System.currentTimeMillis();
+                            future.cancel();
+                            disconnect();
+                        }
+                    } catch (RuntimeIoException rie) {
+                        Throwable throwableCause = rie.getCause();
+                        setBroadcastState(BroadcastState.DISCONNECTED);
+                        if (throwableCause != null) {
                             mLog.debug("Failed to connect", rie);
-                        }
-                        else
-                        {
-                            setBroadcastState(BroadcastState.DISCONNECTED);
+                        } else {
                             mLog.debug("Failed to connect - no exception is available");
                         }
-
+                        mLastConnectionAttempt = System.currentTimeMillis();
                         disconnect();
+                    } finally {
+                        if (!connected()) {
+                            mConnecting.set(false);
+                        }
                     }
-
-                    mConnecting.set(false);
                 }
             };
 
@@ -209,6 +225,11 @@ public class IcecastHTTPAudioBroadcaster extends IcecastAudioBroadcaster
         if(mStreamingSession != null)
         {
             mStreamingSession.closeNow();
+        }
+        
+        mLastConnectionAttempt = System.currentTimeMillis();
+        if(!getBroadcastState().isErrorState()) {
+            setBroadcastState(BroadcastState.DISCONNECTED);
         }
     }
 
@@ -288,6 +309,7 @@ public class IcecastHTTPAudioBroadcaster extends IcecastAudioBroadcaster
         @Override
         public void sessionClosed(IoSession session) throws Exception
         {
+            mLastConnectionAttempt = System.currentTimeMillis();
             //If there is already an error state, don't override it.  Otherwise, set state to disconnected
             if(!getBroadcastState().isErrorState())
             {


### PR DESCRIPTION
This addresses #1892 where Icecast 2.4+ would get stuck after a network disruption.

I’m having unrelated issues with my RTL-SDRs not locking on to P25 frequencies with the latest code base, so I haven’t been able to extensively test this against main. However, I’ve been running these changes with a 6.1 snapshot for the past few weeks, and they’ve been reliable in making sure Icecast 2.4+ reconnects after network disruption.