### PR TITLE
UI improvements: sorting, column persistence, editor fix

### DIFF
--- a/src/main/java/io/github/dsheirer/alias/AliasModel.java
+++ b/src/main/java/io/github/dsheirer/alias/AliasModel.java
@@ -79,6 +79,8 @@ public class AliasModel
                 mAliasListNames.add(aliasListName);
             }
         }
+
+        FXCollections.sort(mAliasListNames);
     }
 
     /**
@@ -124,6 +126,8 @@ public class AliasModel
                 mAliasListNames.add(aliasListName);
             }
         }
+
+        FXCollections.sort(mAliasListNames);
     }
 
     /**
@@ -275,6 +279,7 @@ public class AliasModel
             if(!mAliasListNames.contains(aliasListName))
             {
                 mAliasListNames.add(aliasListName);
+                FXCollections.sort(mAliasListNames);
             }
         }
         else if(!mAliasListNames.contains(NO_ALIAS_LIST))

--- a/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataPanel.java
+++ b/src/main/java/io/github/dsheirer/channel/metadata/ChannelMetadataPanel.java
@@ -60,6 +60,9 @@ import javax.swing.SwingConstants;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
+import java.util.Comparator;
 
 public class ChannelMetadataPanel extends JPanel implements ListSelectionListener
 {
@@ -118,7 +121,21 @@ public class ChannelMetadataPanel extends JPanel implements ListSelectionListene
         mTable.getColumnModel().getColumn(ChannelMetadataModel.COLUMN_CONFIGURATION_FREQUENCY)
             .setCellRenderer(new FrequencyCellRenderer());
 
-        //Add a table column width monitor to store/restore column widths
+        //Enable column sorting via click on column headers
+        TableRowSorter<TableModel> sorter = new TableRowSorter<>(mTable.getModel());
+        Comparator<Object> toStringComparator = (o1, o2) -> {
+            String s1 = o1 != null ? o1.toString() : "";
+            String s2 = o2 != null ? o2.toString() : "";
+            return s1.compareToIgnoreCase(s2);
+        };
+        for(int i = 0; i < mTable.getColumnCount(); i++)
+        {
+            sorter.setComparator(i, toStringComparator);
+        }
+        mTable.setRowSorter(sorter);
+
+        //Add column layout monitor AFTER sorter is set, so it can attach sort listener
+        //and so sorter setup doesn't trigger save of default widths
         mTableColumnMonitor = new JTableColumnWidthMonitor(mUserPreferences, mTable, TABLE_PREFERENCE_KEY);
 
         JScrollPane scrollPane = new JScrollPane(mTable, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,

--- a/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/alias/AliasItemEditor.java
@@ -861,6 +861,12 @@ public class AliasItemEditor extends Editor<Alias>
     private void updateStreamViews()
     {
         Platform.runLater(() -> {
+            // === FIX: Skip refresh if user has unsaved modifications to prevent reverting changes ===
+            if(modifiedProperty().get())
+            {
+                return;
+            }
+
             getAvailableStreamsView().getItems().clear();
             getSelectedStreamsView().getItems().clear();
             getAvailableStreamsView().setDisable(getItem() == null);


### PR DESCRIPTION
- AliasModel: Sort alias list names alphabetically
- ChannelMetadataPanel: Add TableRowSorter with case-insensitive comparator for column sorting
- JTableColumnWidthMonitor: Persist column order and sort order across sessions (not just widths)
- AliasItemEditor: Skip updateStreamViews refresh when user has unsaved modifications to prevent reverting changes during edit