### PR TITLE
Adds 'Match All' toggle under Identifiers

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/Alias.java
+++ b/src/main/java/io/github/dsheirer/alias/Alias.java
@@ -64,6 +64,7 @@ public class Alias
     private BooleanProperty mRecordable = new SimpleBooleanProperty();
     private BooleanProperty mStreamable = new SimpleBooleanProperty();
     private BooleanProperty mOverlap = new SimpleBooleanProperty();
+    private BooleanProperty mMatchAllIdentifiers = new SimpleBooleanProperty(false);
     private IntegerProperty mColor = new SimpleIntegerProperty();
     private IntegerProperty mPriority = new SimpleIntegerProperty(Priority.DEFAULT_PRIORITY);
     private IntegerProperty mNonAudioIdentifierCount = new SimpleIntegerProperty();
@@ -184,6 +185,53 @@ public class Alias
     public ObjectProperty streamTalkgroupAliasProperty()
     {
         return mStreamTalkgroupAlias;
+    }
+
+    /**
+     * Match all identifiers property - when true, all non-audio identifiers must match for this alias to be selected
+     */
+    @JsonIgnore
+    public BooleanProperty matchAllIdentifiersProperty()
+    {
+        return mMatchAllIdentifiers;
+    }
+
+    /**
+     * Indicates if all non-audio identifiers must match for this alias to be selected.
+     * When false (default), any single identifier match will select this alias.
+     * When true, all non-audio identifiers in this alias must be present in the identifier collection.
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "matchAllIdentifiers")
+    public boolean isMatchAllIdentifiers()
+    {
+        return mMatchAllIdentifiers.get();
+    }
+
+    /**
+     * Sets whether all non-audio identifiers must match for this alias to be selected.
+     * @param matchAll true to require all identifiers to match, false for any single match (default)
+     */
+    public void setMatchAllIdentifiers(boolean matchAll)
+    {
+        mMatchAllIdentifiers.set(matchAll);
+    }
+
+    /**
+     * Returns a list of non-audio alias identifiers for this alias.
+     * These are the identifiers used for matching (talkgroup, radio, CTCSS, DCS, etc.)
+     */
+    @JsonIgnore
+    public List<AliasID> getNonAudioIdentifiers()
+    {
+        List<AliasID> nonAudioIds = new ArrayList<>();
+        for(AliasID aliasID : mAliasIDs)
+        {
+            if(!aliasID.isAudioIdentifier())
+            {
+                nonAudioIds.add(aliasID);
+            }
+        }
+        return nonAudioIds;
     }
 
     /**
@@ -735,6 +783,6 @@ public class Alias
         return (Alias a) -> new Observable[] {a.recordableProperty(), a.streamableProperty(), a.colorProperty(),
             a.aliasListNameProperty(), a.groupProperty(), a.iconNameProperty(), a.nameProperty(), a.aliasIds(),
             a.aliasActions(), a.nonAudioIdentifierCountProperty(), a.overlapProperty(), a.priorityProperty(),
-                a.streamTalkgroupAliasProperty()};
+                a.streamTalkgroupAliasProperty(), a.matchAllIdentifiersProperty()};
     }
 }

--- a/src/main/java/io/github/dsheirer/alias/AliasList.java
+++ b/src/main/java/io/github/dsheirer/alias/AliasList.java
@@ -537,6 +537,196 @@ public class AliasList
     }
 
     /**
+     * Returns aliases that match the identifier collection, respecting the matchAllIdentifiers flag.
+     * For aliases with matchAllIdentifiers=true, ALL non-audio identifiers in the alias must be 
+     * present in the identifier collection for the alias to be returned.
+     * For aliases with matchAllIdentifiers=false (default), any single identifier match returns the alias.
+     * 
+     * @param identifierCollection to match against
+     * @return list of matching aliases
+     */
+    public List<Alias> getAliases(IdentifierCollection identifierCollection)
+    {
+        List<Alias> matchingAliases = new ArrayList<>();
+        
+        if(identifierCollection == null)
+        {
+            return matchingAliases;
+        }
+
+        // First, collect all aliases that match at least one identifier (OR logic)
+        Set<Alias> candidateAliases = new HashSet<>();
+        for(Identifier identifier : identifierCollection.getIdentifiers())
+        {
+            List<Alias> aliases = getAliases(identifier);
+            candidateAliases.addAll(aliases);
+        }
+
+        // Now filter based on matchAllIdentifiers flag
+        for(Alias alias : candidateAliases)
+        {
+            if(alias.isMatchAllIdentifiers())
+            {
+                // Check if ALL non-audio identifiers in the alias are present in the collection
+                if(allIdentifiersMatch(alias, identifierCollection))
+                {
+                    matchingAliases.add(alias);
+                }
+            }
+            else
+            {
+                // Default OR behavior - already matched at least one identifier
+                matchingAliases.add(alias);
+            }
+        }
+
+        return matchingAliases;
+    }
+
+    /**
+     * Checks if all non-audio identifiers in the alias are present in the identifier collection.
+     * 
+     * @param alias to check
+     * @param identifierCollection to match against
+     * @return true if all non-audio identifiers in the alias are found in the collection
+     */
+    private boolean allIdentifiersMatch(Alias alias, IdentifierCollection identifierCollection)
+    {
+        List<AliasID> nonAudioIds = alias.getNonAudioIdentifiers();
+        
+        if(nonAudioIds.isEmpty())
+        {
+            return false; // No identifiers to match
+        }
+
+        for(AliasID aliasID : nonAudioIds)
+        {
+            if(!identifierMatchesCollection(aliasID, identifierCollection))
+            {
+                return false; // At least one identifier doesn't match
+            }
+        }
+
+        return true; // All identifiers matched
+    }
+
+    /**
+     * Checks if a specific alias identifier matches any identifier in the collection.
+     * 
+     * @param aliasID to find
+     * @param identifierCollection to search
+     * @return true if the alias identifier matches an identifier in the collection
+     */
+    private boolean identifierMatchesCollection(AliasID aliasID, IdentifierCollection identifierCollection)
+    {
+        if(!aliasID.isValid())
+        {
+            return false;
+        }
+
+        switch(aliasID.getType())
+        {
+            case TALKGROUP:
+                Talkgroup talkgroup = (Talkgroup)aliasID;
+                for(Identifier id : identifierCollection.getIdentifiers())
+                {
+                    if(id instanceof TalkgroupIdentifier tgi)
+                    {
+                        if(id.getProtocol() == talkgroup.getProtocol() && tgi.getValue() == talkgroup.getValue())
+                        {
+                            return true;
+                        }
+                    }
+                }
+                break;
+            case TALKGROUP_RANGE:
+                TalkgroupRange talkgroupRange = (TalkgroupRange)aliasID;
+                for(Identifier id : identifierCollection.getIdentifiers())
+                {
+                    if(id instanceof TalkgroupIdentifier tgi)
+                    {
+                        if(id.getProtocol() == talkgroupRange.getProtocol() && talkgroupRange.contains(tgi.getValue()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                break;
+            case RADIO_ID:
+                Radio radio = (Radio)aliasID;
+                for(Identifier id : identifierCollection.getIdentifiers())
+                {
+                    if(id instanceof RadioIdentifier ri)
+                    {
+                        if(id.getProtocol() == radio.getProtocol() && ri.getValue() == radio.getValue())
+                        {
+                            return true;
+                        }
+                    }
+                }
+                break;
+            case RADIO_ID_RANGE:
+                RadioRange radioRange = (RadioRange)aliasID;
+                for(Identifier id : identifierCollection.getIdentifiers())
+                {
+                    if(id instanceof RadioIdentifier ri)
+                    {
+                        if(id.getProtocol() == radioRange.getProtocol() && radioRange.contains(ri.getValue()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                break;
+            case DCS:
+                Dcs dcs = (Dcs)aliasID;
+                for(Identifier id : identifierCollection.getIdentifiers())
+                {
+                    if(id instanceof DCSIdentifier dcsId)
+                    {
+                        if(dcsId.getValue() == dcs.getDCSCode())
+                        {
+                            return true;
+                        }
+                    }
+                }
+                break;
+            case TONES:
+                TonesID tonesID = (TonesID)aliasID;
+                ToneSequence toneSequence = tonesID.getToneSequence();
+                if(toneSequence != null)
+                {
+                    for(Identifier id : identifierCollection.getIdentifiers())
+                    {
+                        if(id instanceof ToneIdentifier toneId)
+                        {
+                            if(toneSequence.isContainedIn(toneId.getValue()))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                break;
+            case ESN:
+                Esn esn = (Esn)aliasID;
+                for(Identifier id : identifierCollection.getIdentifiers())
+                {
+                    if(id instanceof ESNIdentifier esnId)
+                    {
+                        if(esn.getEsn() != null && esn.getEsn().equalsIgnoreCase(esnId.getValue()))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                break;
+        }
+
+        return false;
+    }
+
+    /**
      * Indicates if any of the identifiers contain a broadcast channel for streaming of audio.
      * @param identifierCollection to inspect
      * @return true if the identifier collection is designated for streaming to one or more channels.

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
@@ -134,6 +134,7 @@ public class AliasItemEditor extends Editor<Alias>
     private Button mResetButton;
     private VBox mButtonBox;
     private ToggleSwitch mMonitorAudioToggleSwitch;
+    private ToggleSwitch mMatchAllIdentifiersToggleSwitch;
     private ComboBox<Integer> mMonitorPriorityComboBox;
     private ToggleSwitch mRecordAudioToggleSwitch;
     private ColorPicker mColorPicker;
@@ -233,6 +234,7 @@ public class AliasItemEditor extends Editor<Alias>
         getGroupField().setDisable(disable);
         getNameField().setDisable(disable);
         getRecordAudioToggleSwitch().setDisable(disable);
+        getMatchAllIdentifiersToggleSwitch().setDisable(disable);
         getColorPicker().setDisable(disable);
         getMonitorAudioToggleSwitch().setDisable(disable);
         getIconNodeComboBox().setDisable(disable);
@@ -252,6 +254,7 @@ public class AliasItemEditor extends Editor<Alias>
             getGroupField().setText(alias.getGroup());
             getNameField().setText(alias.getName());
             getRecordAudioToggleSwitch().setSelected(alias.isRecordable());
+            getMatchAllIdentifiersToggleSwitch().setSelected(alias.isMatchAllIdentifiers());
 
             Icon icon = null;
             String iconName = alias.getIconName();
@@ -318,6 +321,7 @@ public class AliasItemEditor extends Editor<Alias>
             getGroupField().setText(null);
             getNameField().setText(null);
             getRecordAudioToggleSwitch().setSelected(false);
+            getMatchAllIdentifiersToggleSwitch().setSelected(false);
             getColorPicker().setValue(Color.BLACK);
             getMonitorPriorityComboBox().getSelectionModel().select(null);
             getMonitorAudioToggleSwitch().setSelected(false);
@@ -336,6 +340,7 @@ public class AliasItemEditor extends Editor<Alias>
             if(alias != null)
             {
                 alias.setRecordable(getRecordAudioToggleSwitch().isSelected());
+                alias.setMatchAllIdentifiers(getMatchAllIdentifiersToggleSwitch().isSelected());
                 alias.setColor(ColorUtil.toInteger(getColorPicker().getValue()));
 
                 Icon icon = getIconNodeComboBox().getSelectionModel().getSelectedItem();
@@ -477,10 +482,20 @@ public class AliasItemEditor extends Editor<Alias>
             buttonsBox.getChildren().addAll(getAddIdentifierButton(), getDeleteIdentifierButton(),
                 getShowOverlapButton());
 
+            HBox matchAllBox = new HBox();
+            matchAllBox.setSpacing(5);
+            matchAllBox.setAlignment(Pos.CENTER_LEFT);
+            Label matchAllLabel = new Label("Match All");
+            matchAllBox.getChildren().addAll(getMatchAllIdentifiersToggleSwitch(), matchAllLabel);
+
+            VBox identifierControlsBox = new VBox();
+            identifierControlsBox.setSpacing(10);
+            identifierControlsBox.getChildren().addAll(buttonsBox, matchAllBox);
+
             HBox identifiersAndButtonsBox = new HBox();
             identifiersAndButtonsBox.setSpacing(10);
             HBox.setHgrow(getIdentifierEditorBox(), Priority.ALWAYS);
-            identifiersAndButtonsBox.getChildren().addAll(getIdentifierEditorBox(), buttonsBox);
+            identifiersAndButtonsBox.getChildren().addAll(getIdentifierEditorBox(), identifierControlsBox);
 
             mIdentifierPane = new TitledPane("Identifiers", identifiersAndButtonsBox);
         }
@@ -1096,6 +1111,19 @@ public class AliasItemEditor extends Editor<Alias>
         }
 
         return mMonitorAudioToggleSwitch;
+    }
+    private ToggleSwitch getMatchAllIdentifiersToggleSwitch()
+    {
+        if(mMatchAllIdentifiersToggleSwitch == null)
+        {
+            mMatchAllIdentifiersToggleSwitch = new ToggleSwitch();
+            mMatchAllIdentifiersToggleSwitch.setDisable(true);
+            mMatchAllIdentifiersToggleSwitch.setTooltip(new Tooltip("When enabled, ALL identifiers must match for this alias to be selected"));
+            mMatchAllIdentifiersToggleSwitch.selectedProperty()
+                .addListener((observable, oldValue, newValue) -> modifiedProperty().set(true));
+        }
+
+        return mMatchAllIdentifiersToggleSwitch;
     }
 
     private ComboBox<Integer> getMonitorPriorityComboBox()


### PR DESCRIPTION
- Adds toggle under Identifiers section of Alias window
- When enabled, channel must match ALL identifiers listed to match to Alias, instead of ANY identifier
- Allows multiple aliases to share same Alias list, as there won't be any conflicts matching to Alias with similar tone identifier (PL/DPL/NAC)