### PR TITLE
#2304 SDRPlay API - Handle Device Failure Condition

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/callback/DeviceEventAdapter.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/sdrplay/api/callback/DeviceEventAdapter.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2024 Dennis Sheirer
+ * Copyright (C) 2014-2025 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -83,7 +83,7 @@ public class DeviceEventAdapter implements sdrplay_api_EventCallback_t.Function
                 mDeviceEventListener.processPowerOverload(tunerSelect,
                         EventParametersFactory.createPowerOverloadCallbackParameters(eventParams));
             }
-            case DEVICE_REMOVED ->
+            case DEVICE_REMOVED, DEVICE_FAILURE ->
             {
                 mDeviceEventListener.processDeviceRemoval(tunerSelect);
             }


### PR DESCRIPTION
Closes #2304 

sdrplay api now handles device failure without crash
