### PR TITLE
Dark Mode

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastStatusPanel.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastStatusPanel.java
@@ -146,7 +146,7 @@ public class BroadcastStatusPanel extends JPanel
                     if(state == BroadcastState.CONNECTED)
                     {
                         setBackground(Color.GREEN);
-                        setForeground(table.getForeground());
+                        setForeground(Color.BLACK); // Use black text on green background for better readability
                     }
                     else if(state == BroadcastState.DISABLED)
                     {
@@ -157,12 +157,12 @@ public class BroadcastStatusPanel extends JPanel
                             state == BroadcastState.NETWORK_UNAVAILABLE)
                     {
                         setBackground(Color.YELLOW);
-                        setForeground(table.getForeground());
+                        setForeground(Color.BLACK); // Use black text on yellow background for better readability
                     }
                     else if(state.isErrorState())
                     {
                         setBackground(Color.RED);
-                        setForeground(table.getForeground());
+                        setForeground(Color.WHITE); // Use white text on red background for better readability
                     }
                     else
                     {

--- a/src/main/java/io/github/dsheirer/channel/details/ChannelDetailPanel.java
+++ b/src/main/java/io/github/dsheirer/channel/details/ChannelDetailPanel.java
@@ -22,6 +22,7 @@ import io.github.dsheirer.channel.state.DecoderState;
 import io.github.dsheirer.controller.channel.Channel;
 import io.github.dsheirer.controller.channel.ChannelProcessingManager;
 import io.github.dsheirer.module.ProcessingChain;
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.sample.Listener;
 import net.miginfocom.swing.MigLayout;
 
@@ -46,10 +47,12 @@ public class ChannelDetailPanel extends JPanel implements Listener<ProcessingCha
 
     private ChannelProcessingManager mChannelProcessingManager;
     private ProcessingChain mProcessingChain;
+    private UserPreferences mUserPreferences;
 
-    public ChannelDetailPanel(ChannelProcessingManager channelProcessingManager)
+    public ChannelDetailPanel(ChannelProcessingManager channelProcessingManager, UserPreferences userPreferences)
     {
         mChannelProcessingManager = channelProcessingManager;
+        mUserPreferences = userPreferences;
 
         init();
     }
@@ -74,6 +77,14 @@ public class ChannelDetailPanel extends JPanel implements Listener<ProcessingCha
         buttonPanel.add(mNameLabel);
 
         JButton refreshButton = new JButton("Refresh");
+        refreshButton.setOpaque(true);
+        refreshButton.setBorderPainted(true);
+        refreshButton.setContentAreaFilled(true);
+        if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+        {
+            refreshButton.setBackground(new java.awt.Color(43, 43, 43));
+            refreshButton.setForeground(new java.awt.Color(187, 187, 187));
+        }
         refreshButton.addActionListener(new ActionListener()
         {
             @Override

--- a/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataPanel.java
+++ b/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataPanel.java
@@ -144,10 +144,23 @@ public class ChannelMetadataPanel extends JPanel implements ListSelectionListene
         mForegroundColors.put(State.DATA, Color.BLUE);
         mBackgroundColors.put(State.ENCRYPTED, Color.MAGENTA);
         mForegroundColors.put(State.ENCRYPTED, Color.WHITE);
-        mBackgroundColors.put(State.FADE, Color.LIGHT_GRAY);
-        mForegroundColors.put(State.FADE, Color.DARK_GRAY);
-        mBackgroundColors.put(State.IDLE, Color.WHITE);
-        mForegroundColors.put(State.IDLE, Color.DARK_GRAY);
+        
+        // Adjust FADE and IDLE colors based on dark mode
+        if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+        {
+            mBackgroundColors.put(State.FADE, new Color(60, 60, 60));
+            mForegroundColors.put(State.FADE, new Color(187, 187, 187));
+            mBackgroundColors.put(State.IDLE, new Color(43, 43, 43));
+            mForegroundColors.put(State.IDLE, new Color(187, 187, 187));
+        }
+        else
+        {
+            mBackgroundColors.put(State.FADE, Color.LIGHT_GRAY);
+            mForegroundColors.put(State.FADE, Color.DARK_GRAY);
+            mBackgroundColors.put(State.IDLE, Color.WHITE);
+            mForegroundColors.put(State.IDLE, Color.DARK_GRAY);
+        }
+        
         mBackgroundColors.put(State.RESET, Color.PINK);
         mForegroundColors.put(State.RESET, Color.YELLOW);
         mBackgroundColors.put(State.TEARDOWN, Color.DARK_GRAY);

--- a/src/main/java/io/github/dsheirer/channel/metadata/NowPlayingPanel.java
+++ b/src/main/java/io/github/dsheirer/channel/metadata/NowPlayingPanel.java
@@ -54,11 +54,11 @@ public class NowPlayingPanel extends JPanel
     public NowPlayingPanel(PlaylistManager playlistManager, IconModel iconModel, UserPreferences userPreferences,
                            SettingsManager settingsManager, boolean detailTabsVisible)
     {
-        mChannelDetailPanel = new ChannelDetailPanel(playlistManager.getChannelProcessingManager());
+        mChannelDetailPanel = new ChannelDetailPanel(playlistManager.getChannelProcessingManager(), userPreferences);
         mDecodeEventPanel = new DecodeEventPanel(iconModel, userPreferences, playlistManager.getAliasModel());
         mMessageActivityPanel = new MessageActivityPanel(userPreferences);
         mChannelMetadataPanel = new ChannelMetadataPanel(playlistManager, iconModel, userPreferences);
-        mChannelSpectrumSquelchPanel = new ChannelSpectrumPanel(playlistManager, settingsManager);
+        mChannelSpectrumSquelchPanel = new ChannelSpectrumPanel(playlistManager, settingsManager, userPreferences);
         mDetailTabsVisible = detailTabsVisible;
 
         init();

--- a/src/main/java/io/github/dsheirer/controller/ControllerPanel.java
+++ b/src/main/java/io/github/dsheirer/controller/ControllerPanel.java
@@ -64,7 +64,7 @@ public class ControllerPanel extends JPanel
         mAudioPanel = new AudioPanel(iconModel, userPreferences, settingsManager, audioPlaybackManager,
             playlistManager.getAliasModel());
         mNowPlayingPanel = new NowPlayingPanel(playlistManager, iconModel, userPreferences, settingsManager, detailTabsVisible);
-        mMapPanel = new MapPanel(mapService, playlistManager.getAliasModel(), iconModel, settingsManager);
+        mMapPanel = new MapPanel(mapService, playlistManager.getAliasModel(), iconModel, settingsManager, userPreferences);
         mTunerManagerPanel = new TunerViewPanel(tunerManager, userPreferences);
 
         init();

--- a/src/main/java/io/github/dsheirer/gui/JavaFxWindowManager.java
+++ b/src/main/java/io/github/dsheirer/gui/JavaFxWindowManager.java
@@ -35,6 +35,7 @@ import io.github.dsheirer.gui.preference.PreferenceEditorType;
 import io.github.dsheirer.gui.preference.UserPreferencesEditor;
 import io.github.dsheirer.gui.preference.ViewUserPreferenceEditorRequest;
 import io.github.dsheirer.gui.preference.calibration.CalibrationDialog;
+import io.github.dsheirer.gui.preference.colortheme.ColorThemeManager;
 import io.github.dsheirer.gui.viewer.MessageRecordingViewer;
 import io.github.dsheirer.gui.viewer.ViewRecordingViewerRequest;
 import io.github.dsheirer.icon.IconModel;
@@ -135,6 +136,7 @@ public class JavaFxWindowManager extends Application
             //JFXPanel has to be populated on the FX event thread
             Platform.runLater(() -> {
                 Scene scene = new Scene(new StatusBox(resourceMonitor));
+                ColorThemeManager.applyThemeToScene(scene, mUserPreferences);
                 mStatusPanel.setScene(scene);
             });
         }
@@ -207,6 +209,7 @@ public class JavaFxWindowManager extends Application
         {
             createJFXPanel();
             Scene scene = new Scene(getRecordingViewer(), 1100, 800);
+            ColorThemeManager.applyThemeToScene(scene, mUserPreferences);
             mRecordingViewerStage = new Stage();
             mRecordingViewerStage.setTitle("sdrtrunk - Message Recording Viewer (.bits)");
             mRecordingViewerStage.setScene(scene);
@@ -232,6 +235,7 @@ public class JavaFxWindowManager extends Application
         {
             createJFXPanel();
             Scene scene = new Scene(getIconManager(), 500, 500);
+            ColorThemeManager.applyThemeToScene(scene, mUserPreferences);
             mIconManagerStage = new Stage();
             mIconManagerStage.setTitle("sdrtrunk - Icon Manager");
             mIconManagerStage.setScene(scene);
@@ -280,6 +284,7 @@ public class JavaFxWindowManager extends Application
         {
             createJFXPanel();
             Scene scene = new Scene(getJmbeEditor(), 650, 650);
+            ColorThemeManager.applyThemeToScene(scene, mUserPreferences);
             mJmbeEditorStage = new Stage();
             mJmbeEditorStage.setTitle("sdrtrunk - JMBE Library Updater");
             mJmbeEditorStage.setScene(scene);
@@ -321,6 +326,7 @@ public class JavaFxWindowManager extends Application
         {
             createJFXPanel();
             Scene scene = new Scene(getPlaylistEditor(), 1000, 750);
+            ColorThemeManager.applyThemeToScene(scene, mUserPreferences);
             mPlaylistStage = new Stage();
             mPlaylistStage.setTitle("sdrtrunk - Playlist Editor");
             mPlaylistStage.setScene(scene);
@@ -371,6 +377,7 @@ public class JavaFxWindowManager extends Application
         {
             createJFXPanel();
             Scene scene = new Scene(getUserPreferencesEditor(), 900, 500);
+            ColorThemeManager.applyThemeToScene(scene, mUserPreferences);
             mUserPreferencesStage = new Stage();
             mUserPreferencesStage.setTitle("sdrtrunk - User Preferences");
             mUserPreferencesStage.setScene(scene);
@@ -414,6 +421,7 @@ public class JavaFxWindowManager extends Application
         {
             createJFXPanel();
             Scene scene = new Scene(getChannelMapEditor(), 500, 500);
+            ColorThemeManager.applyThemeToScene(scene, mUserPreferences);
             mChannelMapStage = new Stage();
             mChannelMapStage.setTitle("sdrtrunk - Channel Map Editor");
             mChannelMapStage.setScene(scene);

--- a/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
+++ b/src/main/java/io/github/dsheirer/gui/SDRTrunk.java
@@ -38,6 +38,7 @@ import io.github.dsheirer.gui.preference.CalibrateRequest;
 import io.github.dsheirer.gui.preference.PreferenceEditorType;
 import io.github.dsheirer.gui.preference.ViewUserPreferenceEditorRequest;
 import io.github.dsheirer.gui.preference.calibration.CalibrationDialog;
+import io.github.dsheirer.gui.preference.colortheme.ColorThemeManager;
 import io.github.dsheirer.gui.viewer.ViewRecordingViewerRequest;
 import io.github.dsheirer.icon.IconModel;
 import io.github.dsheirer.log.ApplicationLog;
@@ -188,6 +189,9 @@ public class SDRTrunk implements Listener<TunerEvent>
 
         //Register FontAwesome so we can use the fonts in Swing windows
         IconFontSwing.register(FontAwesome.getIconFont());
+
+        //Apply color theme (dark mode if enabled) BEFORE creating GUI components
+        ColorThemeManager.applySwingTheme(mUserPreferences);
 
         mTunerManager = new TunerManager(mUserPreferences);
         mTunerManager.start();
@@ -422,13 +426,22 @@ public class SDRTrunk implements Listener<TunerEvent>
             mMainGui.add(getResourceStatusPanel(), "span,growx");
         }
 
+        //Update GUI components to apply theme after all components are created
+        if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+        {
+            ColorThemeManager.updateComponentTreeUI(mMainGui);
+        }
+
         /**
          * Menu items
          */
         JMenuBar menuBar = new JMenuBar();
+        menuBar.setOpaque(true);
+        ColorThemeManager.applyDarkThemeToComponent(menuBar, mUserPreferences);
         mMainGui.setJMenuBar(menuBar);
 
         JMenu fileMenu = new JMenu("File");
+        ColorThemeManager.applyDarkThemeToComponent(fileMenu, mUserPreferences);
         menuBar.add(fileMenu);
 
         JMenuItem processingStatusReportMenuItem = new JMenuItem("Processing Diagnostic Report");
@@ -481,6 +494,7 @@ public class SDRTrunk implements Listener<TunerEvent>
         fileMenu.add(exitMenu);
 
         JMenu viewMenu = new JMenu("View");
+        ColorThemeManager.applyDarkThemeToComponent(viewMenu, mUserPreferences);
 
         JMenuItem viewPlaylistItem = new JMenuItem("Playlist Editor");
         viewPlaylistItem.setIcon(IconFontSwing.buildIcon(FontAwesome.PLAY_CIRCLE_O, 12));
@@ -597,6 +611,7 @@ public class SDRTrunk implements Listener<TunerEvent>
         menuBar.add(viewMenu);
 
         JMenuItem screenCaptureItem = new JMenuItem("Screen Capture");
+        screenCaptureItem.setOpaque(true);
         screenCaptureItem.setIcon(IconFontSwing.buildIcon(FontAwesome.CAMERA, 12));
         screenCaptureItem.setMnemonic(KeyEvent.VK_C);
         screenCaptureItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, ActionEvent.ALT_MASK));

--- a/src/main/java/io/github/dsheirer/gui/channel/ChannelSpectrumPanel.java
+++ b/src/main/java/io/github/dsheirer/gui/channel/ChannelSpectrumPanel.java
@@ -22,12 +22,14 @@ package io.github.dsheirer.gui.channel;
 import io.github.dsheirer.controller.channel.Channel;
 import io.github.dsheirer.dsp.filter.channelizer.PolyphaseChannelSource;
 import io.github.dsheirer.gui.power.SignalPowerView;
+import io.github.dsheirer.gui.preference.colortheme.ColorThemeManager;
 import io.github.dsheirer.gui.squelch.NoiseSquelchView;
 import io.github.dsheirer.module.ProcessingChain;
 import io.github.dsheirer.module.decode.PrimaryDecoder;
 import io.github.dsheirer.module.decode.am.AMDecoder;
 import io.github.dsheirer.module.decode.nbfm.NBFMDecoder;
 import io.github.dsheirer.playlist.PlaylistManager;
+import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.complex.ComplexSamplesToNativeBufferModule;
 import io.github.dsheirer.settings.SettingsManager;
@@ -92,7 +94,7 @@ public class ChannelSpectrumPanel extends JPanel implements Listener<ProcessingC
     /**
      * Constructs an instance.
      */
-    public ChannelSpectrumPanel(PlaylistManager playlistManager, SettingsManager settingsManager)
+    public ChannelSpectrumPanel(PlaylistManager playlistManager, SettingsManager settingsManager, UserPreferences userPreferences)
     {
         mPlaylistManager = playlistManager;
         mNoiseSquelchView = new NoiseSquelchView(mPlaylistManager);
@@ -198,6 +200,7 @@ public class ChannelSpectrumPanel extends JPanel implements Listener<ProcessingC
         //Spin noise squelch panel construction off onto the JavafX UI thread.
         Platform.runLater(() -> {
             Scene scene = new Scene(mNoiseSquelchView);
+            ColorThemeManager.applyThemeToScene(scene, userPreferences);
             mNoiseSquelchPanel.setScene(scene);
         });
 

--- a/src/main/java/io/github/dsheirer/gui/control/JFrequencyControl.java
+++ b/src/main/java/io/github/dsheirer/gui/control/JFrequencyControl.java
@@ -122,6 +122,15 @@ public class JFrequencyControl extends JPanel implements ISourceEventProcessor
     }
 
     /**
+     * Sets the highlight color for the frequency digits when selected.
+     * @param color the color to use for highlighting selected digits
+     */
+    public void setHighlightColor(Color color)
+    {
+        mHighlightColor = color;
+    }
+
+    /**
      * Receives a frequency change event invoked by another control.  We don't
      * rebroadcast this event, just set the control to indicate the new frequency.
      */

--- a/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorFactory.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorFactory.java
@@ -22,6 +22,7 @@ package io.github.dsheirer.gui.preference;
 import io.github.dsheirer.gui.preference.application.ApplicationPreferenceEditor;
 import io.github.dsheirer.gui.preference.calibration.VectorCalibrationPreferenceEditor;
 import io.github.dsheirer.gui.preference.call.CallManagementPreferenceEditor;
+import io.github.dsheirer.gui.preference.colortheme.ColorThemePreferenceEditor;
 import io.github.dsheirer.gui.preference.decoder.JmbeLibraryPreferenceEditor;
 import io.github.dsheirer.gui.preference.directory.DirectoryPreferenceEditor;
 import io.github.dsheirer.gui.preference.mp3.MP3PreferenceEditor;
@@ -52,6 +53,8 @@ public class PreferenceEditorFactory
                 return new RecordPreferenceEditor(userPreferences);
             case CHANNEL_EVENT:
                 return new DecodeEventViewPreferenceEditor(userPreferences);
+            case COLOR_THEME:
+                return new ColorThemePreferenceEditor(userPreferences);
             case DIRECTORY:
                 return new DirectoryPreferenceEditor(userPreferences);
             case JMBE_LIBRARY:

--- a/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorType.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/PreferenceEditorType.java
@@ -26,6 +26,7 @@ public enum PreferenceEditorType
 {
     APPLICATION("Application"),
     CHANNEL_EVENT("Channel Events"),
+    COLOR_THEME("Color Theme"),
     DIRECTORY("Directories"),
     JMBE_LIBRARY("JMBE Audio Library"),
     AUDIO_MP3("MP3"),

--- a/src/main/java/io/github/dsheirer/gui/preference/UserPreferencesEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/UserPreferencesEditor.java
@@ -167,6 +167,7 @@ public class UserPreferencesEditor extends BorderPane
 
             TreeItem<String> applicationItem = new TreeItem<>("Application");
             applicationItem.getChildren().add(new TreeItem(PreferenceEditorType.APPLICATION));
+            applicationItem.getChildren().add(new TreeItem(PreferenceEditorType.COLOR_THEME));
             treeRoot.getChildren().add(applicationItem);
             applicationItem.setExpanded(true);
 

--- a/src/main/java/io/github/dsheirer/gui/preference/colortheme/ColorThemeManager.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/colortheme/ColorThemeManager.java
@@ -1,0 +1,363 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.preference.colortheme;
+
+import io.github.dsheirer.preference.UserPreferences;
+import javafx.scene.Scene;
+import javax.swing.UIManager;
+import javax.swing.plaf.ColorUIResource;
+import java.awt.Color;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the application's color theme (light/dark mode).
+ * This class handles applying the appropriate theme to both JavaFX and Swing components.
+ */
+public class ColorThemeManager
+{
+    private final static Logger mLog = LoggerFactory.getLogger(ColorThemeManager.class);
+    private static final String DARK_MODE_CSS = "/colortheme/dark-theme.css";
+    
+    /**
+     * Applies the user's preferred color theme to a JavaFX scene.
+     * @param scene to apply the theme to
+     * @param userPreferences containing the theme preference
+     */
+    public static void applyThemeToScene(Scene scene, UserPreferences userPreferences)
+    {
+        if(scene != null && userPreferences != null)
+        {
+            boolean darkMode = userPreferences.getColorThemePreference().isDarkModeEnabled();
+            applyThemeToScene(scene, darkMode);
+        }
+    }
+
+    /**
+     * Applies the specified theme to a JavaFX scene.
+     * @param scene to apply the theme to
+     * @param darkMode true for dark mode, false for light mode
+     */
+    public static void applyThemeToScene(Scene scene, boolean darkMode)
+    {
+        if(scene != null)
+        {
+            scene.getStylesheets().clear();
+            
+            if(darkMode)
+            {
+                try
+                {
+                    String css = ColorThemeManager.class.getResource(DARK_MODE_CSS).toExternalForm();
+                    scene.getStylesheets().add(css);
+                }
+                catch(Exception e)
+                {
+                    mLog.error("Error loading dark mode CSS", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Applies Swing dark mode theme colors to the UIManager defaults.
+     * This should be called early in the application lifecycle, before any Swing components are created.
+     * @param userPreferences containing the theme preference
+     */
+    public static void applySwingTheme(UserPreferences userPreferences)
+    {
+        if(userPreferences != null && userPreferences.getColorThemePreference().isDarkModeEnabled())
+        {
+            applySwingDarkMode();
+        }
+    }
+
+    /**
+     * Applies dark mode colors to Swing components.
+     */
+    private static void applySwingDarkMode()
+    {
+        try
+        {
+            // Dark mode colors
+            Color darkBackground = new Color(43, 43, 43);
+            Color darkerBackground = new Color(30, 30, 30);
+            Color lightBackground = new Color(50, 50, 50);
+            Color darkForeground = new Color(187, 187, 187);
+            Color darkSelectionBackground = new Color(75, 110, 175);
+            Color darkSelectionForeground = Color.WHITE;
+            Color darkBorder = new Color(60, 60, 60);
+            Color darkDisabled = new Color(100, 100, 100);
+            
+            // Panel and general backgrounds
+            UIManager.put("Panel.background", new ColorUIResource(darkBackground));
+            UIManager.put("OptionPane.background", new ColorUIResource(darkBackground));
+            UIManager.put("control", new ColorUIResource(darkBackground));
+            UIManager.put("window", new ColorUIResource(darkerBackground));
+            UIManager.put("desktop", new ColorUIResource(darkerBackground));
+            
+            // Text colors
+            UIManager.put("text", new ColorUIResource(darkForeground));
+            UIManager.put("textText", new ColorUIResource(darkForeground));
+            UIManager.put("textForeground", new ColorUIResource(darkForeground));
+            UIManager.put("textHighlight", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("textHighlightText", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("textInactiveText", new ColorUIResource(darkDisabled));
+            UIManager.put("Label.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("Label.disabledForeground", new ColorUIResource(darkDisabled));
+            UIManager.put("Panel.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("info", new ColorUIResource(darkBackground));
+            UIManager.put("infoText", new ColorUIResource(darkForeground));
+            
+            // Button colors
+            UIManager.put("Button.background", new ColorUIResource(darkBackground));
+            UIManager.put("Button.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("Button.select", new ColorUIResource(darkerBackground));
+            UIManager.put("Button.shadow", new ColorUIResource(darkerBackground));
+            UIManager.put("Button.darkShadow", new ColorUIResource(darkerBackground));
+            UIManager.put("Button.light", new ColorUIResource(lightBackground));
+            UIManager.put("Button.highlight", new ColorUIResource(lightBackground));
+            UIManager.put("Button.border", new ColorUIResource(darkBorder));
+            UIManager.put("Button.disabledText", new ColorUIResource(darkDisabled));
+            UIManager.put("Button.focus", new ColorUIResource(darkSelectionBackground));
+            
+            // TextField colors
+            UIManager.put("TextField.background", new ColorUIResource(darkerBackground));
+            UIManager.put("TextField.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("TextField.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("TextField.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("TextField.inactiveForeground", new ColorUIResource(darkForeground.darker()));
+            UIManager.put("TextField.caretForeground", new ColorUIResource(darkForeground));
+            UIManager.put("FormattedTextField.background", new ColorUIResource(darkerBackground));
+            UIManager.put("FormattedTextField.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("PasswordField.background", new ColorUIResource(darkerBackground));
+            UIManager.put("PasswordField.foreground", new ColorUIResource(darkForeground));
+            
+            // TextArea colors
+            UIManager.put("TextArea.background", new ColorUIResource(darkerBackground));
+            UIManager.put("TextArea.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("TextArea.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("TextArea.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            
+            // List colors
+            UIManager.put("List.background", new ColorUIResource(darkerBackground));
+            UIManager.put("List.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("List.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("List.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            
+            // Table colors
+            UIManager.put("Table.background", new ColorUIResource(darkerBackground));
+            UIManager.put("Table.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("Table.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("Table.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("Table.gridColor", new ColorUIResource(darkBorder));
+            UIManager.put("Table.focusCellBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("Table.focusCellForeground", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("Table.dropLineColor", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("Table.dropLineShortColor", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("TableHeader.background", new ColorUIResource(darkBackground));
+            UIManager.put("TableHeader.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("TableHeader.cellBorder", new ColorUIResource(darkBorder));
+            
+            // Tree colors
+            UIManager.put("Tree.background", new ColorUIResource(darkerBackground));
+            UIManager.put("Tree.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("Tree.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("Tree.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("Tree.textBackground", new ColorUIResource(darkerBackground));
+            UIManager.put("Tree.textForeground", new ColorUIResource(darkForeground));
+            
+            // Menu colors - force dark backgrounds
+            UIManager.put("Menu.background", new ColorUIResource(darkBackground));
+            UIManager.put("Menu.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("Menu.opaque", true);
+            UIManager.put("MenuBar.background", new ColorUIResource(darkBackground));
+            UIManager.put("MenuBar.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("MenuBar.border", new ColorUIResource(darkBorder));
+            UIManager.put("MenuBar.shadow", new ColorUIResource(darkerBackground));
+            UIManager.put("MenuBar.highlight", new ColorUIResource(lightBackground));
+            UIManager.put("MenuItem.background", new ColorUIResource(darkBackground));
+            UIManager.put("MenuItem.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("MenuItem.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("MenuItem.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("MenuItem.opaque", true);
+            UIManager.put("MenuItem.border", new ColorUIResource(darkBorder));
+            UIManager.put("PopupMenu.background", new ColorUIResource(darkBackground));
+            UIManager.put("PopupMenu.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("CheckBoxMenuItem.background", new ColorUIResource(darkBackground));
+            UIManager.put("CheckBoxMenuItem.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("CheckBoxMenuItem.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("CheckBoxMenuItem.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("RadioButtonMenuItem.background", new ColorUIResource(darkBackground));
+            UIManager.put("RadioButtonMenuItem.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("RadioButtonMenuItem.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("RadioButtonMenuItem.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            
+            // ComboBox colors
+            UIManager.put("ComboBox.background", new ColorUIResource(darkerBackground));
+            UIManager.put("ComboBox.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("ComboBox.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("ComboBox.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            
+            // Spinner styling
+            UIManager.put("Spinner.background", new ColorUIResource(darkerBackground));
+            UIManager.put("Spinner.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("Spinner.border", new ColorUIResource(darkBorder));
+            
+            // ProgressBar styling
+            UIManager.put("ProgressBar.background", new ColorUIResource(darkerBackground));
+            UIManager.put("ProgressBar.foreground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("ProgressBar.selectionBackground", new ColorUIResource(darkForeground));
+            UIManager.put("ProgressBar.selectionForeground", new ColorUIResource(darkForeground));
+            
+            // ScrollBar colors
+            UIManager.put("ScrollBar.track", new ColorUIResource(darkerBackground));
+            UIManager.put("ScrollBar.thumb", new ColorUIResource(darkBackground.brighter()));
+            UIManager.put("ScrollBar.background", new ColorUIResource(darkBackground));
+            
+            // TabbedPane colors
+            UIManager.put("TabbedPane.background", new ColorUIResource(darkBackground));
+            UIManager.put("TabbedPane.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("TabbedPane.selected", new ColorUIResource(darkerBackground));
+            UIManager.put("TabbedPane.contentAreaColor", new ColorUIResource(darkBackground));
+            
+            // ToolTip colors
+            UIManager.put("ToolTip.background", new ColorUIResource(darkBackground.brighter()));
+            UIManager.put("ToolTip.foreground", new ColorUIResource(darkForeground));
+            
+            // Border colors
+            UIManager.put("TextField.border", new ColorUIResource(darkBorder));
+            UIManager.put("ScrollPane.border", new ColorUIResource(darkBorder));
+            
+            // Split pane colors
+            UIManager.put("SplitPane.background", new ColorUIResource(darkBackground));
+            UIManager.put("SplitPane.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("SplitPane.dividerFocusColor", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("SplitPaneDivider.draggingColor", new ColorUIResource(darkSelectionBackground));
+            
+            // Viewport and ScrollPane specific
+            UIManager.put("Viewport.background", new ColorUIResource(darkerBackground));
+            UIManager.put("Viewport.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("ScrollPane.background", new ColorUIResource(darkerBackground));
+            UIManager.put("ScrollPane.foreground", new ColorUIResource(darkForeground));
+            
+            // Additional component colors
+            UIManager.put("Separator.foreground", new ColorUIResource(darkBorder));
+            UIManager.put("Separator.background", new ColorUIResource(darkBorder));
+            UIManager.put("Separator.shadow", new ColorUIResource(darkBorder));
+            UIManager.put("Separator.highlight", new ColorUIResource(lightBackground));
+            
+            // EditorPane and TextPane
+            UIManager.put("EditorPane.background", new ColorUIResource(darkerBackground));
+            UIManager.put("EditorPane.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("EditorPane.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("EditorPane.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            UIManager.put("TextPane.background", new ColorUIResource(darkerBackground));
+            UIManager.put("TextPane.foreground", new ColorUIResource(darkForeground));
+            UIManager.put("TextPane.selectionBackground", new ColorUIResource(darkSelectionBackground));
+            UIManager.put("TextPane.selectionForeground", new ColorUIResource(darkSelectionForeground));
+            
+            // InternalFrame
+            UIManager.put("InternalFrame.background", new ColorUIResource(darkBackground));
+            
+            // Ensure nimbusBase and other Nimbus-specific properties don't override
+            UIManager.put("nimbusBase", new ColorUIResource(darkBackground));
+            UIManager.put("nimbusBlueGrey", new ColorUIResource(darkBackground));
+            UIManager.put("control", new ColorUIResource(darkBackground));
+            UIManager.put("controlHighlight", new ColorUIResource(lightBackground));
+            UIManager.put("controlShadow", new ColorUIResource(darkerBackground));
+            UIManager.put("controlDkShadow", new ColorUIResource(darkerBackground));
+            UIManager.put("controlLtHighlight", new ColorUIResource(lightBackground));
+            
+            // Additional components that might have white backgrounds
+            UIManager.put("DesktopPane.background", new ColorUIResource(darkerBackground));
+            UIManager.put("InternalFrame.activeTitleBackground", new ColorUIResource(darkBackground));
+            UIManager.put("InternalFrame.inactiveTitleBackground", new ColorUIResource(darkerBackground));
+            UIManager.put("OptionPane.messageForeground", new ColorUIResource(darkForeground));
+            
+            // Label and text rendering
+            UIManager.put("activeCaption", new ColorUIResource(darkBackground));
+            UIManager.put("activeCaptionText", new ColorUIResource(darkForeground));
+            UIManager.put("inactiveCaption", new ColorUIResource(darkerBackground));
+            UIManager.put("inactiveCaptionText", new ColorUIResource(darkDisabled));
+            
+            mLog.info("Applied Swing dark mode theme");
+        }
+        catch(Exception e)
+        {
+            mLog.error("Error applying Swing dark mode theme", e);
+        }
+    }
+    
+    /**
+     * Updates all components in a container to use the current theme.
+     * This should be called after UIManager properties are set.
+     * @param container the container whose components should be updated
+     */
+    public static void updateComponentTreeUI(java.awt.Container container)
+    {
+        if(container != null)
+        {
+            try
+            {
+                javax.swing.SwingUtilities.updateComponentTreeUI(container);
+
+                // Force repaint
+                container.invalidate();
+                container.validate();
+                container.repaint();
+            }
+            catch(Exception e)
+            {
+                mLog.error("Error updating component tree UI", e);
+            }
+        }
+    }
+
+    /**
+     * Apply dark theme colors directly to a component (for when UIManager defaults don't work)
+     */
+    public static void applyDarkThemeToComponent(java.awt.Component component, UserPreferences userPreferences)
+    {
+        if(userPreferences.getColorThemePreference().isDarkModeEnabled() && component != null)
+        {
+            java.awt.Color darkBackground = new java.awt.Color(43, 43, 43);
+            java.awt.Color darkerBackground = new java.awt.Color(30, 30, 30);
+            java.awt.Color darkForeground = new java.awt.Color(187, 187, 187);
+            
+            if(component instanceof javax.swing.JSlider)
+            {
+                component.setBackground(darkBackground);
+                component.setForeground(darkForeground);
+            }
+            else if(component instanceof javax.swing.JButton || component instanceof javax.swing.JToggleButton)
+            {
+                component.setBackground(darkBackground);
+                component.setForeground(darkForeground);
+            }
+            else if(component instanceof javax.swing.JMenuBar || component instanceof javax.swing.JMenu)
+            {
+                component.setBackground(darkBackground);
+                component.setForeground(darkForeground);
+            }
+        }
+    }
+}
+

--- a/src/main/java/io/github/dsheirer/gui/preference/colortheme/ColorThemePreferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/colortheme/ColorThemePreferenceEditor.java
@@ -1,0 +1,124 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.preference.colortheme;
+
+import io.github.dsheirer.preference.UserPreferences;
+import io.github.dsheirer.preference.colortheme.ColorThemePreference;
+import javafx.geometry.HPos;
+import javafx.geometry.Insets;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.Label;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import org.controlsfx.control.ToggleSwitch;
+
+/**
+ * Preference settings for color theme
+ */
+public class ColorThemePreferenceEditor extends HBox
+{
+    private ColorThemePreference mColorThemePreference;
+    private GridPane mEditorPane;
+    private ToggleSwitch mDarkModeToggle;
+
+    /**
+     * Constructs an instance
+     * @param userPreferences for obtaining reference to preference.
+     */
+    public ColorThemePreferenceEditor(UserPreferences userPreferences)
+    {
+        mColorThemePreference = userPreferences.getColorThemePreference();
+        setMaxWidth(Double.MAX_VALUE);
+
+        VBox vbox = new VBox();
+        vbox.setMaxHeight(Double.MAX_VALUE);
+        vbox.setMaxWidth(Double.MAX_VALUE);
+        vbox.getChildren().add(getEditorPane());
+        HBox.setHgrow(vbox, Priority.ALWAYS);
+        getChildren().add(vbox);
+    }
+
+    private GridPane getEditorPane()
+    {
+        if(mEditorPane == null)
+        {
+            int row = 0;
+            mEditorPane = new GridPane();
+            mEditorPane.setMaxWidth(Double.MAX_VALUE);
+            mEditorPane.setVgap(10);
+            mEditorPane.setHgap(3);
+            mEditorPane.setPadding(new Insets(10, 10, 10, 10));
+
+            Label themeLabel = new Label("Application Color Theme");
+            mEditorPane.add(themeLabel, 0, row, 2, 1);
+            
+            GridPane.setHalignment(getDarkModeToggle(), HPos.RIGHT);
+            mEditorPane.add(getDarkModeToggle(), 0, ++row);
+            mEditorPane.add(new Label("Enable Dark Mode"), 1, row, 2, 1);
+
+            Label restartLabel = new Label("Note: Application restart is required for theme changes to take full effect.");
+            restartLabel.setStyle("-fx-font-style: italic; -fx-text-fill: gray;");
+            mEditorPane.add(restartLabel, 0, ++row, 3, 1);
+
+            ColumnConstraints c1 = new ColumnConstraints();
+            c1.setPercentWidth(30);
+            ColumnConstraints c2 = new ColumnConstraints();
+            c2.setHgrow(Priority.ALWAYS);
+            mEditorPane.getColumnConstraints().addAll(c1, c2);
+        }
+
+        return mEditorPane;
+    }
+
+    /**
+     * Toggle switch to enable/disable dark mode.
+     */
+    private ToggleSwitch getDarkModeToggle()
+    {
+        if(mDarkModeToggle == null)
+        {
+            mDarkModeToggle = new ToggleSwitch();
+            mDarkModeToggle.setSelected(mColorThemePreference.isDarkModeEnabled());
+            mDarkModeToggle.selectedProperty().addListener((observable, oldValue, enabled) -> {
+                mColorThemePreference.setDarkModeEnabled(enabled);
+                showRestartAlert();
+            });
+        }
+
+        return mDarkModeToggle;
+    }
+
+    /**
+     * Shows an alert informing the user that a restart is recommended.
+     */
+    private void showRestartAlert()
+    {
+        Alert alert = new Alert(AlertType.INFORMATION);
+        alert.setTitle("Restart Required");
+        alert.setHeaderText("Theme Change");
+        alert.setContentText("Please restart the application for the theme change to take full effect.");
+        alert.showAndWait();
+    }
+}
+

--- a/src/main/java/io/github/dsheirer/map/MapPanel.java
+++ b/src/main/java/io/github/dsheirer/map/MapPanel.java
@@ -89,18 +89,22 @@ public class MapPanel extends JPanel implements IPlottableUpdateListener
     private JTable mTrackHistoryTable;
     private JLabel mSelectedTrackSystemLabel;
 
+    private io.github.dsheirer.preference.UserPreferences mUserPreferences;
+
     /**
      * Constructs an instance
      * @param mapService for accessing entities to plot
      * @param aliasModel for alias lookup
      * @param iconModel for icon lookup
      * @param settingsManager for user specified options/settings.
+     * @param userPreferences for accessing user preferences like dark mode
      */
-    public MapPanel(MapService mapService, AliasModel aliasModel, IconModel iconModel, SettingsManager settingsManager)
+    public MapPanel(MapService mapService, AliasModel aliasModel, IconModel iconModel, SettingsManager settingsManager, io.github.dsheirer.preference.UserPreferences userPreferences)
     {
         mSettingsManager = settingsManager;
         mMapService = mapService;
         mMapPainter = new PlottableEntityPainter(aliasModel, iconModel);
+        mUserPreferences = userPreferences;
 
         init();
     }
@@ -189,6 +193,13 @@ public class MapPanel extends JPanel implements IPlottableUpdateListener
         if(mReplotAllTracksButton == null)
         {
             mReplotAllTracksButton = new JButton("Replot All");
+            mReplotAllTracksButton.setOpaque(true);
+            mReplotAllTracksButton.setContentAreaFilled(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mReplotAllTracksButton.setBackground(new java.awt.Color(43, 43, 43));
+                mReplotAllTracksButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mReplotAllTracksButton.addActionListener(e ->
             {
                 boolean added = mMapPainter.addAll(mMapService.getPlottableEntityModel().getAll());
@@ -329,6 +340,13 @@ public class MapPanel extends JPanel implements IPlottableUpdateListener
         if(mClearMapButton == null)
         {
             mClearMapButton = new JButton("Clear Map");
+            mClearMapButton.setOpaque(true);
+            mClearMapButton.setContentAreaFilled(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mClearMapButton.setBackground(new java.awt.Color(43, 43, 43));
+                mClearMapButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mClearMapButton.addActionListener(e ->
             {
                 mMapPainter.clearAllEntities();
@@ -348,6 +366,12 @@ public class MapPanel extends JPanel implements IPlottableUpdateListener
         if(mCenterOnSelectedCheckBox == null)
         {
             mCenterOnSelectedCheckBox = new JCheckBox("Center on Selection");
+            mCenterOnSelectedCheckBox.setOpaque(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mCenterOnSelectedCheckBox.setBackground(new java.awt.Color(43, 43, 43));
+                mCenterOnSelectedCheckBox.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mCenterOnSelectedCheckBox.setSelected(true);
         }
 
@@ -359,6 +383,13 @@ public class MapPanel extends JPanel implements IPlottableUpdateListener
         if(mDeleteAllTracksButton == null)
         {
             mDeleteAllTracksButton = new JButton("Delete All");
+            mDeleteAllTracksButton.setOpaque(true);
+            mDeleteAllTracksButton.setContentAreaFilled(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mDeleteAllTracksButton.setBackground(new java.awt.Color(43, 43, 43));
+                mDeleteAllTracksButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mDeleteAllTracksButton.addActionListener(e -> {
                 mMapService.getPlottableEntityModel().deleteAllTracks();
                 mMapPainter.clearAllEntities();
@@ -592,8 +623,12 @@ public class MapPanel extends JPanel implements IPlottableUpdateListener
 
             /**
              * Map image source
+             * Note: Dark mode map tiles have compatibility issues with JXMapViewer.
+             * The map will use standard OpenStreetMap tiles regardless of dark mode setting.
+             * All UI controls around the map will still respect dark mode.
              */
             TileFactoryInfo info = new OSMTileFactoryInfo();
+            
             DefaultTileFactory tileFactory = new DefaultTileFactory(info);
             mMapViewer.setTileFactory(tileFactory);
 

--- a/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/DecodeEventPanel.java
@@ -99,7 +99,7 @@ public class DecodeEventPanel extends JPanel implements Listener<ProcessingChain
         mTable.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
         mTableColumnWidthMonitor = new JTableColumnWidthMonitor(mUserPreferences, mTable, TABLE_PREFERENCE_KEY);
         updateCellRenderers();
-        mHistoryManagementPanel = new HistoryManagementPanel<>(mEventModel, "Event Filter Editor");
+        mHistoryManagementPanel = new HistoryManagementPanel<>(mEventModel, "Event Filter Editor", mUserPreferences);
         mHistoryManagementPanel.updateFilterSet(mFilterSet);
         add(mHistoryManagementPanel, "span,growx");
         mEmptyScroller = new JScrollPane(mTable);

--- a/src/main/java/io/github/dsheirer/module/decode/event/HistoryManagementPanel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/HistoryManagementPanel.java
@@ -21,6 +21,7 @@ package io.github.dsheirer.module.decode.event;
 
 import io.github.dsheirer.filter.FilterEditor;
 import io.github.dsheirer.filter.FilterSet;
+import io.github.dsheirer.preference.UserPreferences;
 import java.awt.EventQueue;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -46,15 +47,19 @@ public class HistoryManagementPanel<T> extends JPanel
     private JLabel mHistoryTitleLabel;
     private JLabel mHistoryValueLabel;
     private String mFilterEditorTitle;
+    private UserPreferences mUserPreferences;
 
     /**
      * Constructs an instance
      * @param model to manage
+     * @param filterEditorTitle for the filter editor
+     * @param userPreferences for accessing user preferences like dark mode
      */
-    public HistoryManagementPanel(ClearableHistoryModel model, String filterEditorTitle)
+    public HistoryManagementPanel(ClearableHistoryModel model, String filterEditorTitle, UserPreferences userPreferences)
     {
         mModel = model;
         mFilterEditorTitle = filterEditorTitle;
+        mUserPreferences = userPreferences;
         setLayout(new MigLayout("insets 6 1 5 5", "[]5[]10[]5[]5[][grow]", ""));
         add(getFilterButton());
         add(getClearButton());
@@ -176,6 +181,12 @@ public class HistoryManagementPanel<T> extends JPanel
         if(mHistorySlider == null)
         {
             mHistorySlider = new JSlider();
+            mHistorySlider.setOpaque(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mHistorySlider.setBackground(new java.awt.Color(43, 43, 43));
+                mHistorySlider.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mHistorySlider.setToolTipText("Adjust history size.  Double-click to reset to default 200");
             mHistorySlider.setMinimum(0);
             mHistorySlider.setMaximum(2000);

--- a/src/main/java/io/github/dsheirer/module/decode/event/MessageActivityPanel.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/MessageActivityPanel.java
@@ -68,7 +68,7 @@ public class MessageActivityPanel extends JPanel implements Listener<ProcessingC
         mTable.setRowSorter(mTableRowSorter);
         mTableColumnWidthMonitor = new JTableColumnWidthMonitor(mUserPreferences, mTable, TABLE_PREFERENCE_KEY);
         setLayout(new MigLayout("insets 0 0 0 0", "[][grow,fill]", "[]0[grow,fill]"));
-        mHistoryManagementPanel = new HistoryManagementPanel<>(mMessageModel, "Message Filter Editor");
+        mHistoryManagementPanel = new HistoryManagementPanel<>(mMessageModel, "Message Filter Editor", mUserPreferences);
         add(mHistoryManagementPanel, "span,growx");
         add(new JScrollPane(mTable), "span,grow");
     }

--- a/src/main/java/io/github/dsheirer/module/decode/event/filter/EventClearButton.java
+++ b/src/main/java/io/github/dsheirer/module/decode/event/filter/EventClearButton.java
@@ -73,6 +73,8 @@ public class EventClearButton extends JideSplitButton
         private JSlider initializeHistorySlider()
         {
             final JSlider slider = new JSlider();
+            slider.setOpaque(true);
+            // Dark mode colors will be applied by UIManager if enabled
             slider.setMinimum(0);
             slider.setMaximum(2000);
             slider.setMajorTickSpacing(500);

--- a/src/main/java/io/github/dsheirer/preference/PreferenceType.java
+++ b/src/main/java/io/github/dsheirer/preference/PreferenceType.java
@@ -26,6 +26,7 @@ public enum PreferenceType
 {
     APPLICATION,
     CALIBRATION,
+    COLOR_THEME,
     DECODE_EVENT,
     DIRECTORY,
     DUPLICATE_CALL_DETECTION,

--- a/src/main/java/io/github/dsheirer/preference/UserPreferences.java
+++ b/src/main/java/io/github/dsheirer/preference/UserPreferences.java
@@ -22,6 +22,7 @@ package io.github.dsheirer.preference;
 import io.github.dsheirer.eventbus.MyEventBus;
 import io.github.dsheirer.preference.application.ApplicationPreference;
 import io.github.dsheirer.preference.calibration.VectorCalibrationPreference;
+import io.github.dsheirer.preference.colortheme.ColorThemePreference;
 import io.github.dsheirer.preference.decoder.JmbeLibraryPreference;
 import io.github.dsheirer.preference.directory.DirectoryPreference;
 import io.github.dsheirer.preference.duplicate.CallManagementPreference;
@@ -58,6 +59,7 @@ public class UserPreferences implements Listener<PreferenceType>
 {
     private ApplicationPreference mApplicationPreference;
     private ChannelMultiFrequencyPreference mChannelMultiFrequencyPreference;
+    private ColorThemePreference mColorThemePreference;
     private DecodeEventPreference mDecodeEventPreference;
     private DirectoryPreference mDirectoryPreference;
     private CallManagementPreference mCallManagementPreference;
@@ -214,12 +216,21 @@ public class UserPreferences implements Listener<PreferenceType>
     }
 
     /**
+     * Color theme preferences
+     */
+    public ColorThemePreference getColorThemePreference()
+    {
+        return mColorThemePreference;
+    }
+
+    /**
      * Loads the managed preferences
      */
     private void loadPreferenceTypes()
     {
         mApplicationPreference = new ApplicationPreference(this::receive);
         mChannelMultiFrequencyPreference = new ChannelMultiFrequencyPreference(this::receive);
+        mColorThemePreference = new ColorThemePreference(this::receive);
         mDecodeEventPreference = new DecodeEventPreference(this::receive);
         mDirectoryPreference = new DirectoryPreference(this::receive);
         mCallManagementPreference = new CallManagementPreference(this::receive);

--- a/src/main/java/io/github/dsheirer/preference/colortheme/ColorThemePreference.java
+++ b/src/main/java/io/github/dsheirer/preference/colortheme/ColorThemePreference.java
@@ -1,0 +1,174 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.preference.colortheme;
+
+import io.github.dsheirer.preference.Preference;
+import io.github.dsheirer.preference.PreferenceType;
+import io.github.dsheirer.sample.Listener;
+import java.util.prefs.Preferences;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Color theme preferences for the application UI
+ */
+public class ColorThemePreference extends Preference
+{
+    private static final String PREFERENCE_KEY_DARK_MODE_ENABLED = "color.theme.dark.mode.enabled";
+    private static final String PREFERENCE_KEY_USER_SET = "color.theme.user.set";
+    
+    private final static Logger mLog = LoggerFactory.getLogger(ColorThemePreference.class);
+    private Preferences mPreferences = Preferences.userNodeForPackage(ColorThemePreference.class);
+    private Boolean mDarkModeEnabled;
+
+    /**
+     * Constructs an instance
+     * @param updateListener to receive notifications that a preference has been updated
+     */
+    public ColorThemePreference(Listener<PreferenceType> updateListener)
+    {
+        super(updateListener);
+    }
+
+    @Override
+    public PreferenceType getPreferenceType()
+    {
+        return PreferenceType.COLOR_THEME;
+    }
+
+    /**
+     * Indicates if dark mode is enabled.
+     * On first run, automatically detects Windows system theme.
+     * @return true if dark mode is enabled.
+     */
+    public boolean isDarkModeEnabled()
+    {
+        if(mDarkModeEnabled == null)
+        {
+            // Check if user has explicitly set the preference
+            boolean userHasSet = mPreferences.getBoolean(PREFERENCE_KEY_USER_SET, false);
+            
+            System.out.println("[ColorTheme] User has set preference: " + userHasSet);
+            
+            if(!userHasSet)
+            {
+                // First time - detect system theme and use as default
+                System.out.println("[ColorTheme] First run detected - checking system theme...");
+                boolean systemDarkMode = isSystemInDarkMode();
+                mDarkModeEnabled = systemDarkMode;
+                // Save the detected value to preferences
+                mPreferences.putBoolean(PREFERENCE_KEY_DARK_MODE_ENABLED, systemDarkMode);
+                System.out.println("[ColorTheme] Detected and saved: " + (systemDarkMode ? "DARK MODE" : "LIGHT MODE"));
+                mLog.info("First run - detected Windows system theme: " + (systemDarkMode ? "Dark" : "Light") + " - applying as default");
+            }
+            else
+            {
+                // User has set preference before - use saved value
+                mDarkModeEnabled = mPreferences.getBoolean(PREFERENCE_KEY_DARK_MODE_ENABLED, false);
+                System.out.println("[ColorTheme] Using saved preference: " + (mDarkModeEnabled ? "DARK MODE" : "LIGHT MODE"));
+            }
+        }
+
+        return mDarkModeEnabled;
+    }
+    
+    /**
+     * Detects if Windows is in dark mode by checking the registry.
+     * @return true if Windows is in dark mode, false otherwise or if detection fails.
+     */
+    private boolean isSystemInDarkMode()
+    {
+        try
+        {
+            String os = System.getProperty("os.name").toLowerCase();
+            System.out.println("[ColorTheme] Detecting system theme for OS: " + os);
+            mLog.info("Detecting system theme for OS: " + os);
+            
+            if(os.contains("win"))
+            {
+                // Check Windows registry for dark mode setting
+                // HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize\AppsUseLightTheme
+                // 0x0 = Dark mode, 0x1 = Light mode
+                String command = "reg query HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize /v AppsUseLightTheme";
+                System.out.println("[ColorTheme] Executing: " + command);
+                mLog.info("Executing registry query: " + command);
+                
+                Process process = Runtime.getRuntime().exec(command);
+                
+                java.io.BufferedReader reader = new java.io.BufferedReader(
+                    new java.io.InputStreamReader(process.getInputStream()));
+                
+                String line;
+                while((line = reader.readLine()) != null)
+                {
+                    System.out.println("[ColorTheme] Registry: " + line);
+                    mLog.info("Registry output: " + line);
+                    if(line.contains("AppsUseLightTheme"))
+                    {
+                        // Extract the value (0x0 or 0x1)
+                        String[] parts = line.trim().split("\\s+");
+                        if(parts.length >= 3)
+                        {
+                            String value = parts[parts.length - 1];
+                            // 0x0 = Dark mode, 0x1 = Light mode
+                            boolean isDark = "0x0".equals(value);
+                            System.out.println("[ColorTheme] Result: AppsUseLightTheme=" + value + " -> " + (isDark ? "DARK MODE" : "LIGHT MODE"));
+                            mLog.info("Windows theme detected - AppsUseLightTheme=" + value + " -> " + (isDark ? "DARK MODE" : "LIGHT MODE"));
+                            reader.close();
+                            return isDark;
+                        }
+                    }
+                }
+                reader.close();
+                System.out.println("[ColorTheme] WARNING: Could not find registry value");
+                mLog.warn("Could not find AppsUseLightTheme registry value - defaulting to light mode");
+            }
+            else
+            {
+                System.out.println("[ColorTheme] Non-Windows OS - defaulting to light mode");
+                mLog.info("Non-Windows OS detected: " + os + " - defaulting to light mode");
+            }
+        }
+        catch(Exception e)
+        {
+            System.out.println("[ColorTheme] ERROR: " + e.getMessage());
+            e.printStackTrace();
+            mLog.error("Exception while detecting system theme - defaulting to light mode", e);
+        }
+        
+        // Default to light mode if detection fails or not on Windows
+        System.out.println("[ColorTheme] Defaulting to LIGHT MODE");
+        return false;
+    }
+
+    /**
+     * Sets the dark mode enabled state.
+     * @param enabled true to enable dark mode.
+     */
+    public void setDarkModeEnabled(boolean enabled)
+    {
+        mDarkModeEnabled = enabled;
+        mPreferences.putBoolean(PREFERENCE_KEY_DARK_MODE_ENABLED, enabled);
+        // Mark that user has explicitly set this preference
+        mPreferences.putBoolean(PREFERENCE_KEY_USER_SET, true);
+        notifyPreferenceUpdated();
+    }
+}
+

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/e4k/E4KTunerEditor.java
@@ -215,6 +215,13 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         if(mBiasTButton == null)
         {
             mBiasTButton = new JToggleButton("Bias-T");
+            mBiasTButton.setOpaque(true);
+            mBiasTButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mBiasTButton.setBackground(new java.awt.Color(43, 43, 43));
+                mBiasTButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mBiasTButton.setEnabled(false);
             mBiasTButton.addActionListener(e -> {
                 if(!isLoading())
@@ -267,6 +274,13 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         if(mLNAGainCombo == null)
         {
             mLNAGainCombo = new JComboBox<>(E4KLNAGain.values());
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mLNAGainCombo.setBackground(new java.awt.Color(43, 43, 43));
+                mLNAGainCombo.setForeground(new java.awt.Color(187, 187, 187));
+                // Set a darker gray for disabled state that's more visible in dark mode
+                javax.swing.UIManager.put("ComboBox.disabledForeground", new java.awt.Color(120, 120, 120));
+            }
             mLNAGainCombo.addActionListener(arg0 ->
             {
                 if(!isLoading())
@@ -297,6 +311,13 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         if(mMixerGainCombo == null)
         {
             mMixerGainCombo = new JComboBox<>(E4KMixerGain.values());
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mMixerGainCombo.setBackground(new java.awt.Color(43, 43, 43));
+                mMixerGainCombo.setForeground(new java.awt.Color(187, 187, 187));
+                // Set a darker gray for disabled state that's more visible in dark mode
+                javax.swing.UIManager.put("ComboBox.disabledForeground", new java.awt.Color(120, 120, 120));
+            }
             mMixerGainCombo.addActionListener(arg0 ->
             {
                 if(!isLoading())
@@ -410,6 +431,13 @@ public class E4KTunerEditor extends TunerEditor<RTL2832Tuner, E4KTunerConfigurat
         if(mTunerInfoButton == null)
         {
             mTunerInfoButton = new JButton("Tuner Info");
+            mTunerInfoButton.setOpaque(true);
+            mTunerInfoButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mTunerInfoButton.setBackground(new java.awt.Color(43, 43, 43));
+                mTunerInfoButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mTunerInfoButton.setEnabled(false);
             mTunerInfoButton.addActionListener(e -> JOptionPane.showMessageDialog(E4KTunerEditor.this,
                     getTunerInfo(), "Tuner Info", JOptionPane.INFORMATION_MESSAGE));

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/fc0013/FC0013TunerEditor.java
@@ -191,6 +191,13 @@ public class FC0013TunerEditor extends TunerEditor<RTL2832Tuner, FC0013TunerConf
         if(mBiasTButton == null)
         {
             mBiasTButton = new JToggleButton("Bias-T");
+            mBiasTButton.setOpaque(true);
+            mBiasTButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mBiasTButton.setBackground(new java.awt.Color(43, 43, 43));
+                mBiasTButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mBiasTButton.setEnabled(false);
             mBiasTButton.addActionListener(e -> {
                 if(!isLoading())
@@ -212,6 +219,13 @@ public class FC0013TunerEditor extends TunerEditor<RTL2832Tuner, FC0013TunerConf
         if(mTunerInfoButton == null)
         {
             mTunerInfoButton = new JButton("Info");
+            mTunerInfoButton.setOpaque(true);
+            mTunerInfoButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mTunerInfoButton.setBackground(new java.awt.Color(43, 43, 43));
+                mTunerInfoButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mTunerInfoButton.setEnabled(false);
             mTunerInfoButton.addActionListener(e -> JOptionPane.showMessageDialog(FC0013TunerEditor.this,
                     getTunerInfo(), "Tuner Info", JOptionPane.INFORMATION_MESSAGE));
@@ -225,6 +239,13 @@ public class FC0013TunerEditor extends TunerEditor<RTL2832Tuner, FC0013TunerConf
         if(mLNAGainCombo == null)
         {
             mLNAGainCombo = new JComboBox<>(FC0013EmbeddedTuner.LNAGain.values());
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mLNAGainCombo.setBackground(new java.awt.Color(43, 43, 43));
+                mLNAGainCombo.setForeground(new java.awt.Color(187, 187, 187));
+                // Set a darker gray for disabled state that's more visible in dark mode
+                javax.swing.UIManager.put("ComboBox.disabledForeground", new java.awt.Color(120, 120, 120));
+            }
             mLNAGainCombo.setEnabled(false);
             mLNAGainCombo.addActionListener(arg0 ->
             {

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/r8x/R8xTunerEditor.java
@@ -223,6 +223,13 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
         if(mBiasTButton == null)
         {
             mBiasTButton = new JToggleButton("Bias-T");
+            mBiasTButton.setOpaque(true);
+            mBiasTButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mBiasTButton.setBackground(new java.awt.Color(43, 43, 43));
+                mBiasTButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mBiasTButton.setEnabled(false);
             mBiasTButton.addActionListener(e -> {
                 if(!isLoading())
@@ -244,6 +251,13 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
         if(mTunerInfoButton == null)
         {
             mTunerInfoButton = new JButton("Info");
+            mTunerInfoButton.setOpaque(true);
+            mTunerInfoButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mTunerInfoButton.setBackground(new java.awt.Color(43, 43, 43));
+                mTunerInfoButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mTunerInfoButton.setEnabled(false);
             mTunerInfoButton.addActionListener(e -> JOptionPane.showMessageDialog(R8xTunerEditor.this,
                     getTunerInfo(), "Tuner Info", JOptionPane.INFORMATION_MESSAGE));
@@ -257,6 +271,13 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
         if(mVGAGainCombo == null)
         {
             mVGAGainCombo = new JComboBox<>(R8xEmbeddedTuner.VGAGain.values());
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mVGAGainCombo.setBackground(new java.awt.Color(43, 43, 43));
+                mVGAGainCombo.setForeground(new java.awt.Color(187, 187, 187));
+                // Set a darker gray for disabled state that's more visible in dark mode
+                javax.swing.UIManager.put("ComboBox.disabledForeground", new java.awt.Color(120, 120, 120));
+            }
             mVGAGainCombo.setEnabled(false);
             mVGAGainCombo.addActionListener(arg0 ->
             {
@@ -294,6 +315,13 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
         if(mLNAGainCombo == null)
         {
             mLNAGainCombo = new JComboBox<>(R8xEmbeddedTuner.LNAGain.values());
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mLNAGainCombo.setBackground(new java.awt.Color(43, 43, 43));
+                mLNAGainCombo.setForeground(new java.awt.Color(187, 187, 187));
+                // Set a darker gray for disabled state that's more visible in dark mode
+                javax.swing.UIManager.put("ComboBox.disabledForeground", new java.awt.Color(120, 120, 120));
+            }
             mLNAGainCombo.setEnabled(false);
             mLNAGainCombo.addActionListener(arg0 ->
             {
@@ -366,6 +394,13 @@ public class R8xTunerEditor extends TunerEditor<RTL2832Tuner, R8xTunerConfigurat
         if(mMixerGainCombo == null)
         {
             mMixerGainCombo = new JComboBox<>(R8xEmbeddedTuner.MixerGain.values());
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mMixerGainCombo.setBackground(new java.awt.Color(43, 43, 43));
+                mMixerGainCombo.setForeground(new java.awt.Color(187, 187, 187));
+                // Set a darker gray for disabled state that's more visible in dark mode
+                javax.swing.UIManager.put("ComboBox.disabledForeground", new java.awt.Color(120, 120, 120));
+            }
             mMixerGainCombo.setEnabled(false);
             mMixerGainCombo.addActionListener(arg0 ->
             {

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/RspTunerEditor.java
@@ -243,6 +243,12 @@ public abstract class RspTunerEditor<C extends RspTunerConfiguration> extends Tu
         if(mLNASlider == null)
         {
             mLNASlider = new LnaSlider();
+            mLNASlider.setOpaque(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mLNASlider.setBackground(new java.awt.Color(43, 43, 43));
+                mLNASlider.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mLNASlider.setEnabled(true);
             mLNASlider.setMajorTickSpacing(1);
             mLNASlider.setPaintTicks(true);
@@ -305,6 +311,12 @@ public abstract class RspTunerEditor<C extends RspTunerConfiguration> extends Tu
         if(mIfGainSlider == null)
         {
             mIfGainSlider = new IfGainSlider();
+            mIfGainSlider.setOpaque(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mIfGainSlider.setBackground(new java.awt.Color(43, 43, 43));
+                mIfGainSlider.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mIfGainSlider.setEnabled(true);
             mIfGainSlider.setMajorTickSpacing(1);
             mIfGainSlider.setPaintTicks(true);

--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/rsp2/Rsp2TunerEditor.java
@@ -269,6 +269,12 @@ public class Rsp2TunerEditor extends RspTunerEditor<Rsp2TunerConfiguration>
         if(mBiasTCheckBox == null)
         {
             mBiasTCheckBox = new JCheckBox("ANT B Bias-T Power");
+            mBiasTCheckBox.setOpaque(true);
+            if(mUserPreferences != null && mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mBiasTCheckBox.setBackground(new java.awt.Color(43, 43, 43));
+                mBiasTCheckBox.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mBiasTCheckBox.setEnabled(false);
             mBiasTCheckBox.addActionListener(e -> {
                 if(hasTuner() && !isLoading())

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerEditor.java
@@ -72,7 +72,7 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
     private static final String BUTTON_STATUS_ENABLE = "Enable";
     private static final String BUTTON_STATUS_DISABLE = "Disable";
     private static final long serialVersionUID = 1L;
-    private UserPreferences mUserPreferences;
+    protected UserPreferences mUserPreferences;
     private TunerManager mTunerManager;
     private DiscoveredTuner mDiscoveredTuner;
     private C mTunerConfiguration;
@@ -237,6 +237,12 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mAutoPPMCheckBox == null)
         {
             mAutoPPMCheckBox = new JCheckBox("Enable decoder(s) to auto-adjust PPM");
+            mAutoPPMCheckBox.setOpaque(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mAutoPPMCheckBox.setBackground(new java.awt.Color(43, 43, 43));
+                mAutoPPMCheckBox.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mAutoPPMCheckBox.setToolTipText("Allow decoders to measure channel frequency error and correct tuner PPM");
             mAutoPPMCheckBox.addActionListener(e ->
             {
@@ -314,6 +320,12 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mFrequencyControl == null)
         {
             mFrequencyControl = new JFrequencyControl();
+            
+            // Set highlight color based on dark mode preference
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mFrequencyControl.setHighlightColor(new java.awt.Color(75, 110, 175)); // Light blue for dark mode
+            }
         }
 
         return mFrequencyControl;
@@ -539,6 +551,13 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mResetFrequenciesButton == null)
         {
             mResetFrequenciesButton = new JButton("Reset");
+            mResetFrequenciesButton.setOpaque(true);
+            mResetFrequenciesButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mResetFrequenciesButton.setBackground(new java.awt.Color(43, 43, 43));
+                mResetFrequenciesButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mResetFrequenciesButton.addActionListener(e -> {
 
                 long min = getMinimumTunableFrequency();
@@ -561,6 +580,13 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mNewSpectrumButton == null)
         {
             mNewSpectrumButton = new JButton("New Spectrum Display");
+            mNewSpectrumButton.setOpaque(true);
+            mNewSpectrumButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mNewSpectrumButton.setBackground(new java.awt.Color(43, 43, 43));
+                mNewSpectrumButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mNewSpectrumButton.setToolTipText("Show this tuner in a new (separate) spectral display window");
             mNewSpectrumButton.addActionListener(e ->
             {
@@ -585,6 +611,13 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mViewSpectrumButton == null)
         {
             mViewSpectrumButton = new JButton("View Spectrum");
+            mViewSpectrumButton.setOpaque(true);
+            mViewSpectrumButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mViewSpectrumButton.setBackground(new java.awt.Color(43, 43, 43));
+                mViewSpectrumButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mViewSpectrumButton.setToolTipText("Show this tuner in the spectral display");
             mViewSpectrumButton.addActionListener(e ->
             {
@@ -611,6 +644,13 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mEnabledButton == null)
         {
             mEnabledButton = new JButton(BUTTON_STATUS_ENABLE);
+            mEnabledButton.setOpaque(true);
+            mEnabledButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mEnabledButton.setBackground(new java.awt.Color(43, 43, 43));
+                mEnabledButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mEnabledButton.setToolTipText("Enable or disable the tuner for use by sdrtrunk");
             mEnabledButton.addActionListener(e ->
             {
@@ -638,6 +678,13 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mRestartTunerButton == null)
         {
             mRestartTunerButton = new JButton("Restart Tuner");
+            mRestartTunerButton.setOpaque(true);
+            mRestartTunerButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mRestartTunerButton.setBackground(new java.awt.Color(43, 43, 43));
+                mRestartTunerButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mRestartTunerButton.setVisible(false);
             mRestartTunerButton.setToolTipText("Attempt to restart this tuner to recover from error condition");
             mRestartTunerButton.addActionListener(e ->
@@ -672,6 +719,13 @@ public abstract class TunerEditor<T extends Tuner,C extends TunerConfiguration> 
         if(mRecordButton == null)
         {
             mRecordButton = new JToggleButton("Record");
+            mRecordButton.setOpaque(true);
+            mRecordButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mRecordButton.setBackground(new java.awt.Color(43, 43, 43));
+                mRecordButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mRecordButton.setToolTipText("Create a baseband recording for this tuner");
             mRecordButton.setEnabled(false);
             mRecordButton.addActionListener(e ->

--- a/src/main/java/io/github/dsheirer/source/tuner/ui/TunerViewPanel.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/ui/TunerViewPanel.java
@@ -214,6 +214,13 @@ public class TunerViewPanel extends JPanel
         if(mAddRecordingButton == null)
         {
             mAddRecordingButton = new JButton("Add Recording Tuner");
+            mAddRecordingButton.setOpaque(true);
+            mAddRecordingButton.setContentAreaFilled(true);
+            if(mUserPreferences.getColorThemePreference().isDarkModeEnabled())
+            {
+                mAddRecordingButton.setBackground(new java.awt.Color(43, 43, 43));
+                mAddRecordingButton.setForeground(new java.awt.Color(187, 187, 187));
+            }
             mAddRecordingButton.addActionListener(e ->
             {
                 AddRecordingTunerDialog dialog = new AddRecordingTunerDialog(mUserPreferences, mDiscoveredTunerModel,

--- a/src/main/resources/colortheme/dark-theme.css
+++ b/src/main/resources/colortheme/dark-theme.css
@@ -1,0 +1,273 @@
+/*
+ * Dark Theme CSS for SDRTrunk JavaFX Components
+ */
+
+/* Root styling */
+.root {
+    -fx-base: rgb(30, 30, 30);
+    -fx-background: rgb(30, 30, 30);
+    -fx-control-inner-background: rgb(43, 43, 43);
+    -fx-font-family: "Segoe UI", "Helvetica", "Arial", sans-serif;
+}
+
+/* Text colors */
+.label, .text {
+    -fx-text-fill: rgb(187, 187, 187);
+}
+
+/* Button styling */
+.button {
+    -fx-background-color: rgb(60, 60, 60);
+    -fx-text-fill: rgb(220, 220, 220);
+    -fx-border-color: rgb(80, 80, 80);
+    -fx-border-width: 1px;
+}
+
+.button:hover {
+    -fx-background-color: rgb(70, 70, 70);
+}
+
+.button:pressed {
+    -fx-background-color: rgb(50, 50, 50);
+}
+
+/* TextField styling */
+.text-field, .text-area {
+    -fx-background-color: rgb(43, 43, 43);
+    -fx-text-fill: rgb(220, 220, 220);
+    -fx-prompt-text-fill: rgb(130, 130, 130);
+    -fx-border-color: rgb(80, 80, 80);
+}
+
+.text-field:focused, .text-area:focused {
+    -fx-border-color: rgb(100, 140, 200);
+}
+
+/* List and Table styling */
+.list-view, .table-view {
+    -fx-background-color: rgb(43, 43, 43);
+    -fx-control-inner-background: rgb(43, 43, 43);
+    -fx-table-cell-border-color: rgb(60, 60, 60);
+}
+
+.list-cell, .table-row-cell {
+    -fx-background-color: rgb(43, 43, 43);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.list-cell:filled:selected:focused, .list-cell:filled:selected,
+.table-row-cell:selected {
+    -fx-background-color: rgb(75, 110, 175);
+    -fx-text-fill: white;
+}
+
+.table-view .column-header-background {
+    -fx-background-color: rgb(50, 50, 50);
+}
+
+.table-view .column-header {
+    -fx-background-color: rgb(50, 50, 50);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+/* Tree View styling */
+.tree-view {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+.tree-cell {
+    -fx-background-color: rgb(43, 43, 43);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.tree-cell:selected {
+    -fx-background-color: rgb(75, 110, 175);
+    -fx-text-fill: white;
+}
+
+/* TabPane styling */
+.tab-pane {
+    -fx-background-color: rgb(30, 30, 30);
+}
+
+.tab-pane .tab-header-area .tab-header-background {
+    -fx-background-color: rgb(40, 40, 40);
+}
+
+.tab {
+    -fx-background-color: rgb(50, 50, 50);
+    -fx-text-fill: rgb(180, 180, 180);
+}
+
+.tab:selected {
+    -fx-background-color: rgb(43, 43, 43);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.tab:hover {
+    -fx-background-color: rgb(60, 60, 60);
+}
+
+.tab-pane .tab-content-area {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+/* ComboBox styling */
+.combo-box {
+    -fx-background-color: rgb(60, 60, 60);
+}
+
+.combo-box .list-cell {
+    -fx-background-color: rgb(60, 60, 60);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.combo-box-popup .list-view {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+/* ScrollBar styling */
+.scroll-bar {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+.scroll-bar .thumb {
+    -fx-background-color: rgb(80, 80, 80);
+    -fx-background-radius: 5px;
+}
+
+.scroll-bar .thumb:hover {
+    -fx-background-color: rgb(100, 100, 100);
+}
+
+.scroll-bar .track {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+/* Menu styling */
+.menu-bar {
+    -fx-background-color: rgb(40, 40, 40);
+}
+
+.menu, .menu-item {
+    -fx-background-color: rgb(50, 50, 50);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.menu:showing, .menu:hover, .menu-item:hover {
+    -fx-background-color: rgb(75, 110, 175);
+}
+
+.context-menu {
+    -fx-background-color: rgb(50, 50, 50);
+}
+
+/* Separator styling */
+.separator {
+    -fx-background-color: rgb(80, 80, 80);
+}
+
+/* ProgressBar styling */
+.progress-bar {
+    -fx-background-color: rgb(60, 60, 60);
+}
+
+.progress-bar .bar {
+    -fx-background-color: rgb(75, 110, 175);
+}
+
+/* Spinner styling */
+.spinner {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+.spinner .text-field {
+    -fx-background-color: rgb(43, 43, 43);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+/* ToggleButton styling */
+.toggle-button {
+    -fx-background-color: rgb(60, 60, 60);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.toggle-button:selected {
+    -fx-background-color: rgb(75, 110, 175);
+}
+
+/* CheckBox and RadioButton styling */
+.check-box, .radio-button {
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.check-box .box, .radio-button .radio {
+    -fx-background-color: rgb(60, 60, 60);
+    -fx-border-color: rgb(100, 100, 100);
+}
+
+.check-box:selected .mark, .radio-button:selected .dot {
+    -fx-background-color: rgb(220, 220, 220);
+}
+
+/* SplitPane styling */
+.split-pane {
+    -fx-background-color: rgb(30, 30, 30);
+}
+
+.split-pane-divider {
+    -fx-background-color: rgb(60, 60, 60);
+}
+
+/* TitledPane styling */
+.titled-pane {
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.titled-pane > .title {
+    -fx-background-color: rgb(50, 50, 50);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+.titled-pane > .content {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+/* ToolBar styling */
+.tool-bar {
+    -fx-background-color: rgb(40, 40, 40);
+}
+
+/* Tooltip styling */
+.tooltip {
+    -fx-background-color: rgb(60, 60, 60);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+
+/* ScrollPane styling */
+.scroll-pane {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+.scroll-pane .viewport {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+/* Chart styling (for spectral displays) */
+.chart {
+    -fx-background-color: rgb(30, 30, 30);
+}
+
+.chart-plot-background {
+    -fx-background-color: rgb(43, 43, 43);
+}
+
+.axis {
+    -fx-tick-label-fill: rgb(187, 187, 187);
+}
+
+.chart-legend {
+    -fx-background-color: rgb(50, 50, 50);
+    -fx-text-fill: rgb(220, 220, 220);
+}
+


### PR DESCRIPTION
99% Ai slop...
- Add ColorThemePreference to store and manage dark mode setting
- Auto-detect Windows system theme on first launch
- Add dark mode toggle in preferences with modern UI
- Apply dark theme to all Swing components (menus, buttons, text fields, etc.)
- Apply dark theme to all JavaFX components via CSS
- Improve text readability in broadcast status panel
- Style all tuner editor controls (RTL, SDRplay, etc.)
- Style map controls and channel spectrum panel
- Style history management sliders
- Style channel metadata and detail panels
- Respect user preference throughout entire application