### PR TITLE
Add Zello Work and Consumer real-time audio streaming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     implementation 'org.usb4java:libusb4java:1.3.0'
     implementation 'org.usb4java:usb4java-javax:1.3.0'
     implementation 'pl.edu.icm:JLargeArrays:1.6'
+    implementation 'io.github.jaredmdobson:concentus:1.0.2'
 }
 
 def os = org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.currentOperatingSystem

--- a/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastConfiguration.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastConfiguration.java
@@ -29,6 +29,8 @@ import io.github.dsheirer.audio.broadcast.openmhz.OpenMHzConfiguration;
 import io.github.dsheirer.audio.broadcast.icecast.IcecastConfiguration;
 import io.github.dsheirer.audio.broadcast.shoutcast.v1.ShoutcastV1Configuration;
 import io.github.dsheirer.audio.broadcast.shoutcast.v2.ShoutcastV2Configuration;
+import io.github.dsheirer.audio.broadcast.zello.ZelloConfiguration;
+import io.github.dsheirer.audio.broadcast.zello.ZelloConsumerConfiguration;
 import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
@@ -53,6 +55,8 @@ import java.net.SocketAddress;
     @JsonSubTypes.Type(value = IcecastConfiguration.class, name="icecastConfiguration"),
     @JsonSubTypes.Type(value = ShoutcastV1Configuration.class, name="shoutcastV1Configuration"),
     @JsonSubTypes.Type(value = ShoutcastV2Configuration.class, name="shoutcastV2Configuration"),
+    @JsonSubTypes.Type(value = ZelloConfiguration.class, name="zelloConfiguration"),
+    @JsonSubTypes.Type(value = ZelloConsumerConfiguration.class, name="zelloConsumerConfiguration"),
 })
 @JacksonXmlRootElement(localName = "stream")
 public abstract class BroadcastConfiguration

--- a/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastFactory.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastFactory.java
@@ -36,6 +36,10 @@ import io.github.dsheirer.audio.broadcast.shoutcast.v1.ShoutcastV1AudioBroadcast
 import io.github.dsheirer.audio.broadcast.shoutcast.v1.ShoutcastV1Configuration;
 import io.github.dsheirer.audio.broadcast.shoutcast.v2.ShoutcastV2AudioStreamingBroadcaster;
 import io.github.dsheirer.audio.broadcast.shoutcast.v2.ShoutcastV2Configuration;
+import io.github.dsheirer.audio.broadcast.zello.ZelloBroadcaster;
+import io.github.dsheirer.audio.broadcast.zello.ZelloConfiguration;
+import io.github.dsheirer.audio.broadcast.zello.ZelloConsumerBroadcaster;
+import io.github.dsheirer.audio.broadcast.zello.ZelloConsumerConfiguration;
 import io.github.dsheirer.audio.convert.ISilenceGenerator;
 import io.github.dsheirer.audio.convert.InputAudioFormat;
 import io.github.dsheirer.audio.convert.MP3Setting;
@@ -88,6 +92,12 @@ public class BroadcastFactory
                 case SHOUTCAST_V2:
                     return new ShoutcastV2AudioStreamingBroadcaster((ShoutcastV2Configuration) configuration,
                             inputAudioFormat, mp3Setting, aliasModel);
+                case ZELLO_WORK:
+                    return new ZelloBroadcaster((ZelloConfiguration) configuration,
+                            inputAudioFormat, mp3Setting, aliasModel);
+                case ZELLO:
+                    return new ZelloConsumerBroadcaster((ZelloConsumerConfiguration) configuration,
+                            inputAudioFormat, mp3Setting, aliasModel);
                 case UNKNOWN:
                 default:
                     mLog.info("Unrecognized broadcastAudio configuration: " + configuration.getBroadcastFormat().name());
@@ -125,6 +135,10 @@ public class BroadcastFactory
                 return new ShoutcastV1Configuration(format);
             case SHOUTCAST_V2:
                 return new ShoutcastV2Configuration(format);
+            case ZELLO_WORK:
+                return new ZelloConfiguration(format);
+            case ZELLO:
+                return new ZelloConsumerConfiguration(format);
             case UNKNOWN:
             default:
                 mLog.info("Unrecognized broadcastAudio server type: " + serverType.name());

--- a/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastServerType.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/BroadcastServerType.java
@@ -36,6 +36,17 @@ public enum BroadcastServerType
     ICECAST_TCP("Icecast (v2.3)", "images/icecast.png"),
     SHOUTCAST_V1("Shoutcast v1.x", "images/shoutcast.png"),
     SHOUTCAST_V2("Shoutcast v2.x", "images/shoutcast.png"),
+
+    /**
+     * Zello Work - real-time audio streaming to Zello Work channels
+     */
+    ZELLO_WORK("Zello Work", null),
+
+    /**
+     * Zello Consumer (Friends & Family) - real-time audio streaming
+     */
+    ZELLO("Zello Consumer", null),
+
     UNKNOWN("Unknown", null);
 
     private String mLabel;

--- a/src/main/java/io/github/dsheirer/audio/broadcast/IRealTimeAudioBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/IRealTimeAudioBroadcaster.java
@@ -1,0 +1,66 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.audio.broadcast;
+
+import io.github.dsheirer.identifier.IdentifierCollection;
+
+/**
+ * Interface for broadcasters that support real-time audio streaming (as opposed to
+ * the standard recording-then-upload approach). Real-time broadcasters receive audio
+ * buffers as they are produced, with explicit start/stop signals for each audio segment.
+ *
+ * This interface is used by AudioStreamingManager to route audio directly to
+ * real-time broadcasters without waiting for the audio segment to complete.
+ */
+public interface IRealTimeAudioBroadcaster
+{
+    /**
+     * Called when a new audio segment starts. The broadcaster should prepare for
+     * incoming audio (e.g., open a stream connection).
+     *
+     * @param identifiers the identifier collection for this audio segment
+     */
+    void startRealTimeStream(IdentifierCollection identifiers);
+
+    /**
+     * Called for each audio buffer as it arrives in real-time.
+     * Buffers are 8 kHz mono float samples, normalized to [-1.0, 1.0].
+     *
+     * This method must return quickly and not block. Implementations should
+     * queue the buffer for processing on a separate thread.
+     *
+     * @param audioBuffer the audio samples
+     */
+    void receiveRealTimeAudio(float[] audioBuffer);
+
+    /**
+     * Called when the audio segment is complete. The broadcaster should finalize
+     * and close the stream.
+     */
+    void stopRealTimeStream();
+
+    /**
+     * Indicates if this broadcaster is currently capable of real-time streaming.
+     * If false, the audio streaming manager will fall back to recording-based delivery.
+     *
+     * @return true if ready for real-time streaming
+     */
+    boolean isRealTimeReady();
+}

--- a/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloBroadcaster.java
@@ -1,0 +1,542 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.audio.broadcast.zello;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.github.dsheirer.alias.AliasModel;
+import io.github.dsheirer.audio.broadcast.AbstractAudioBroadcaster;
+import io.github.dsheirer.audio.broadcast.AudioRecording;
+import io.github.dsheirer.audio.broadcast.BroadcastEvent;
+import io.github.dsheirer.audio.broadcast.BroadcastState;
+import io.github.dsheirer.audio.broadcast.IRealTimeAudioBroadcaster;
+import io.github.dsheirer.audio.convert.InputAudioFormat;
+import io.github.dsheirer.audio.convert.MP3Setting;
+import io.github.dsheirer.identifier.IdentifierCollection;
+import io.github.dsheirer.util.ThreadPool;
+import io.github.jaredmdobson.concentus.OpusApplication;
+import io.github.jaredmdobson.concentus.OpusEncoder;
+import io.github.jaredmdobson.concentus.OpusSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Real-time audio broadcaster for Zello Work channels via WebSocket.
+ *
+ * Implements IRealTimeAudioBroadcaster to receive 8kHz mono float audio buffers
+ * in real-time. Audio is resampled to 16kHz, Opus-encoded, and streamed via
+ * the Zello Channel API WebSocket protocol.
+ *
+ * Each audio segment maps to one Zello push-to-talk voice message:
+ * - startRealTimeStream() -> start_stream command
+ * - receiveRealTimeAudio() -> accumulate, resample, Opus encode, send packets
+ * - stopRealTimeStream() -> stop_stream command
+ */
+public class ZelloBroadcaster extends AbstractAudioBroadcaster<ZelloConfiguration>
+    implements IRealTimeAudioBroadcaster
+{
+    private static final Logger mLog = LoggerFactory.getLogger(ZelloBroadcaster.class);
+
+    private static final int ZELLO_SAMPLE_RATE = 16000;
+    private static final int ZELLO_CHANNELS = 1;
+    private static final int ZELLO_FRAME_SIZE_MS = 60;
+    private static final int ZELLO_FRAME_SIZE_SAMPLES = ZELLO_SAMPLE_RATE * ZELLO_FRAME_SIZE_MS / 1000; // 960
+    private static final int OPUS_BITRATE = 16000;
+
+    // codec_header: {sample_rate_hz(16LE), frames_per_packet(8), frame_size_ms(8)}
+    private static final byte[] CODEC_HEADER = {(byte)0x80, (byte)0x3E, 0x01, 0x3C};
+    private static final String CODEC_HEADER_B64 = Base64.getEncoder().encodeToString(CODEC_HEADER);
+
+    private static final long RECONNECT_INTERVAL_MS = 15000;
+
+    private final HttpClient mHttpClient;
+    private final Gson mGson = new Gson();
+    private final AliasModel mAliasModel;
+
+    private WebSocket mWebSocket;
+    private final AtomicBoolean mConnected = new AtomicBoolean(false);
+    private final AtomicBoolean mChannelOnline = new AtomicBoolean(false);
+    private final AtomicInteger mSequence = new AtomicInteger(1);
+    private ScheduledFuture<?> mReconnectFuture;
+
+    private final AtomicBoolean mStreamActive = new AtomicBoolean(false);
+    private final AtomicLong mCurrentStreamId = new AtomicLong(-1);
+    private final LinkedTransferQueue<float[]> mAudioQueue = new LinkedTransferQueue<>();
+    private ScheduledFuture<?> mEncoderFuture;
+
+    private OpusEncoder mOpusEncoder;
+    private short[] mResampleBuffer = new short[ZELLO_FRAME_SIZE_SAMPLES];
+    private int mResampleBufferPos = 0;
+    private byte[] mOpusOutputBuffer = new byte[1275];
+    private int mStreamedCount = 0;
+
+    public ZelloBroadcaster(ZelloConfiguration configuration, InputAudioFormat inputAudioFormat,
+                            MP3Setting mp3Setting, AliasModel aliasModel)
+    {
+        super(configuration);
+        mAliasModel = aliasModel;
+        mHttpClient = HttpClient.newBuilder()
+            .connectTimeout(java.time.Duration.ofSeconds(15))
+            .build();
+    }
+
+    @Override
+    public void start()
+    {
+        setBroadcastState(BroadcastState.CONNECTING);
+        try
+        {
+            initOpusEncoder();
+            connectWebSocket();
+        }
+        catch(Exception e)
+        {
+            mLog.error("Error starting Zello broadcaster", e);
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+        }
+    }
+
+    @Override
+    public void stop()
+    {
+        if(mStreamActive.get()) stopRealTimeStream();
+        if(mReconnectFuture != null) { mReconnectFuture.cancel(true); mReconnectFuture = null; }
+        disconnectWebSocket();
+        setBroadcastState(BroadcastState.DISCONNECTED);
+    }
+
+    @Override
+    public void dispose() { stop(); }
+
+    @Override
+    public int getAudioQueueSize() { return mAudioQueue.size(); }
+
+    /** Standard recording receive — discarded since we use real-time streaming */
+    @Override
+    public void receive(AudioRecording audioRecording)
+    {
+        if(audioRecording != null) audioRecording.removePendingReplay();
+    }
+
+    // ========================================================================
+    // IRealTimeAudioBroadcaster
+    // ========================================================================
+
+    @Override
+    public boolean isRealTimeReady()
+    {
+        return mConnected.get() && mChannelOnline.get() && !mStreamActive.get();
+    }
+
+    @Override
+    public void startRealTimeStream(IdentifierCollection identifiers)
+    {
+        if(!mConnected.get() || !mChannelOnline.get())
+        {
+            mLog.warn("Cannot start Zello stream - not connected");
+            return;
+        }
+        if(mStreamActive.get())
+        {
+            stopRealTimeStream();
+        }
+
+        mStreamActive.set(true);
+        mCurrentStreamId.set(-1);
+        mResampleBufferPos = 0;
+        mAudioQueue.clear();
+
+        sendStartStream();
+
+        if(mEncoderFuture == null || mEncoderFuture.isDone())
+        {
+            mEncoderFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(
+                this::processAudioQueue, 10, 10, TimeUnit.MILLISECONDS);
+        }
+
+        mLog.debug("Real-time Zello stream started");
+    }
+
+    @Override
+    public void receiveRealTimeAudio(float[] audioBuffer)
+    {
+        if(mStreamActive.get()) mAudioQueue.offer(audioBuffer);
+    }
+
+    @Override
+    public void stopRealTimeStream()
+    {
+        if(!mStreamActive.get()) return;
+
+        mStreamActive.set(false);
+        processAudioQueue();
+        if(mResampleBufferPos > 0) flushResampleBuffer();
+
+        if(mEncoderFuture != null) { mEncoderFuture.cancel(false); mEncoderFuture = null; }
+
+        long streamId = mCurrentStreamId.get();
+        if(streamId > 0)
+        {
+            sendStopStream(streamId);
+            mStreamedCount++;
+            broadcast(new BroadcastEvent(this, BroadcastEvent.Event.BROADCASTER_STREAMED_COUNT_CHANGE));
+        }
+
+        mCurrentStreamId.set(-1);
+        mAudioQueue.clear();
+        mLog.debug("Real-time Zello stream stopped");
+    }
+
+    // ========================================================================
+    // Audio Processing
+    // ========================================================================
+
+    private void processAudioQueue()
+    {
+        try
+        {
+            float[] buffer;
+            while((buffer = mAudioQueue.poll()) != null)
+            {
+                processAudioBuffer(buffer);
+            }
+        }
+        catch(Exception e)
+        {
+            mLog.error("Error processing audio queue", e);
+        }
+    }
+
+    /** Convert float 8kHz -> short 16kHz (2x upsample), accumulate, encode when frame full */
+    private void processAudioBuffer(float[] audio8k)
+    {
+        for(int i = 0; i < audio8k.length; i++)
+        {
+            short sample = (short)(audio8k[i] * 32767.0f);
+
+            // 2x upsample: duplicate each sample
+            mResampleBuffer[mResampleBufferPos++] = sample;
+            if(mResampleBufferPos >= ZELLO_FRAME_SIZE_SAMPLES)
+            {
+                encodeAndSendFrame();
+                mResampleBufferPos = 0;
+            }
+
+            mResampleBuffer[mResampleBufferPos++] = sample;
+            if(mResampleBufferPos >= ZELLO_FRAME_SIZE_SAMPLES)
+            {
+                encodeAndSendFrame();
+                mResampleBufferPos = 0;
+            }
+        }
+    }
+
+    private void encodeAndSendFrame()
+    {
+        long streamId = mCurrentStreamId.get();
+        if(streamId <= 0) return;
+
+        try
+        {
+            int encoded = mOpusEncoder.encode(mResampleBuffer, 0, ZELLO_FRAME_SIZE_SAMPLES,
+                mOpusOutputBuffer, 0, mOpusOutputBuffer.length);
+
+            if(encoded > 0)
+            {
+                byte[] opusFrame = new byte[encoded];
+                System.arraycopy(mOpusOutputBuffer, 0, opusFrame, 0, encoded);
+                sendAudioPacket(streamId, opusFrame);
+            }
+        }
+        catch(Exception e)
+        {
+            mLog.error("Opus encoding error", e);
+        }
+    }
+
+    private void flushResampleBuffer()
+    {
+        for(int i = mResampleBufferPos; i < ZELLO_FRAME_SIZE_SAMPLES; i++)
+            mResampleBuffer[i] = 0;
+        encodeAndSendFrame();
+        mResampleBufferPos = 0;
+    }
+
+    private void initOpusEncoder() throws Exception
+    {
+        mOpusEncoder = new OpusEncoder(ZELLO_SAMPLE_RATE, ZELLO_CHANNELS, OpusApplication.OPUS_APPLICATION_VOIP);
+        mOpusEncoder.setBitrate(OPUS_BITRATE);
+        mOpusEncoder.setSignalType(OpusSignal.OPUS_SIGNAL_VOICE);
+        mOpusEncoder.setComplexity(5);
+        mLog.info("Opus encoder initialized: {}Hz, {}ch, {}kbps, {}ms frames",
+            ZELLO_SAMPLE_RATE, ZELLO_CHANNELS, OPUS_BITRATE / 1000, ZELLO_FRAME_SIZE_MS);
+    }
+
+    // ========================================================================
+    // WebSocket
+    // ========================================================================
+
+    private void connectWebSocket()
+    {
+        String wsUrl = getBroadcastConfiguration().getWebSocketUrl();
+        if(wsUrl == null)
+        {
+            mLog.error("Zello WebSocket URL is null");
+            setBroadcastState(BroadcastState.CONFIGURATION_ERROR);
+            return;
+        }
+
+        mLog.info("Connecting to Zello Work: {}", wsUrl);
+        try
+        {
+            mHttpClient.newWebSocketBuilder()
+                .buildAsync(URI.create(wsUrl), new ZelloWebSocketListener())
+                .thenAccept(ws -> { mWebSocket = ws; mLog.info("WebSocket connected"); sendLogon(); })
+                .exceptionally(ex -> {
+                    mLog.error("WebSocket connection failed: {}", ex.getMessage());
+                    setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+                    scheduleReconnect();
+                    return null;
+                });
+        }
+        catch(Exception e)
+        {
+            mLog.error("Error creating WebSocket connection", e);
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+        }
+    }
+
+    private void disconnectWebSocket()
+    {
+        mConnected.set(false);
+        mChannelOnline.set(false);
+        if(mWebSocket != null)
+        {
+            try { mWebSocket.sendClose(WebSocket.NORMAL_CLOSURE, "Shutting down"); }
+            catch(Exception e) { /* ignore */ }
+            mWebSocket = null;
+        }
+    }
+
+    private void scheduleReconnect()
+    {
+        if(mReconnectFuture == null || mReconnectFuture.isDone())
+        {
+            mReconnectFuture = ThreadPool.SCHEDULED.schedule(() -> {
+                if(!mConnected.get()) { mLog.info("Zello reconnecting..."); connectWebSocket(); }
+            }, RECONNECT_INTERVAL_MS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    // ========================================================================
+    // Zello Protocol
+    // ========================================================================
+
+    private void sendLogon()
+    {
+        ZelloConfiguration config = getBroadcastConfiguration();
+        JsonObject logon = new JsonObject();
+        logon.addProperty("command", "logon");
+        logon.addProperty("seq", mSequence.getAndIncrement());
+        com.google.gson.JsonArray channels = new com.google.gson.JsonArray();
+        channels.add(config.getChannel());
+        logon.add("channels", channels);
+        logon.addProperty("username", config.getUsername());
+        logon.addProperty("password", config.getPassword());
+        String authToken = config.getAuthToken();
+        if(authToken != null && !authToken.isEmpty()) logon.addProperty("auth_token", authToken);
+        logon.addProperty("listen_only", false);
+        mWebSocket.sendText(mGson.toJson(logon), true);
+    }
+
+    private void sendStartStream()
+    {
+        JsonObject cmd = new JsonObject();
+        cmd.addProperty("command", "start_stream");
+        cmd.addProperty("seq", mSequence.getAndIncrement());
+        cmd.addProperty("type", "audio");
+        cmd.addProperty("codec", "opus");
+        cmd.addProperty("codec_header", CODEC_HEADER_B64);
+        cmd.addProperty("packet_duration", ZELLO_FRAME_SIZE_MS);
+        mWebSocket.sendText(mGson.toJson(cmd), true);
+    }
+
+    private void sendStopStream(long streamId)
+    {
+        JsonObject cmd = new JsonObject();
+        cmd.addProperty("command", "stop_stream");
+        cmd.addProperty("seq", mSequence.getAndIncrement());
+        cmd.addProperty("stream_id", streamId);
+        mWebSocket.sendText(mGson.toJson(cmd), true);
+    }
+
+    private void sendAudioPacket(long streamId, byte[] opusData)
+    {
+        if(mWebSocket == null) return;
+        ByteBuffer packet = ByteBuffer.allocate(1 + 4 + 4 + opusData.length);
+        packet.order(ByteOrder.BIG_ENDIAN);
+        packet.put((byte)0x01);
+        packet.putInt((int)streamId);
+        packet.putInt(0);
+        packet.put(opusData);
+        packet.flip();
+        mWebSocket.sendBinary(packet, true);
+    }
+
+    // ========================================================================
+    // WebSocket Listener
+    // ========================================================================
+
+    private class ZelloWebSocketListener implements WebSocket.Listener
+    {
+        private StringBuilder mTextBuffer = new StringBuilder();
+
+        @Override public void onOpen(WebSocket ws) { mLog.info("Zello WebSocket opened"); ws.request(1); }
+
+        @Override
+        public CompletionStage<?> onText(WebSocket ws, CharSequence data, boolean last)
+        {
+            mTextBuffer.append(data);
+            if(last) { handleTextMessage(mTextBuffer.toString()); mTextBuffer.setLength(0); }
+            ws.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onBinary(WebSocket ws, ByteBuffer data, boolean last)
+        {
+            ws.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onPing(WebSocket ws, ByteBuffer msg)
+        {
+            ws.sendPong(msg);
+            ws.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onClose(WebSocket ws, int code, String reason)
+        {
+            mLog.info("Zello WebSocket closed: {} {}", code, reason);
+            mConnected.set(false);
+            mChannelOnline.set(false);
+            if(mStreamActive.get()) { mStreamActive.set(false); mCurrentStreamId.set(-1); }
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket ws, Throwable error)
+        {
+            mLog.error("Zello WebSocket error: {}", error.getMessage());
+            mConnected.set(false);
+            mChannelOnline.set(false);
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+        }
+
+        private void handleTextMessage(String message)
+        {
+            try
+            {
+                JsonObject json = JsonParser.parseString(message).getAsJsonObject();
+
+                if(json.has("refresh_token") ||
+                    (json.has("success") && json.get("success").getAsBoolean() && !json.has("stream_id")))
+                {
+                    mLog.info("Zello logon successful");
+                    mConnected.set(true);
+                }
+                else if(json.has("error") && !json.has("command"))
+                {
+                    mLog.error("Zello logon failed: {}", message);
+                    setBroadcastState(BroadcastState.CONFIGURATION_ERROR);
+                    return;
+                }
+
+                if(json.has("command"))
+                {
+                    String command = json.get("command").getAsString();
+                    if("on_channel_status".equals(command))
+                    {
+                        String status = json.has("status") ? json.get("status").getAsString() : "";
+                        if("online".equals(status))
+                        {
+                            mChannelOnline.set(true);
+                            setBroadcastState(BroadcastState.CONNECTED);
+                            mLog.info("Zello channel online: {}",
+                                json.has("channel") ? json.get("channel").getAsString() : "");
+                        }
+                        else
+                        {
+                            mChannelOnline.set(false);
+                        }
+                    }
+                    else if("on_error".equals(command))
+                    {
+                        mLog.error("Zello error: {}", message);
+                    }
+                }
+
+                if(json.has("stream_id") && json.has("success"))
+                {
+                    if(json.get("success").getAsBoolean())
+                    {
+                        long streamId = json.get("stream_id").getAsLong();
+                        mCurrentStreamId.set(streamId);
+                        mLog.debug("Zello stream_id={}", streamId);
+                    }
+                    else
+                    {
+                        mLog.error("Zello start_stream failed: {}", message);
+                        mCurrentStreamId.set(-2);
+                        mStreamActive.set(false);
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                mLog.error("Error parsing Zello message: {}", message, e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConfiguration.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConfiguration.java
@@ -1,0 +1,198 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.audio.broadcast.zello;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import io.github.dsheirer.audio.broadcast.BroadcastConfiguration;
+import io.github.dsheirer.audio.broadcast.BroadcastFormat;
+import io.github.dsheirer.audio.broadcast.BroadcastServerType;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+/**
+ * Broadcast configuration for Zello Work channel streaming.
+ *
+ * Zello Work uses a WebSocket-based channel API to stream Opus-encoded audio
+ * to Zello channels. Each completed audio recording is encoded to Opus and
+ * pushed as a voice message to the configured Zello channel.
+ *
+ * Configuration fields:
+ * - Network Name: The Zello Work network name (e.g., "actionpage")
+ * - Channel: The Zello channel name to stream to
+ * - Username: Zello account username
+ * - Password: Zello account password
+ * - Auth Token: JWT authentication token (optional for Zello Work)
+ */
+public class ZelloConfiguration extends BroadcastConfiguration
+{
+    private StringProperty mNetworkName = new SimpleStringProperty();
+    private StringProperty mChannel = new SimpleStringProperty();
+    private StringProperty mUsername = new SimpleStringProperty();
+    private StringProperty mAuthToken = new SimpleStringProperty();
+
+    /**
+     * Default constructor for Jackson XML deserialization
+     */
+    public ZelloConfiguration()
+    {
+        this(BroadcastFormat.MP3);
+    }
+
+    /**
+     * Public constructor
+     * @param format audio format (MP3 — audio will be re-encoded to Opus for Zello)
+     */
+    public ZelloConfiguration(BroadcastFormat format)
+    {
+        super(format);
+
+        // Unbind parent validation and rebind with Zello-specific requirements
+        mValid.unbind();
+        mValid.bind(Bindings.and(
+            Bindings.and(
+                Bindings.isNotEmpty(mNetworkName),
+                Bindings.isNotEmpty(mChannel)
+            ),
+            Bindings.and(
+                Bindings.isNotEmpty(mUsername),
+                Bindings.isNotNull(mPassword)
+            )
+        ));
+    }
+
+    // ========================================================================
+    // Network Name (Zello Work subdomain)
+    // ========================================================================
+
+    public StringProperty networkNameProperty()
+    {
+        return mNetworkName;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "network_name")
+    public String getNetworkName()
+    {
+        return mNetworkName.get();
+    }
+
+    public void setNetworkName(String networkName)
+    {
+        mNetworkName.set(networkName);
+    }
+
+    // ========================================================================
+    // Channel Name
+    // ========================================================================
+
+    public StringProperty channelProperty()
+    {
+        return mChannel;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "channel")
+    public String getChannel()
+    {
+        return mChannel.get();
+    }
+
+    public void setChannel(String channel)
+    {
+        mChannel.set(channel);
+    }
+
+    // ========================================================================
+    // Username
+    // ========================================================================
+
+    public StringProperty usernameProperty()
+    {
+        return mUsername;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "username")
+    public String getUsername()
+    {
+        return mUsername.get();
+    }
+
+    public void setUsername(String username)
+    {
+        mUsername.set(username);
+    }
+
+    // ========================================================================
+    // Auth Token (JWT — optional for Zello Work)
+    // ========================================================================
+
+    public StringProperty authTokenProperty()
+    {
+        return mAuthToken;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "auth_token")
+    public String getAuthToken()
+    {
+        return mAuthToken.get();
+    }
+
+    public void setAuthToken(String authToken)
+    {
+        mAuthToken.set(authToken);
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    /**
+     * Returns the WebSocket URL for this Zello Work network.
+     * Format: wss://zellowork.io/ws/{network_name}
+     */
+    public String getWebSocketUrl()
+    {
+        String network = getNetworkName();
+        if(network != null && !network.isEmpty())
+        {
+            return "wss://zellowork.io/ws/" + network;
+        }
+        return null;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "type",
+        namespace = "http://www.w3.org/2001/XMLSchema-instance")
+    @Override
+    public BroadcastServerType getBroadcastServerType()
+    {
+        return BroadcastServerType.ZELLO_WORK;
+    }
+
+    @Override
+    public BroadcastConfiguration copyOf()
+    {
+        ZelloConfiguration copy = new ZelloConfiguration();
+        copy.setNetworkName(getNetworkName());
+        copy.setChannel(getChannel());
+        copy.setUsername(getUsername());
+        copy.setPassword(getPassword());
+        copy.setAuthToken(getAuthToken());
+        return copy;
+    }
+}

--- a/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConsumerBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConsumerBroadcaster.java
@@ -74,7 +74,7 @@ public class ZelloConsumerBroadcaster extends AbstractAudioBroadcaster<ZelloCons
     private static final int ZELLO_CHANNELS = 1;
     private static final int ZELLO_FRAME_SIZE_MS = 60;
     private static final int ZELLO_FRAME_SIZE_SAMPLES = ZELLO_SAMPLE_RATE * ZELLO_FRAME_SIZE_MS / 1000; // 960
-    private static final int OPUS_BITRATE = 16000;
+    private static final int OPUS_BITRATE = 28000;
 
     // codec_header: {sample_rate_hz(16LE), frames_per_packet(8), frame_size_ms(8)}
     private static final byte[] CODEC_HEADER = {(byte)0x80, (byte)0x3E, 0x01, 0x3C};
@@ -102,6 +102,7 @@ public class ZelloConsumerBroadcaster extends AbstractAudioBroadcaster<ZelloCons
     private int mResampleBufferPos = 0;
     private byte[] mOpusOutputBuffer = new byte[1275];
     private int mStreamedCount = 0;
+    private short mPreviousSample = 0;
 
     public ZelloConsumerBroadcaster(ZelloConsumerConfiguration configuration, InputAudioFormat inputAudioFormat,
                             MP3Setting mp3Setting, AliasModel aliasModel)
@@ -178,6 +179,7 @@ public class ZelloConsumerBroadcaster extends AbstractAudioBroadcaster<ZelloCons
         mStreamActive.set(true);
         mCurrentStreamId.set(-1);
         mResampleBufferPos = 0;
+        mPreviousSample = 0;
         mAudioQueue.clear();
 
         sendStartStream();
@@ -241,27 +243,32 @@ public class ZelloConsumerBroadcaster extends AbstractAudioBroadcaster<ZelloCons
         }
     }
 
-    /** Convert float 8kHz -> short 16kHz (2x upsample), accumulate, encode when frame full */
+    /** Convert float 8kHz -> short 16kHz (2x upsample with linear interpolation), accumulate, encode when frame full */
     private void processAudioBuffer(float[] audio8k)
     {
         for(int i = 0; i < audio8k.length; i++)
         {
-            short sample = (short)(audio8k[i] * 32767.0f);
+            short currentSample = (short)(audio8k[i] * 32767.0f);
 
-            // 2x upsample: duplicate each sample
-            mResampleBuffer[mResampleBufferPos++] = sample;
+            // 2x upsample with linear interpolation:
+            // Insert midpoint between previous and current sample, then current sample
+            short midpoint = (short)((mPreviousSample + currentSample) / 2);
+
+            mResampleBuffer[mResampleBufferPos++] = midpoint;
             if(mResampleBufferPos >= ZELLO_FRAME_SIZE_SAMPLES)
             {
                 encodeAndSendFrame();
                 mResampleBufferPos = 0;
             }
 
-            mResampleBuffer[mResampleBufferPos++] = sample;
+            mResampleBuffer[mResampleBufferPos++] = currentSample;
             if(mResampleBufferPos >= ZELLO_FRAME_SIZE_SAMPLES)
             {
                 encodeAndSendFrame();
                 mResampleBufferPos = 0;
             }
+
+            mPreviousSample = currentSample;
         }
     }
 
@@ -301,7 +308,7 @@ public class ZelloConsumerBroadcaster extends AbstractAudioBroadcaster<ZelloCons
         mOpusEncoder = new OpusEncoder(ZELLO_SAMPLE_RATE, ZELLO_CHANNELS, OpusApplication.OPUS_APPLICATION_VOIP);
         mOpusEncoder.setBitrate(OPUS_BITRATE);
         mOpusEncoder.setSignalType(OpusSignal.OPUS_SIGNAL_VOICE);
-        mOpusEncoder.setComplexity(5);
+        mOpusEncoder.setComplexity(8);
         mLog.info("Opus encoder initialized: {}Hz, {}ch, {}kbps, {}ms frames",
             ZELLO_SAMPLE_RATE, ZELLO_CHANNELS, OPUS_BITRATE / 1000, ZELLO_FRAME_SIZE_MS);
     }

--- a/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConsumerBroadcaster.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConsumerBroadcaster.java
@@ -1,0 +1,542 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.audio.broadcast.zello;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.github.dsheirer.alias.AliasModel;
+import io.github.dsheirer.audio.broadcast.AbstractAudioBroadcaster;
+import io.github.dsheirer.audio.broadcast.AudioRecording;
+import io.github.dsheirer.audio.broadcast.BroadcastEvent;
+import io.github.dsheirer.audio.broadcast.BroadcastState;
+import io.github.dsheirer.audio.broadcast.IRealTimeAudioBroadcaster;
+import io.github.dsheirer.audio.convert.InputAudioFormat;
+import io.github.dsheirer.audio.convert.MP3Setting;
+import io.github.dsheirer.identifier.IdentifierCollection;
+import io.github.dsheirer.util.ThreadPool;
+import io.github.jaredmdobson.concentus.OpusApplication;
+import io.github.jaredmdobson.concentus.OpusEncoder;
+import io.github.jaredmdobson.concentus.OpusSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Real-time audio broadcaster for Zello Work channels via WebSocket.
+ *
+ * Implements IRealTimeAudioBroadcaster to receive 8kHz mono float audio buffers
+ * in real-time. Audio is resampled to 16kHz, Opus-encoded, and streamed via
+ * the Zello Channel API WebSocket protocol.
+ *
+ * Each audio segment maps to one Zello push-to-talk voice message:
+ * - startRealTimeStream() -> start_stream command
+ * - receiveRealTimeAudio() -> accumulate, resample, Opus encode, send packets
+ * - stopRealTimeStream() -> stop_stream command
+ */
+public class ZelloConsumerBroadcaster extends AbstractAudioBroadcaster<ZelloConsumerConfiguration>
+    implements IRealTimeAudioBroadcaster
+{
+    private static final Logger mLog = LoggerFactory.getLogger(ZelloConsumerBroadcaster.class);
+
+    private static final int ZELLO_SAMPLE_RATE = 16000;
+    private static final int ZELLO_CHANNELS = 1;
+    private static final int ZELLO_FRAME_SIZE_MS = 60;
+    private static final int ZELLO_FRAME_SIZE_SAMPLES = ZELLO_SAMPLE_RATE * ZELLO_FRAME_SIZE_MS / 1000; // 960
+    private static final int OPUS_BITRATE = 16000;
+
+    // codec_header: {sample_rate_hz(16LE), frames_per_packet(8), frame_size_ms(8)}
+    private static final byte[] CODEC_HEADER = {(byte)0x80, (byte)0x3E, 0x01, 0x3C};
+    private static final String CODEC_HEADER_B64 = Base64.getEncoder().encodeToString(CODEC_HEADER);
+
+    private static final long RECONNECT_INTERVAL_MS = 15000;
+
+    private final HttpClient mHttpClient;
+    private final Gson mGson = new Gson();
+    private final AliasModel mAliasModel;
+
+    private WebSocket mWebSocket;
+    private final AtomicBoolean mConnected = new AtomicBoolean(false);
+    private final AtomicBoolean mChannelOnline = new AtomicBoolean(false);
+    private final AtomicInteger mSequence = new AtomicInteger(1);
+    private ScheduledFuture<?> mReconnectFuture;
+
+    private final AtomicBoolean mStreamActive = new AtomicBoolean(false);
+    private final AtomicLong mCurrentStreamId = new AtomicLong(-1);
+    private final LinkedTransferQueue<float[]> mAudioQueue = new LinkedTransferQueue<>();
+    private ScheduledFuture<?> mEncoderFuture;
+
+    private OpusEncoder mOpusEncoder;
+    private short[] mResampleBuffer = new short[ZELLO_FRAME_SIZE_SAMPLES];
+    private int mResampleBufferPos = 0;
+    private byte[] mOpusOutputBuffer = new byte[1275];
+    private int mStreamedCount = 0;
+
+    public ZelloConsumerBroadcaster(ZelloConsumerConfiguration configuration, InputAudioFormat inputAudioFormat,
+                            MP3Setting mp3Setting, AliasModel aliasModel)
+    {
+        super(configuration);
+        mAliasModel = aliasModel;
+        mHttpClient = HttpClient.newBuilder()
+            .connectTimeout(java.time.Duration.ofSeconds(15))
+            .build();
+    }
+
+    @Override
+    public void start()
+    {
+        setBroadcastState(BroadcastState.CONNECTING);
+        try
+        {
+            initOpusEncoder();
+            connectWebSocket();
+        }
+        catch(Exception e)
+        {
+            mLog.error("Error starting Zello broadcaster", e);
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+        }
+    }
+
+    @Override
+    public void stop()
+    {
+        if(mStreamActive.get()) stopRealTimeStream();
+        if(mReconnectFuture != null) { mReconnectFuture.cancel(true); mReconnectFuture = null; }
+        disconnectWebSocket();
+        setBroadcastState(BroadcastState.DISCONNECTED);
+    }
+
+    @Override
+    public void dispose() { stop(); }
+
+    @Override
+    public int getAudioQueueSize() { return mAudioQueue.size(); }
+
+    /** Standard recording receive — discarded since we use real-time streaming */
+    @Override
+    public void receive(AudioRecording audioRecording)
+    {
+        if(audioRecording != null) audioRecording.removePendingReplay();
+    }
+
+    // ========================================================================
+    // IRealTimeAudioBroadcaster
+    // ========================================================================
+
+    @Override
+    public boolean isRealTimeReady()
+    {
+        return mConnected.get() && mChannelOnline.get() && !mStreamActive.get();
+    }
+
+    @Override
+    public void startRealTimeStream(IdentifierCollection identifiers)
+    {
+        if(!mConnected.get() || !mChannelOnline.get())
+        {
+            mLog.warn("Cannot start Zello stream - not connected");
+            return;
+        }
+        if(mStreamActive.get())
+        {
+            stopRealTimeStream();
+        }
+
+        mStreamActive.set(true);
+        mCurrentStreamId.set(-1);
+        mResampleBufferPos = 0;
+        mAudioQueue.clear();
+
+        sendStartStream();
+
+        if(mEncoderFuture == null || mEncoderFuture.isDone())
+        {
+            mEncoderFuture = ThreadPool.SCHEDULED.scheduleAtFixedRate(
+                this::processAudioQueue, 10, 10, TimeUnit.MILLISECONDS);
+        }
+
+        mLog.debug("Real-time Zello stream started");
+    }
+
+    @Override
+    public void receiveRealTimeAudio(float[] audioBuffer)
+    {
+        if(mStreamActive.get()) mAudioQueue.offer(audioBuffer);
+    }
+
+    @Override
+    public void stopRealTimeStream()
+    {
+        if(!mStreamActive.get()) return;
+
+        mStreamActive.set(false);
+        processAudioQueue();
+        if(mResampleBufferPos > 0) flushResampleBuffer();
+
+        if(mEncoderFuture != null) { mEncoderFuture.cancel(false); mEncoderFuture = null; }
+
+        long streamId = mCurrentStreamId.get();
+        if(streamId > 0)
+        {
+            sendStopStream(streamId);
+            mStreamedCount++;
+            broadcast(new BroadcastEvent(this, BroadcastEvent.Event.BROADCASTER_STREAMED_COUNT_CHANGE));
+        }
+
+        mCurrentStreamId.set(-1);
+        mAudioQueue.clear();
+        mLog.debug("Real-time Zello stream stopped");
+    }
+
+    // ========================================================================
+    // Audio Processing
+    // ========================================================================
+
+    private void processAudioQueue()
+    {
+        try
+        {
+            float[] buffer;
+            while((buffer = mAudioQueue.poll()) != null)
+            {
+                processAudioBuffer(buffer);
+            }
+        }
+        catch(Exception e)
+        {
+            mLog.error("Error processing audio queue", e);
+        }
+    }
+
+    /** Convert float 8kHz -> short 16kHz (2x upsample), accumulate, encode when frame full */
+    private void processAudioBuffer(float[] audio8k)
+    {
+        for(int i = 0; i < audio8k.length; i++)
+        {
+            short sample = (short)(audio8k[i] * 32767.0f);
+
+            // 2x upsample: duplicate each sample
+            mResampleBuffer[mResampleBufferPos++] = sample;
+            if(mResampleBufferPos >= ZELLO_FRAME_SIZE_SAMPLES)
+            {
+                encodeAndSendFrame();
+                mResampleBufferPos = 0;
+            }
+
+            mResampleBuffer[mResampleBufferPos++] = sample;
+            if(mResampleBufferPos >= ZELLO_FRAME_SIZE_SAMPLES)
+            {
+                encodeAndSendFrame();
+                mResampleBufferPos = 0;
+            }
+        }
+    }
+
+    private void encodeAndSendFrame()
+    {
+        long streamId = mCurrentStreamId.get();
+        if(streamId <= 0) return;
+
+        try
+        {
+            int encoded = mOpusEncoder.encode(mResampleBuffer, 0, ZELLO_FRAME_SIZE_SAMPLES,
+                mOpusOutputBuffer, 0, mOpusOutputBuffer.length);
+
+            if(encoded > 0)
+            {
+                byte[] opusFrame = new byte[encoded];
+                System.arraycopy(mOpusOutputBuffer, 0, opusFrame, 0, encoded);
+                sendAudioPacket(streamId, opusFrame);
+            }
+        }
+        catch(Exception e)
+        {
+            mLog.error("Opus encoding error", e);
+        }
+    }
+
+    private void flushResampleBuffer()
+    {
+        for(int i = mResampleBufferPos; i < ZELLO_FRAME_SIZE_SAMPLES; i++)
+            mResampleBuffer[i] = 0;
+        encodeAndSendFrame();
+        mResampleBufferPos = 0;
+    }
+
+    private void initOpusEncoder() throws Exception
+    {
+        mOpusEncoder = new OpusEncoder(ZELLO_SAMPLE_RATE, ZELLO_CHANNELS, OpusApplication.OPUS_APPLICATION_VOIP);
+        mOpusEncoder.setBitrate(OPUS_BITRATE);
+        mOpusEncoder.setSignalType(OpusSignal.OPUS_SIGNAL_VOICE);
+        mOpusEncoder.setComplexity(5);
+        mLog.info("Opus encoder initialized: {}Hz, {}ch, {}kbps, {}ms frames",
+            ZELLO_SAMPLE_RATE, ZELLO_CHANNELS, OPUS_BITRATE / 1000, ZELLO_FRAME_SIZE_MS);
+    }
+
+    // ========================================================================
+    // WebSocket
+    // ========================================================================
+
+    private void connectWebSocket()
+    {
+        String wsUrl = getBroadcastConfiguration().getWebSocketUrl();
+        if(wsUrl == null)
+        {
+            mLog.error("Zello WebSocket URL is null");
+            setBroadcastState(BroadcastState.CONFIGURATION_ERROR);
+            return;
+        }
+
+        mLog.info("Connecting to Zello Work: {}", wsUrl);
+        try
+        {
+            mHttpClient.newWebSocketBuilder()
+                .buildAsync(URI.create(wsUrl), new ZelloWebSocketListener())
+                .thenAccept(ws -> { mWebSocket = ws; mLog.info("WebSocket connected"); sendLogon(); })
+                .exceptionally(ex -> {
+                    mLog.error("WebSocket connection failed: {}", ex.getMessage());
+                    setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+                    scheduleReconnect();
+                    return null;
+                });
+        }
+        catch(Exception e)
+        {
+            mLog.error("Error creating WebSocket connection", e);
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+        }
+    }
+
+    private void disconnectWebSocket()
+    {
+        mConnected.set(false);
+        mChannelOnline.set(false);
+        if(mWebSocket != null)
+        {
+            try { mWebSocket.sendClose(WebSocket.NORMAL_CLOSURE, "Shutting down"); }
+            catch(Exception e) { /* ignore */ }
+            mWebSocket = null;
+        }
+    }
+
+    private void scheduleReconnect()
+    {
+        if(mReconnectFuture == null || mReconnectFuture.isDone())
+        {
+            mReconnectFuture = ThreadPool.SCHEDULED.schedule(() -> {
+                if(!mConnected.get()) { mLog.info("Zello reconnecting..."); connectWebSocket(); }
+            }, RECONNECT_INTERVAL_MS, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    // ========================================================================
+    // Zello Protocol
+    // ========================================================================
+
+    private void sendLogon()
+    {
+        ZelloConsumerConfiguration config = getBroadcastConfiguration();
+        JsonObject logon = new JsonObject();
+        logon.addProperty("command", "logon");
+        logon.addProperty("seq", mSequence.getAndIncrement());
+        com.google.gson.JsonArray channels = new com.google.gson.JsonArray();
+        channels.add(config.getChannel());
+        logon.add("channels", channels);
+        logon.addProperty("username", config.getUsername());
+        logon.addProperty("password", config.getPassword());
+        String authToken = config.getAuthToken();
+        if(authToken != null && !authToken.isEmpty()) logon.addProperty("auth_token", authToken);
+        logon.addProperty("listen_only", false);
+        mWebSocket.sendText(mGson.toJson(logon), true);
+    }
+
+    private void sendStartStream()
+    {
+        JsonObject cmd = new JsonObject();
+        cmd.addProperty("command", "start_stream");
+        cmd.addProperty("seq", mSequence.getAndIncrement());
+        cmd.addProperty("type", "audio");
+        cmd.addProperty("codec", "opus");
+        cmd.addProperty("codec_header", CODEC_HEADER_B64);
+        cmd.addProperty("packet_duration", ZELLO_FRAME_SIZE_MS);
+        mWebSocket.sendText(mGson.toJson(cmd), true);
+    }
+
+    private void sendStopStream(long streamId)
+    {
+        JsonObject cmd = new JsonObject();
+        cmd.addProperty("command", "stop_stream");
+        cmd.addProperty("seq", mSequence.getAndIncrement());
+        cmd.addProperty("stream_id", streamId);
+        mWebSocket.sendText(mGson.toJson(cmd), true);
+    }
+
+    private void sendAudioPacket(long streamId, byte[] opusData)
+    {
+        if(mWebSocket == null) return;
+        ByteBuffer packet = ByteBuffer.allocate(1 + 4 + 4 + opusData.length);
+        packet.order(ByteOrder.BIG_ENDIAN);
+        packet.put((byte)0x01);
+        packet.putInt((int)streamId);
+        packet.putInt(0);
+        packet.put(opusData);
+        packet.flip();
+        mWebSocket.sendBinary(packet, true);
+    }
+
+    // ========================================================================
+    // WebSocket Listener
+    // ========================================================================
+
+    private class ZelloWebSocketListener implements WebSocket.Listener
+    {
+        private StringBuilder mTextBuffer = new StringBuilder();
+
+        @Override public void onOpen(WebSocket ws) { mLog.info("Zello WebSocket opened"); ws.request(1); }
+
+        @Override
+        public CompletionStage<?> onText(WebSocket ws, CharSequence data, boolean last)
+        {
+            mTextBuffer.append(data);
+            if(last) { handleTextMessage(mTextBuffer.toString()); mTextBuffer.setLength(0); }
+            ws.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onBinary(WebSocket ws, ByteBuffer data, boolean last)
+        {
+            ws.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onPing(WebSocket ws, ByteBuffer msg)
+        {
+            ws.sendPong(msg);
+            ws.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onClose(WebSocket ws, int code, String reason)
+        {
+            mLog.info("Zello WebSocket closed: {} {}", code, reason);
+            mConnected.set(false);
+            mChannelOnline.set(false);
+            if(mStreamActive.get()) { mStreamActive.set(false); mCurrentStreamId.set(-1); }
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket ws, Throwable error)
+        {
+            mLog.error("Zello WebSocket error: {}", error.getMessage());
+            mConnected.set(false);
+            mChannelOnline.set(false);
+            setBroadcastState(BroadcastState.TEMPORARY_BROADCAST_ERROR);
+            scheduleReconnect();
+        }
+
+        private void handleTextMessage(String message)
+        {
+            try
+            {
+                JsonObject json = JsonParser.parseString(message).getAsJsonObject();
+
+                if(json.has("refresh_token") ||
+                    (json.has("success") && json.get("success").getAsBoolean() && !json.has("stream_id")))
+                {
+                    mLog.info("Zello logon successful");
+                    mConnected.set(true);
+                }
+                else if(json.has("error") && !json.has("command"))
+                {
+                    mLog.error("Zello logon failed: {}", message);
+                    setBroadcastState(BroadcastState.CONFIGURATION_ERROR);
+                    return;
+                }
+
+                if(json.has("command"))
+                {
+                    String command = json.get("command").getAsString();
+                    if("on_channel_status".equals(command))
+                    {
+                        String status = json.has("status") ? json.get("status").getAsString() : "";
+                        if("online".equals(status))
+                        {
+                            mChannelOnline.set(true);
+                            setBroadcastState(BroadcastState.CONNECTED);
+                            mLog.info("Zello channel online: {}",
+                                json.has("channel") ? json.get("channel").getAsString() : "");
+                        }
+                        else
+                        {
+                            mChannelOnline.set(false);
+                        }
+                    }
+                    else if("on_error".equals(command))
+                    {
+                        mLog.error("Zello error: {}", message);
+                    }
+                }
+
+                if(json.has("stream_id") && json.has("success"))
+                {
+                    if(json.get("success").getAsBoolean())
+                    {
+                        long streamId = json.get("stream_id").getAsLong();
+                        mCurrentStreamId.set(streamId);
+                        mLog.debug("Zello stream_id={}", streamId);
+                    }
+                    else
+                    {
+                        mLog.error("Zello start_stream failed: {}", message);
+                        mCurrentStreamId.set(-2);
+                        mStreamActive.set(false);
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                mLog.error("Error parsing Zello message: {}", message, e);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConsumerConfiguration.java
+++ b/src/main/java/io/github/dsheirer/audio/broadcast/zello/ZelloConsumerConfiguration.java
@@ -1,0 +1,178 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.audio.broadcast.zello;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import io.github.dsheirer.audio.broadcast.BroadcastConfiguration;
+import io.github.dsheirer.audio.broadcast.BroadcastFormat;
+import io.github.dsheirer.audio.broadcast.BroadcastServerType;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+/**
+ * Broadcast configuration for Zello Consumer (Friends & Family) channel streaming.
+ *
+ * Zello Consumer uses a fixed WebSocket endpoint (wss://zello.io/ws) and requires
+ * a JWT authentication token obtained from the Zello developer portal.
+ *
+ * Configuration fields:
+ * - Channel: The Zello channel name to stream to
+ * - Username: Zello account username
+ * - Password: Zello account password
+ * - Auth Token: JWT authentication token (required for Zello Consumer)
+ */
+public class ZelloConsumerConfiguration extends BroadcastConfiguration
+{
+    private static final String CONSUMER_WS_URL = "wss://zello.io/ws";
+
+    private StringProperty mChannel = new SimpleStringProperty();
+    private StringProperty mUsername = new SimpleStringProperty();
+    private StringProperty mAuthToken = new SimpleStringProperty();
+
+    /**
+     * Default constructor for Jackson XML deserialization
+     */
+    public ZelloConsumerConfiguration()
+    {
+        this(BroadcastFormat.MP3);
+    }
+
+    /**
+     * Public constructor
+     * @param format audio format (MP3 — audio will be re-encoded to Opus for Zello)
+     */
+    public ZelloConsumerConfiguration(BroadcastFormat format)
+    {
+        super(format);
+
+        mValid.unbind();
+        mValid.bind(Bindings.and(
+            Bindings.and(
+                Bindings.isNotEmpty(mChannel),
+                Bindings.isNotEmpty(mAuthToken)
+            ),
+            Bindings.and(
+                Bindings.isNotEmpty(mUsername),
+                Bindings.isNotNull(mPassword)
+            )
+        ));
+    }
+
+    // ========================================================================
+    // Channel Name
+    // ========================================================================
+
+    public StringProperty channelProperty()
+    {
+        return mChannel;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "channel")
+    public String getChannel()
+    {
+        return mChannel.get();
+    }
+
+    public void setChannel(String channel)
+    {
+        mChannel.set(channel);
+    }
+
+    // ========================================================================
+    // Username
+    // ========================================================================
+
+    public StringProperty usernameProperty()
+    {
+        return mUsername;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "username")
+    public String getUsername()
+    {
+        return mUsername.get();
+    }
+
+    public void setUsername(String username)
+    {
+        mUsername.set(username);
+    }
+
+    // ========================================================================
+    // Auth Token (JWT — required for Zello Consumer)
+    // ========================================================================
+
+    public StringProperty authTokenProperty()
+    {
+        return mAuthToken;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "auth_token")
+    public String getAuthToken()
+    {
+        return mAuthToken.get();
+    }
+
+    public void setAuthToken(String authToken)
+    {
+        mAuthToken.set(authToken);
+    }
+
+    // ========================================================================
+    // Network Name — not used for Consumer, but needed for broadcaster compat
+    // ========================================================================
+
+    public String getNetworkName()
+    {
+        return null;
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    /**
+     * Returns the fixed WebSocket URL for Zello Consumer.
+     */
+    public String getWebSocketUrl()
+    {
+        return CONSUMER_WS_URL;
+    }
+
+    @JacksonXmlProperty(isAttribute = true, localName = "type",
+        namespace = "http://www.w3.org/2001/XMLSchema-instance")
+    @Override
+    public BroadcastServerType getBroadcastServerType()
+    {
+        return BroadcastServerType.ZELLO;
+    }
+
+    @Override
+    public BroadcastConfiguration copyOf()
+    {
+        ZelloConsumerConfiguration copy = new ZelloConsumerConfiguration();
+        copy.setChannel(getChannel());
+        copy.setUsername(getUsername());
+        copy.setPassword(getPassword());
+        copy.setAuthToken(getAuthToken());
+        return copy;
+    }
+}

--- a/src/main/java/io/github/dsheirer/gui/playlist/streaming/StreamEditorFactory.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/streaming/StreamEditorFactory.java
@@ -52,6 +52,10 @@ public class StreamEditorFactory
                 return new ShoutcastV1StreamEditor(playlistManager);
             case SHOUTCAST_V2:
                 return new ShoutcastV2StreamEditor(playlistManager);
+            case ZELLO_WORK:
+                return new ZelloEditor(playlistManager);
+            case ZELLO:
+                return new ZelloConsumerEditor(playlistManager);
             default:
                 return new UnknownStreamEditor(playlistManager);
         }

--- a/src/main/java/io/github/dsheirer/gui/playlist/streaming/ZelloConsumerEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/streaming/ZelloConsumerEditor.java
@@ -1,0 +1,266 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.playlist.streaming;
+
+import io.github.dsheirer.audio.broadcast.BroadcastServerType;
+import io.github.dsheirer.audio.broadcast.zello.ZelloConsumerConfiguration;
+import io.github.dsheirer.gui.control.IntegerTextField;
+import io.github.dsheirer.playlist.PlaylistManager;
+import javafx.geometry.HPos;
+import javafx.geometry.Insets;
+import javafx.scene.control.Label;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Zello Consumer (Friends & Family) channel streaming configuration editor.
+ *
+ * Fields:
+ * - Name: Display name for this stream configuration
+ * - Channel: Zello channel name to stream audio to
+ * - Username: Zello account username
+ * - Password: Zello account password
+ * - Auth Token: JWT token (required for Zello Consumer)
+ * - Max Recording Age: Maximum age of audio recording before it is discarded
+ */
+public class ZelloConsumerEditor extends AbstractBroadcastEditor<ZelloConsumerConfiguration>
+{
+    private static final Logger mLog = LoggerFactory.getLogger(ZelloConsumerEditor.class);
+
+    private TextField mChannelTextField;
+    private TextField mUsernameTextField;
+    private PasswordField mPasswordField;
+    private TextField mAuthTokenTextField;
+    private IntegerTextField mMaxAgeTextField;
+    private GridPane mEditorPane;
+
+    /**
+     * Constructs an instance
+     * @param playlistManager for accessing the broadcast model
+     */
+    public ZelloConsumerEditor(PlaylistManager playlistManager)
+    {
+        super(playlistManager);
+    }
+
+    @Override
+    public void setItem(ZelloConsumerConfiguration item)
+    {
+        super.setItem(item);
+
+        getChannelTextField().setDisable(item == null);
+        getUsernameTextField().setDisable(item == null);
+        getPasswordField().setDisable(item == null);
+        getAuthTokenTextField().setDisable(item == null);
+        getMaxAgeTextField().setDisable(item == null);
+
+        if(item != null)
+        {
+            getChannelTextField().setText(item.getChannel());
+            getUsernameTextField().setText(item.getUsername());
+            getPasswordField().setText(item.getPassword());
+            getAuthTokenTextField().setText(item.getAuthToken());
+            getMaxAgeTextField().set((int)(item.getMaximumRecordingAge() / 1000));
+        }
+        else
+        {
+            getChannelTextField().setText(null);
+            getUsernameTextField().setText(null);
+            getPasswordField().setText(null);
+            getAuthTokenTextField().setText(null);
+            getMaxAgeTextField().set(0);
+        }
+
+        modifiedProperty().set(false);
+    }
+
+    @Override
+    public void dispose()
+    {
+    }
+
+    @Override
+    public void save()
+    {
+        if(getItem() != null)
+        {
+            getItem().setChannel(getChannelTextField().getText());
+            getItem().setUsername(getUsernameTextField().getText());
+            getItem().setPassword(getPasswordField().getText());
+            getItem().setAuthToken(getAuthTokenTextField().getText());
+            getItem().setMaximumRecordingAge(getMaxAgeTextField().get() * 1000);
+        }
+
+        super.save();
+    }
+
+    @Override
+    public BroadcastServerType getBroadcastServerType()
+    {
+        return BroadcastServerType.ZELLO;
+    }
+
+    @Override
+    protected GridPane getEditorPane()
+    {
+        if(mEditorPane == null)
+        {
+            mEditorPane = new GridPane();
+            mEditorPane.setPadding(new Insets(10, 5, 10, 10));
+            mEditorPane.setVgap(10);
+            mEditorPane.setHgap(5);
+
+            int row = 0;
+
+            // Row 0: Format and Enabled
+            Label formatLabel = new Label("Format");
+            GridPane.setHalignment(formatLabel, HPos.RIGHT);
+            GridPane.setConstraints(formatLabel, 0, row);
+            mEditorPane.getChildren().add(formatLabel);
+
+            GridPane.setConstraints(getFormatField(), 1, row);
+            mEditorPane.getChildren().add(getFormatField());
+
+            Label enabledLabel = new Label("Enabled");
+            GridPane.setHalignment(enabledLabel, HPos.RIGHT);
+            GridPane.setConstraints(enabledLabel, 2, row);
+            mEditorPane.getChildren().add(enabledLabel);
+
+            GridPane.setConstraints(getEnabledSwitch(), 3, row);
+            mEditorPane.getChildren().add(getEnabledSwitch());
+
+            // Row 1: Name
+            Label nameLabel = new Label("Name");
+            GridPane.setHalignment(nameLabel, HPos.RIGHT);
+            GridPane.setConstraints(nameLabel, 0, ++row);
+            mEditorPane.getChildren().add(nameLabel);
+
+            GridPane.setConstraints(getNameTextField(), 1, row);
+            mEditorPane.getChildren().add(getNameTextField());
+
+            // Row 2: Channel
+            Label channelLabel = new Label("Channel");
+            GridPane.setHalignment(channelLabel, HPos.RIGHT);
+            GridPane.setConstraints(channelLabel, 0, ++row);
+            mEditorPane.getChildren().add(channelLabel);
+
+            GridPane.setConstraints(getChannelTextField(), 1, row);
+            mEditorPane.getChildren().add(getChannelTextField());
+
+            // Row 3: Username
+            Label usernameLabel = new Label("Username");
+            GridPane.setHalignment(usernameLabel, HPos.RIGHT);
+            GridPane.setConstraints(usernameLabel, 0, ++row);
+            mEditorPane.getChildren().add(usernameLabel);
+
+            GridPane.setConstraints(getUsernameTextField(), 1, row);
+            mEditorPane.getChildren().add(getUsernameTextField());
+
+            // Row 4: Password
+            Label passwordLabel = new Label("Password");
+            GridPane.setHalignment(passwordLabel, HPos.RIGHT);
+            GridPane.setConstraints(passwordLabel, 0, ++row);
+            mEditorPane.getChildren().add(passwordLabel);
+
+            GridPane.setConstraints(getPasswordField(), 1, row);
+            mEditorPane.getChildren().add(getPasswordField());
+
+            // Row 5: Auth Token (required)
+            Label tokenLabel = new Label("Auth Token (required)");
+            GridPane.setHalignment(tokenLabel, HPos.RIGHT);
+            GridPane.setConstraints(tokenLabel, 0, ++row);
+            mEditorPane.getChildren().add(tokenLabel);
+
+            GridPane.setConstraints(getAuthTokenTextField(), 1, row);
+            mEditorPane.getChildren().add(getAuthTokenTextField());
+
+            // Row 6: Max Recording Age
+            Label maxAgeLabel = new Label("Max Recording Age (seconds)");
+            GridPane.setHalignment(maxAgeLabel, HPos.RIGHT);
+            GridPane.setConstraints(maxAgeLabel, 0, ++row);
+            mEditorPane.getChildren().add(maxAgeLabel);
+
+            GridPane.setConstraints(getMaxAgeTextField(), 1, row);
+            mEditorPane.getChildren().add(getMaxAgeTextField());
+        }
+
+        return mEditorPane;
+    }
+
+    private TextField getChannelTextField()
+    {
+        if(mChannelTextField == null)
+        {
+            mChannelTextField = new TextField();
+            mChannelTextField.setDisable(true);
+            mChannelTextField.setPromptText("Zello channel name");
+            mChannelTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mChannelTextField;
+    }
+
+    private TextField getUsernameTextField()
+    {
+        if(mUsernameTextField == null)
+        {
+            mUsernameTextField = new TextField();
+            mUsernameTextField.setDisable(true);
+            mUsernameTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mUsernameTextField;
+    }
+
+    private PasswordField getPasswordField()
+    {
+        if(mPasswordField == null)
+        {
+            mPasswordField = new PasswordField();
+            mPasswordField.setDisable(true);
+            mPasswordField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mPasswordField;
+    }
+
+    private TextField getAuthTokenTextField()
+    {
+        if(mAuthTokenTextField == null)
+        {
+            mAuthTokenTextField = new TextField();
+            mAuthTokenTextField.setDisable(true);
+            mAuthTokenTextField.setPromptText("JWT authentication token");
+            mAuthTokenTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mAuthTokenTextField;
+    }
+
+    private IntegerTextField getMaxAgeTextField()
+    {
+        if(mMaxAgeTextField == null)
+        {
+            mMaxAgeTextField = new IntegerTextField();
+            mMaxAgeTextField.setDisable(true);
+            mMaxAgeTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mMaxAgeTextField;
+    }
+}

--- a/src/main/java/io/github/dsheirer/gui/playlist/streaming/ZelloEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/streaming/ZelloEditor.java
@@ -1,0 +1,298 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.gui.playlist.streaming;
+
+import io.github.dsheirer.audio.broadcast.BroadcastServerType;
+import io.github.dsheirer.audio.broadcast.zello.ZelloConfiguration;
+import io.github.dsheirer.gui.control.IntegerTextField;
+import io.github.dsheirer.playlist.PlaylistManager;
+import javafx.geometry.HPos;
+import javafx.geometry.Insets;
+import javafx.scene.control.Label;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Zello Work channel streaming configuration editor.
+ *
+ * Fields:
+ * - Name: Display name for this stream configuration
+ * - Network Name: Zello Work subdomain (e.g., "actionpage" for actionpage.zellowork.com)
+ * - Channel: Zello channel name to stream audio to
+ * - Username: Zello account username
+ * - Password: Zello account password
+ * - Auth Token: JWT token (optional for Zello Work)
+ * - Max Recording Age: Maximum age of audio recording before it is discarded
+ */
+public class ZelloEditor extends AbstractBroadcastEditor<ZelloConfiguration>
+{
+    private static final Logger mLog = LoggerFactory.getLogger(ZelloEditor.class);
+
+    private TextField mNetworkNameTextField;
+    private TextField mChannelTextField;
+    private TextField mUsernameTextField;
+    private PasswordField mPasswordField;
+    private TextField mAuthTokenTextField;
+    private IntegerTextField mMaxAgeTextField;
+    private GridPane mEditorPane;
+
+    /**
+     * Constructs an instance
+     * @param playlistManager for accessing the broadcast model
+     */
+    public ZelloEditor(PlaylistManager playlistManager)
+    {
+        super(playlistManager);
+    }
+
+    @Override
+    public void setItem(ZelloConfiguration item)
+    {
+        super.setItem(item);
+
+        getNetworkNameTextField().setDisable(item == null);
+        getChannelTextField().setDisable(item == null);
+        getUsernameTextField().setDisable(item == null);
+        getPasswordField().setDisable(item == null);
+        getAuthTokenTextField().setDisable(item == null);
+        getMaxAgeTextField().setDisable(item == null);
+
+        if(item != null)
+        {
+            getNetworkNameTextField().setText(item.getNetworkName());
+            getChannelTextField().setText(item.getChannel());
+            getUsernameTextField().setText(item.getUsername());
+            getPasswordField().setText(item.getPassword());
+            getAuthTokenTextField().setText(item.getAuthToken());
+            getMaxAgeTextField().set((int)(item.getMaximumRecordingAge() / 1000));
+        }
+        else
+        {
+            getNetworkNameTextField().setText(null);
+            getChannelTextField().setText(null);
+            getUsernameTextField().setText(null);
+            getPasswordField().setText(null);
+            getAuthTokenTextField().setText(null);
+            getMaxAgeTextField().set(0);
+        }
+
+        modifiedProperty().set(false);
+    }
+
+    @Override
+    public void dispose()
+    {
+    }
+
+    @Override
+    public void save()
+    {
+        if(getItem() != null)
+        {
+            getItem().setNetworkName(getNetworkNameTextField().getText());
+            getItem().setChannel(getChannelTextField().getText());
+            getItem().setUsername(getUsernameTextField().getText());
+            getItem().setPassword(getPasswordField().getText());
+            getItem().setAuthToken(getAuthTokenTextField().getText());
+            getItem().setMaximumRecordingAge(getMaxAgeTextField().get() * 1000);
+        }
+
+        super.save();
+    }
+
+    @Override
+    public BroadcastServerType getBroadcastServerType()
+    {
+        return BroadcastServerType.ZELLO_WORK;
+    }
+
+    @Override
+    protected GridPane getEditorPane()
+    {
+        if(mEditorPane == null)
+        {
+            mEditorPane = new GridPane();
+            mEditorPane.setPadding(new Insets(10, 5, 10, 10));
+            mEditorPane.setVgap(10);
+            mEditorPane.setHgap(5);
+
+            int row = 0;
+
+            // Row 0: Format and Enabled
+            Label formatLabel = new Label("Format");
+            GridPane.setHalignment(formatLabel, HPos.RIGHT);
+            GridPane.setConstraints(formatLabel, 0, row);
+            mEditorPane.getChildren().add(formatLabel);
+
+            GridPane.setConstraints(getFormatField(), 1, row);
+            mEditorPane.getChildren().add(getFormatField());
+
+            Label enabledLabel = new Label("Enabled");
+            GridPane.setHalignment(enabledLabel, HPos.RIGHT);
+            GridPane.setConstraints(enabledLabel, 2, row);
+            mEditorPane.getChildren().add(enabledLabel);
+
+            GridPane.setConstraints(getEnabledSwitch(), 3, row);
+            mEditorPane.getChildren().add(getEnabledSwitch());
+
+            // Row 1: Name (display name for this stream config)
+            Label nameLabel = new Label("Name");
+            GridPane.setHalignment(nameLabel, HPos.RIGHT);
+            GridPane.setConstraints(nameLabel, 0, ++row);
+            mEditorPane.getChildren().add(nameLabel);
+
+            GridPane.setConstraints(getNameTextField(), 1, row);
+            mEditorPane.getChildren().add(getNameTextField());
+
+            // Row 2: Network Name
+            Label networkLabel = new Label("Zello Work Network");
+            GridPane.setHalignment(networkLabel, HPos.RIGHT);
+            GridPane.setConstraints(networkLabel, 0, ++row);
+            mEditorPane.getChildren().add(networkLabel);
+
+            GridPane.setConstraints(getNetworkNameTextField(), 1, row);
+            mEditorPane.getChildren().add(getNetworkNameTextField());
+
+            Label networkHint = new Label(".zellowork.com");
+            GridPane.setHalignment(networkHint, HPos.LEFT);
+            GridPane.setConstraints(networkHint, 2, row);
+            mEditorPane.getChildren().add(networkHint);
+
+            // Row 3: Channel
+            Label channelLabel = new Label("Channel");
+            GridPane.setHalignment(channelLabel, HPos.RIGHT);
+            GridPane.setConstraints(channelLabel, 0, ++row);
+            mEditorPane.getChildren().add(channelLabel);
+
+            GridPane.setConstraints(getChannelTextField(), 1, row);
+            mEditorPane.getChildren().add(getChannelTextField());
+
+            // Row 4: Username
+            Label usernameLabel = new Label("Username");
+            GridPane.setHalignment(usernameLabel, HPos.RIGHT);
+            GridPane.setConstraints(usernameLabel, 0, ++row);
+            mEditorPane.getChildren().add(usernameLabel);
+
+            GridPane.setConstraints(getUsernameTextField(), 1, row);
+            mEditorPane.getChildren().add(getUsernameTextField());
+
+            // Row 5: Password
+            Label passwordLabel = new Label("Password");
+            GridPane.setHalignment(passwordLabel, HPos.RIGHT);
+            GridPane.setConstraints(passwordLabel, 0, ++row);
+            mEditorPane.getChildren().add(passwordLabel);
+
+            GridPane.setConstraints(getPasswordField(), 1, row);
+            mEditorPane.getChildren().add(getPasswordField());
+
+            // Row 6: Auth Token (optional)
+            Label tokenLabel = new Label("Auth Token (optional)");
+            GridPane.setHalignment(tokenLabel, HPos.RIGHT);
+            GridPane.setConstraints(tokenLabel, 0, ++row);
+            mEditorPane.getChildren().add(tokenLabel);
+
+            GridPane.setConstraints(getAuthTokenTextField(), 1, row);
+            mEditorPane.getChildren().add(getAuthTokenTextField());
+
+            // Row 7: Max Recording Age
+            Label maxAgeLabel = new Label("Max Recording Age (seconds)");
+            GridPane.setHalignment(maxAgeLabel, HPos.RIGHT);
+            GridPane.setConstraints(maxAgeLabel, 0, ++row);
+            mEditorPane.getChildren().add(maxAgeLabel);
+
+            GridPane.setConstraints(getMaxAgeTextField(), 1, row);
+            mEditorPane.getChildren().add(getMaxAgeTextField());
+        }
+
+        return mEditorPane;
+    }
+
+    private TextField getNetworkNameTextField()
+    {
+        if(mNetworkNameTextField == null)
+        {
+            mNetworkNameTextField = new TextField();
+            mNetworkNameTextField.setDisable(true);
+            mNetworkNameTextField.setPromptText("e.g., actionpage");
+            mNetworkNameTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mNetworkNameTextField;
+    }
+
+    private TextField getChannelTextField()
+    {
+        if(mChannelTextField == null)
+        {
+            mChannelTextField = new TextField();
+            mChannelTextField.setDisable(true);
+            mChannelTextField.setPromptText("Zello channel name");
+            mChannelTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mChannelTextField;
+    }
+
+    private TextField getUsernameTextField()
+    {
+        if(mUsernameTextField == null)
+        {
+            mUsernameTextField = new TextField();
+            mUsernameTextField.setDisable(true);
+            mUsernameTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mUsernameTextField;
+    }
+
+    private PasswordField getPasswordField()
+    {
+        if(mPasswordField == null)
+        {
+            mPasswordField = new PasswordField();
+            mPasswordField.setDisable(true);
+            mPasswordField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mPasswordField;
+    }
+
+    private TextField getAuthTokenTextField()
+    {
+        if(mAuthTokenTextField == null)
+        {
+            mAuthTokenTextField = new TextField();
+            mAuthTokenTextField.setDisable(true);
+            mAuthTokenTextField.setPromptText("JWT token (optional for Zello Work)");
+            mAuthTokenTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mAuthTokenTextField;
+    }
+
+    private IntegerTextField getMaxAgeTextField()
+    {
+        if(mMaxAgeTextField == null)
+        {
+            mMaxAgeTextField = new IntegerTextField();
+            mMaxAgeTextField.setDisable(true);
+            mMaxAgeTextField.textProperty().addListener(mEditorModificationListener);
+        }
+        return mMaxAgeTextField;
+    }
+}


### PR DESCRIPTION
- Real-time audio streaming via WebSocket with Opus encoding
- Zello Work: authenticated channel streaming (tested and working)
- Zello Consumer: consumer app streaming support
- IRealTimeAudioBroadcaster interface for incremental audio
- Linear interpolation resampler (8kHz to 16kHz for Opus)
- Opus encoding via Concentus library (28kbps, complexity 8)
- Full GUI editors for both Zello Work and Consumer configs
- BroadcastServerType: ZELLO_WORK and ZELLO enum values

NOTE: Requires adding to build.gradle dependencies:
  implementation 'io.github.jaredmdobson:concentus:1.0.2'