### PR TITLE
Add P25 NAC alias support for streaming

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/AliasFactory.java
+++ b/src/main/java/io/github/dsheirer/alias/AliasFactory.java
@@ -26,6 +26,7 @@ import io.github.dsheirer.alias.id.AliasID;
 import io.github.dsheirer.alias.id.broadcast.BroadcastChannel;
 import io.github.dsheirer.alias.id.dcs.Dcs;
 import io.github.dsheirer.alias.id.esn.Esn;
+import io.github.dsheirer.alias.id.nac.Nac;
 import io.github.dsheirer.alias.id.legacy.mobileID.Min;
 import io.github.dsheirer.alias.id.legacy.siteID.SiteID;
 import io.github.dsheirer.alias.id.lojack.LoJackFunctionAndID;
@@ -79,6 +80,12 @@ public class AliasFactory
                 Min copyMin = new Min();
                 copyMin.setMin(originalMin.getMin());
                 return copyMin;
+            case NAC:
+                if(id instanceof Nac original)
+                {
+                    return new Nac(original.getNac());
+                }
+                break;
             case P25_FULLY_QUALIFIED_RADIO_ID:
                 P25FullyQualifiedRadio originalP25 = (P25FullyQualifiedRadio) id;
                 P25FullyQualifiedRadio copyP25 = new P25FullyQualifiedRadio(originalP25.getWacn(),

--- a/src/main/java/io/github/dsheirer/alias/AliasList.java
+++ b/src/main/java/io/github/dsheirer/alias/AliasList.java
@@ -23,6 +23,7 @@ import io.github.dsheirer.alias.id.AliasID;
 import io.github.dsheirer.alias.id.broadcast.BroadcastChannel;
 import io.github.dsheirer.alias.id.dcs.Dcs;
 import io.github.dsheirer.alias.id.esn.Esn;
+import io.github.dsheirer.alias.id.nac.Nac;
 import io.github.dsheirer.alias.id.priority.Priority;
 import io.github.dsheirer.alias.id.radio.P25FullyQualifiedRadio;
 import io.github.dsheirer.alias.id.radio.Radio;
@@ -48,6 +49,7 @@ import io.github.dsheirer.identifier.talkgroup.TalkgroupIdentifier;
 import io.github.dsheirer.identifier.tone.ToneIdentifier;
 import io.github.dsheirer.identifier.tone.ToneSequence;
 import io.github.dsheirer.module.decode.dcs.DCSCode;
+import io.github.dsheirer.module.decode.p25.identifier.APCO25Nac;
 import io.github.dsheirer.protocol.Protocol;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,6 +76,7 @@ public class AliasList
     private Map<Protocol,TalkgroupAliasList> mTalkgroupProtocolMap = new EnumMap<>(Protocol.class);
     private Map<Protocol,RadioAliasList> mRadioProtocolMap = new EnumMap<>(Protocol.class);
     private Map<DCSCode,Alias> mDCSCodeAliasMap = new EnumMap<>(DCSCode.class);
+    private Map<Integer,Alias> mNacAliasMap = new HashMap<>();
     private Map<String,Alias> mESNMap = new HashMap<>();
     private Map<Integer,Alias> mUnitStatusMap = new HashMap<>();
     private Map<Integer,Alias> mUserStatusMap = new HashMap<>();
@@ -217,6 +220,12 @@ public class AliasList
                             mDCSCodeAliasMap.put(dcs.getDCSCode(), alias);
                         }
                         break;
+                    case NAC:
+                        if(id instanceof Nac nac)
+                        {
+                            mNacAliasMap.put(nac.getNac(), alias);
+                        }
+                        break;
                     case ESN:
                         String esn = ((Esn)id).getEsn();
 
@@ -311,6 +320,7 @@ public class AliasList
 
         Collection<Alias> collection = Collections.singleton(alias);
         mESNMap.values().removeAll(collection);
+        mNacAliasMap.values().removeAll(collection);
         mUnitStatusMap.values().removeAll(collection);
         mUserStatusMap.values().removeAll(collection);
         mToneSequenceMap.values().removeAll(collection);
@@ -520,6 +530,13 @@ public class AliasList
                         }
                     }
                     break;
+                case NETWORK_ACCESS_CODE:
+                    if(identifier instanceof APCO25Nac apco25Nac)
+                    {
+                        int nacValue = apco25Nac.getValue();
+                        return toList(mNacAliasMap.get(nacValue));
+                    }
+                break;
             }
         }
 

--- a/src/main/java/io/github/dsheirer/alias/id/AliasID.java
+++ b/src/main/java/io/github/dsheirer/alias/id/AliasID.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import io.github.dsheirer.alias.id.broadcast.BroadcastChannel;
 import io.github.dsheirer.alias.id.dcs.Dcs;
 import io.github.dsheirer.alias.id.esn.Esn;
+import io.github.dsheirer.alias.id.nac.Nac;
 import io.github.dsheirer.alias.id.legacy.fleetsync.FleetsyncID;
 import io.github.dsheirer.alias.id.legacy.mdc.MDC1200ID;
 import io.github.dsheirer.alias.id.legacy.mobileID.Min;
@@ -63,6 +64,7 @@ import javafx.util.Callback;
     @JsonSubTypes.Type(value = MDC1200ID.class, name = "mdc1200ID"),
     @JsonSubTypes.Type(value = Min.class, name = "min"),
     @JsonSubTypes.Type(value = MPT1327ID.class, name = "mpt1327ID"),
+    @JsonSubTypes.Type(value = Nac.class, name = "nac"),
     @JsonSubTypes.Type(value = NonRecordable.class, name = "nonRecordable"),
     @JsonSubTypes.Type(value = P25FullyQualifiedRadio.class, name = "p25FullyQualifiedRadio"),
     @JsonSubTypes.Type(value = P25FullyQualifiedTalkgroup.class, name = "p25FullyQualifiedTalkgroup"),

--- a/src/main/java/io/github/dsheirer/alias/id/AliasIDType.java
+++ b/src/main/java/io/github/dsheirer/alias/id/AliasIDType.java
@@ -29,6 +29,7 @@ public enum AliasIDType
     LOJACK("LoJack"),
     LTR_NET_UID("LTR-Net UID"),
     MIN("Passport MIN"),
+    NAC("P25 NAC"),
     P25_FULLY_QUALIFIED_RADIO_ID("P25 Fully Qualified Radio ID"),
     P25_FULLY_QUALIFIED_TALKGROUP("P25 Fully Qualified Talkgroup"),
     PRIORITY("Audio Priority"),

--- a/src/main/java/io/github/dsheirer/alias/id/nac/Nac.java
+++ b/src/main/java/io/github/dsheirer/alias/id/nac/Nac.java
@@ -1,0 +1,123 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.alias.id.nac;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import io.github.dsheirer.alias.id.AliasID;
+import io.github.dsheirer.alias.id.AliasIDType;
+
+/**
+ * P25 Network Access Code (NAC) alias identifier
+ */
+public class Nac extends AliasID implements Comparable<Nac>
+{
+    private int mNac;
+
+    /**
+     * Default constructor for JAXB
+     */
+    public Nac()
+    {
+    }
+
+    /**
+     * Constructs with a NAC value
+     * @param nac value (0-4095)
+     */
+    public Nac(int nac)
+    {
+        mNac = nac;
+    }
+
+    @Override
+    public AliasIDType getType()
+    {
+        return AliasIDType.NAC;
+    }
+
+    @Override
+    public boolean matches(AliasID id)
+    {
+        if(isValid() && id instanceof Nac other)
+        {
+            return other.isValid() && getNac() == other.getNac();
+        }
+        return false;
+    }
+
+    /**
+     * NAC value
+     * @return NAC value (0-4095)
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "nac")
+    public int getNac()
+    {
+        return mNac;
+    }
+
+    /**
+     * Sets the NAC value
+     * @param nac value (0-4095)
+     */
+    public void setNac(int nac)
+    {
+        mNac = nac;
+        updateValueProperty();
+    }
+
+    @Override
+    public boolean isValid()
+    {
+        return mNac >= 0 && mNac <= 4095;
+    }
+
+    @Override
+    public boolean isAudioIdentifier()
+    {
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        if(isValid())
+        {
+            return "NAC: " + mNac + " (x" + String.format("%03X", mNac) + ")";
+        }
+        return "NAC - Invalid";
+    }
+
+    @Override
+    public int compareTo(Nac o)
+    {
+        if(isValid())
+        {
+            if(o.isValid())
+            {
+                return Integer.compare(getNac(), o.getNac());
+            }
+            else
+            {
+                return 1;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
@@ -37,6 +37,7 @@ import io.github.dsheirer.alias.id.broadcast.BroadcastChannel;
 import io.github.dsheirer.alias.id.dcs.Dcs;
 import io.github.dsheirer.alias.id.esn.Esn;
 import io.github.dsheirer.alias.id.lojack.LoJackFunctionAndID;
+import io.github.dsheirer.alias.id.nac.Nac;
 import io.github.dsheirer.alias.id.radio.P25FullyQualifiedRadio;
 import io.github.dsheirer.alias.id.radio.Radio;
 import io.github.dsheirer.alias.id.radio.RadioFormatter;
@@ -725,6 +726,7 @@ public class AliasItemEditor extends Editor<Alias>
             amMenu.getItems().add(new AddTalkgroupRangeItem(Protocol.AM));
 
             Menu p25Menu = new ProtocolMenu(Protocol.APCO25);
+            p25Menu.getItems().add(new AddNacItem());
             p25Menu.getItems().add(new AddTalkgroupItem(Protocol.APCO25));
             p25Menu.getItems().add(new AddTalkgroupRangeItem(Protocol.APCO25));
             p25Menu.getItems().add(new AddP25FullyQualifiedTalkgroupItem());
@@ -1363,6 +1365,24 @@ public class AliasItemEditor extends Editor<Alias>
                 getIdentifiersList().getItems().add(dcs);
                 getIdentifiersList().getSelectionModel().select(dcs);
                 getIdentifiersList().scrollTo(dcs);
+                modifiedProperty().set(true);
+            });
+        }
+    }
+
+    /**
+     * Menu item to add a P25 NAC identifier
+     */
+    public class AddNacItem extends MenuItem
+    {
+        public AddNacItem()
+        {
+            super("NAC");
+            setOnAction(event -> {
+                Nac nac = new Nac();
+                getIdentifiersList().getItems().add(nac);
+                getIdentifiersList().getSelectionModel().select(nac);
+                getIdentifiersList().scrollTo(nac);
                 modifiedProperty().set(true);
             });
         }

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/IdentifierEditorFactory.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/IdentifierEditorFactory.java
@@ -23,6 +23,7 @@ import io.github.dsheirer.alias.id.AliasIDType;
 import io.github.dsheirer.preference.UserPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.github.dsheirer.alias.id.nac.Nac;
 
 /**
  * Factory for creating JavaFX editors for alias identifiers
@@ -41,6 +42,8 @@ public class IdentifierEditorFactory
                 return new EsnEditor();
             case LOJACK:
                 return new LojackEditor();
+            case NAC:
+                return new NacEditor();
             case P25_FULLY_QUALIFIED_RADIO_ID:
                 return new P25FullyQualifiedRadioIdEditor(userPreferences);
             case P25_FULLY_QUALIFIED_TALKGROUP:

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/NacEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/identifier/NacEditor.java
@@ -1,0 +1,159 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2025 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.playlist.alias.identifier;
+
+import io.github.dsheirer.alias.id.nac.Nac;
+import javafx.scene.control.Label;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.TextFormatter;
+import javafx.scene.layout.GridPane;
+import javafx.util.converter.IntegerStringConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Editor for P25 Network Access Code (NAC) alias identifiers
+ */
+public class NacEditor extends IdentifierEditor<Nac>
+{
+    private static final Logger mLog = LoggerFactory.getLogger(NacEditor.class);
+    private Spinner<Integer> mNacSpinner;
+    private Label mHexLabel;
+
+    /**
+     * Constructs an instance
+     */
+    public NacEditor()
+    {
+        GridPane gridPane = new GridPane();
+        gridPane.setHgap(5);
+
+        Label typeLabel = new Label("NAC (0-4095)");
+        GridPane.setConstraints(typeLabel, 0, 0);
+        gridPane.getChildren().add(typeLabel);
+
+        GridPane.setConstraints(getNacSpinner(), 1, 0);
+        gridPane.getChildren().add(getNacSpinner());
+
+        mHexLabel = new Label("(x000)");
+        GridPane.setConstraints(mHexLabel, 2, 0);
+        gridPane.getChildren().add(mHexLabel);
+
+        getChildren().add(gridPane);
+    }
+
+    @Override
+    public void setItem(Nac item)
+    {
+        super.setItem(item);
+        getNacSpinner().getValueFactory().setValue(item.getNac());
+        updateHexLabel(item.getNac());
+        modifiedProperty().set(false);
+    }
+
+    @Override
+    public void save()
+    {
+        //no-op
+    }
+
+    @Override
+    public void dispose()
+    {
+        //no-op
+    }
+
+    /**
+     * Updates the hex display label
+     */
+    private void updateHexLabel(int value)
+    {
+        mHexLabel.setText("(x" + String.format("%03X", value) + ")");
+    }
+
+    /**
+     * Spinner for NAC value entry
+     * @return spinner
+     */
+    private Spinner<Integer> getNacSpinner()
+    {
+        if(mNacSpinner == null)
+        {
+            mNacSpinner = new Spinner<>();
+            mNacSpinner.setEditable(true);
+            mNacSpinner.setPrefWidth(100);
+
+            SpinnerValueFactory<Integer> factory = new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 4095, 0);
+            mNacSpinner.setValueFactory(factory);
+
+            // Add text formatter to handle invalid input
+            TextFormatter<Integer> formatter = new TextFormatter<>(new IntegerStringConverter(), 0, change -> {
+                String newText = change.getControlNewText();
+                if(newText.isEmpty())
+                {
+                    return change;
+                }
+                try
+                {
+                    int value = Integer.parseInt(newText);
+                    if(value >= 0 && value <= 4095)
+                    {
+                        return change;
+                    }
+                }
+                catch(NumberFormatException e)
+                {
+                    // Also allow hex input
+                    if(newText.toLowerCase().startsWith("x") || newText.toLowerCase().startsWith("0x"))
+                    {
+                        try
+                        {
+                            String hexPart = newText.toLowerCase().startsWith("0x") ? 
+                                newText.substring(2) : newText.substring(1);
+                            int value = Integer.parseInt(hexPart, 16);
+                            if(value >= 0 && value <= 4095)
+                            {
+                                return change;
+                            }
+                        }
+                        catch(NumberFormatException ex)
+                        {
+                            // Fall through to return null
+                        }
+                    }
+                }
+                return null;
+            });
+            mNacSpinner.getEditor().setTextFormatter(formatter);
+
+            mNacSpinner.valueProperty().addListener((observable, oldValue, newValue) -> {
+                if(getItem() != null && newValue != null)
+                {
+                    getItem().setNac(newValue);
+                    updateHexLabel(newValue);
+                    modifiedProperty().set(true);
+                }
+            });
+        }
+
+        return mNacSpinner;
+    }
+}


### PR DESCRIPTION
Adds P25 NAC (Network Access Code) alias support, allowing users to create aliases based on NAC values for streaming and identification. Tested with P25 conventional channels streaming to Rdio Scanner with correct talkgroup override. 

- Added NAC as an alias identifier type
- NAC values (0-4095) can be configured in the alias editor under P25 → NAC
- Streaming works correctly with "Stream this Alias as Talkgroup" setting
- Fixed RdioScannerBroadcaster to check all identifiers for StreamAsTalkgroup, not just the TO identifier

Files Changed
- NEW: alias/id/nac/Nac.java
- NEW: gui/playlist/alias/identifier/NacEditor.java
- Modified: 7 existing files (see commit)

Tested with Rdio scanner, unknown if any changes are needed for Calls, OpenMHz, etc. Again, I am no coder, Claude Opus did the bulk of the work. 