### PR TITLE
#2305 P25P1 Audio Squeak

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DemodulatorLSM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DemodulatorLSM.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2025 Dennis Sheirer
+ * Copyright (C) 2014-2026 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -112,7 +112,6 @@ public class P25P1DemodulatorLSM
         double maxTimingAdjustment = samplesPerSymbol / 25;
         double pointer, residual, timingAdjustment;
         float magnitude, phaseError = 0, requiredGain, softSymbol, pllI, pllQ, pllTemp;
-//        float previousSymbol = 0;
         float iMiddle, qMiddle, iCurrent, qCurrent, iMiddleDemodulated, qMiddleDemodulated, iSymbol, qSymbol;
         int offset;
         Dibit hardSymbol;

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageFramer.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageFramer.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2025 Dennis Sheirer
+ * Copyright (C) 2014-2026 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -123,13 +123,12 @@ public class P25P1MessageFramer
      */
     public void syncDetected()
     {
-        if(mDebugSymbolCount > 2204767)
+        //Only allow sync detection processing if we're not currently assembling a message
+        if(mMessageAssembler == null)
         {
-            int a = 0;
+            mSyncDetected = true;
+            mNIDPointer = 0;
         }
-
-        mSyncDetected = true;
-        mNIDPointer = 0;
     }
 
     /**


### PR DESCRIPTION
Closes #2305 

Updates P25P1 message framer to prevent false sync detects from aborting message assembly, which can cause an audio squeak when the audio is reconstituted from empty IMBE audio frames.
