### PR TITLE
Add channel squelch Delay Time with optional silence removal for NBFM channels

### DIFF
--- a/src/main/java/io/github/dsheirer/audio/AudioModule.java
+++ b/src/main/java/io/github/dsheirer/audio/AudioModule.java
@@ -262,10 +262,12 @@ public class AudioModule extends AbstractAudioModule implements ISquelchStateLis
                         // If not removing silence, add silence for the time squelch was closed
                         if(!mSquelchDelayRemoveSilence && mSquelchClosedTimestamp > 0)
                         {
-                            long silenceDuration = System.currentTimeMillis() - mSquelchClosedTimestamp;
+                            long elapsedMs = System.currentTimeMillis() - mSquelchClosedTimestamp;
+                            // Round up to nearest 100ms to match delay increments
+                            int silenceDuration = (int)(((elapsedMs + 99) / 100) * 100);
                             if(silenceDuration > 0 && silenceDuration <= mSquelchDelayTimeMs)
                             {
-                                addSilence((int) silenceDuration);
+                                addSilence(silenceDuration);
                             }
                         }
                     }

--- a/src/main/java/io/github/dsheirer/audio/AudioModule.java
+++ b/src/main/java/io/github/dsheirer/audio/AudioModule.java
@@ -181,10 +181,24 @@ public class AudioModule extends AbstractAudioModule implements ISquelchStateLis
      */
     private void addSilence(int durationMs)
     {
-        // Calculate number of samples needed for the duration at 8kHz sample rate
-        int samples = (AUDIO_SAMPLE_RATE * durationMs) / 1000;
-        float[] silence = new float[samples];
-        addAudio(silence);
+        // Add silence in 100ms chunks at 8kHz sample rate (800 samples per chunk)
+        int chunkSize = 800; // 100ms at 8kHz
+        float[] silenceChunk = new float[chunkSize];
+        
+        int remainingMs = durationMs;
+        while(remainingMs >= 100)
+        {
+            addAudio(silenceChunk);
+            remainingMs -= 100;
+        }
+        
+        // Add any remaining partial chunk
+        if(remainingMs > 0)
+        {
+            int remainingSamples = (AUDIO_SAMPLE_RATE * remainingMs) / 1000;
+            float[] partialChunk = new float[remainingSamples];
+            addAudio(partialChunk);
+        }
     }
 
     @Override

--- a/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
@@ -355,7 +355,7 @@ public class DecoderFactory
         // not create a new segment if the processing chain finishes a bit after
         // actual call timeout.
         long maxAudioSegmentLengthMillis = (callTimeoutMilliseconds + 5000);
-        modules.add(new AudioModule(aliasList, AbstractAudioModule.DEFAULT_TIMESLOT, maxAudioSegmentLengthMillis, AUDIO_FILTER_ENABLE));
+        modules.add(new AudioModule(aliasList, AbstractAudioModule.DEFAULT_TIMESLOT, maxAudioSegmentLengthMillis, AUDIO_FILTER_ENABLE, 0, true));
 
         SourceType sourceType = channel.getSourceConfiguration().getSourceType();
         if(sourceType == SourceType.TUNER || sourceType == SourceType.TUNER_MULTIPLE_FREQUENCIES)
@@ -437,7 +437,7 @@ public class DecoderFactory
         DecodeConfigNBFM decodeConfigNBFM = (DecodeConfigNBFM)decodeConfig;
         modules.add(new NBFMDecoder(decodeConfigNBFM));
         modules.add(new NBFMDecoderState(channel.getName(), decodeConfigNBFM));
-        modules.add(new AudioModule(aliasList, 0, 60000, decodeConfigNBFM.isAudioFilter()));
+        modules.add(new AudioModule(aliasList, 0, 60000, decodeConfigNBFM.isAudioFilter(), decodeConfigNBFM.getSquelchDelayTimeMs(), decodeConfigNBFM.isSquelchDelayRemoveSilence()));
     }
 
     /**
@@ -453,7 +453,7 @@ public class DecoderFactory
         {
             modules.add(new AMDecoder(configAM));
             modules.add(new AMDecoderState(channel.getName(), configAM));
-            modules.add(new AudioModule(aliasList, 0, 60000, AUDIO_FILTER_ENABLE));
+            modules.add(new AudioModule(aliasList, 0, 60000, AUDIO_FILTER_ENABLE, 0, true));
         }
         else
         {

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
@@ -35,6 +35,8 @@ public class DecodeConfigNBFM extends DecodeConfigAnalog
     private float mSquelchNoiseCloseThreshold = NoiseSquelch.DEFAULT_NOISE_CLOSE_THRESHOLD;
     private int mSquelchHysteresisOpenThreshold = NoiseSquelch.DEFAULT_HYSTERESIS_OPEN_THRESHOLD;
     private int mSquelchHysteresisCloseThreshold = NoiseSquelch.DEFAULT_HYSTERESIS_CLOSE_THRESHOLD;
+    private int mSquelchDelayTimeMs = 0;
+    private boolean mSquelchDelayRemoveSilence = true;
 
     /**
      * Constructs an instance
@@ -188,5 +190,49 @@ public class DecodeConfigNBFM extends DecodeConfigAnalog
         }
 
         mSquelchHysteresisCloseThreshold = close;
+    }
+
+    /**
+     * Squelch delay time in milliseconds (0-5000). Time to wait after squelch closes
+     * before ending the audio segment, allowing brief pauses in transmission.
+     * @return delay time in milliseconds
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "squelchDelayTimeMs")
+    public int getSquelchDelayTimeMs()
+    {
+        return mSquelchDelayTimeMs;
+    }
+
+    /**
+     * Sets the squelch delay time in milliseconds.
+     * @param delayTimeMs delay time (0-5000ms)
+     */
+    public void setSquelchDelayTimeMs(int delayTimeMs)
+    {
+        if(delayTimeMs < 0 || delayTimeMs > 5000)
+        {
+            throw new IllegalArgumentException("Squelch delay time must be between 0 and 5000ms: " + delayTimeMs);
+        }
+        mSquelchDelayTimeMs = delayTimeMs;
+    }
+
+    /**
+     * Indicates if silence should be removed during squelch delay period.
+     * When true, silence is removed. When false, silence is preserved in the recording.
+     * @return true to remove silence, false to preserve it
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "squelchDelayRemoveSilence")
+    public boolean isSquelchDelayRemoveSilence()
+    {
+        return mSquelchDelayRemoveSilence;
+    }
+
+    /**
+     * Sets whether silence should be removed during squelch delay period.
+     * @param removeSilence true to remove silence, false to preserve it
+     */
+    public void setSquelchDelayRemoveSilence(boolean removeSilence)
+    {
+        mSquelchDelayRemoveSilence = removeSilence;
     }
 }


### PR DESCRIPTION
- Adds "Squelch Delay" timer to NBFM channels
- Allows user to set a time to look for additional radio traffic once squelch (plus Alias) has closed before sending audio to stream
- Functions similarly to the Delay Hold feature on traditional scanners
- Adjustable from 0-5000ms in 100ms increments
- Optional "Remove Silence" will remove silence between transmissions in same clip, or can be left in for accurate timing
- Alias agnostic

Disclaimer: Another Claude Opus specialty. Works great in testing and should fix issues with intermittent dropouts due to local transmissions and prevent shortened clips