### PR TITLE
#2283 Mac-OS Tahoe Version 26 Support

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" project-jdk-name="liberica-25" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25_PREVIEW" project-jdk-name="liberica-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,8 @@ dependencies {
     implementation 'commons-io:commons-io:2.21.0'
     implementation 'eu.hansolo:charts:1.0.5'
     implementation 'io.github.dsheirer:radio-reference-api:18.0.0'
-    implementation 'io.github.dsheirer:usb4java-native-libraries:1.3.1' //OSX & Windows aarch64 native libs
+    implementation 'io.github.dsheirer:usb4java-native-libraries:1.3.2' //OSX & Windows aarch64 native libs
+    implementation 'io.github.dsheirer:usb4java:1.3.2' //Fork with Loader support for OSX Multi-Version
     implementation 'javax.usb:usb-api:1.0.2'
     implementation 'net.coderazzi:tablefilter-swing:5.5.4'
     implementation 'org.apache.commons:commons-compress:1.28.0'
@@ -118,7 +119,6 @@ dependencies {
     implementation 'org.rauschig:jarchivelib:1.2.0'
     implementation 'org.slf4j:slf4j-api:2.0.17'
     implementation 'org.usb4java:libusb4java:1.3.0'
-    implementation 'org.usb4java:usb4java:1.3.0'
     implementation 'org.usb4java:usb4java-javax:1.3.0'
     implementation 'pl.edu.icm:JLargeArrays:1.6'
 }


### PR DESCRIPTION
Closes #2283 

Mac-OS Tahoe version 26.  Updates usb4java with forked library to support multi-versioned native libraries on aarch-64
