### PR TITLE
Add NBFM channel-level CTCSS/DCS tone filtering

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/squelch/SquelchTailRemover.java
+++ b/src/main/java/io/github/dsheirer/dsp/squelch/SquelchTailRemover.java
@@ -1,0 +1,237 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.dsp.squelch;
+
+import io.github.dsheirer.sample.Listener;
+import java.util.ArrayDeque;
+
+/**
+ * Removes squelch tail (noise burst at end of transmission) and optionally squelch head
+ * (noise/tone ramp at start of transmission) from audio streams.
+ *
+ * Works by buffering audio with a configurable delay. When squelch closes (end of
+ * transmission), the trailing buffered audio is discarded instead of being output.
+ * When squelch opens (start of transmission), the first N milliseconds can be
+ * discarded to remove CTCSS tone ramp-up noise.
+ *
+ * Thread safety: this class is NOT thread-safe. All calls should be from the same
+ * processing thread.
+ */
+public class SquelchTailRemover
+{
+    public static final int DEFAULT_TAIL_REMOVAL_MS = 100;
+    public static final int DEFAULT_HEAD_REMOVAL_MS = 0;
+    public static final int MINIMUM_REMOVAL_MS = 0;
+    public static final int MAXIMUM_TAIL_REMOVAL_MS = 300;
+    public static final int MAXIMUM_HEAD_REMOVAL_MS = 150;
+    private static final int AUDIO_SAMPLE_RATE = 8000;
+
+    private final ArrayDeque<float[]> mDelayBuffer = new ArrayDeque<>();
+    private Listener<float[]> mOutputListener;
+    private int mTailRemovalSamples;
+    private int mHeadRemovalSamples;
+    private int mBufferedSampleCount = 0;
+    private int mHeadSamplesRemaining = 0;
+    private boolean mSquelchOpen = false;
+    private boolean mFirstBufferAfterOpen = true;
+
+    /**
+     * Constructs an instance
+     * @param tailRemovalMs milliseconds of audio to discard at end of transmission (0-300)
+     * @param headRemovalMs milliseconds of audio to discard at start of transmission (0-150)
+     */
+    public SquelchTailRemover(int tailRemovalMs, int headRemovalMs)
+    {
+        setTailRemovalMs(tailRemovalMs);
+        setHeadRemovalMs(headRemovalMs);
+    }
+
+    /**
+     * Constructs with default values
+     */
+    public SquelchTailRemover()
+    {
+        this(DEFAULT_TAIL_REMOVAL_MS, DEFAULT_HEAD_REMOVAL_MS);
+    }
+
+    /**
+     * Sets the tail removal duration
+     * @param tailMs milliseconds to remove from end of transmission
+     */
+    public void setTailRemovalMs(int tailMs)
+    {
+        tailMs = Math.max(MINIMUM_REMOVAL_MS, Math.min(MAXIMUM_TAIL_REMOVAL_MS, tailMs));
+        mTailRemovalSamples = (int)(AUDIO_SAMPLE_RATE * tailMs / 1000.0);
+    }
+
+    /**
+     * Sets the head removal duration
+     * @param headMs milliseconds to remove from start of transmission
+     */
+    public void setHeadRemovalMs(int headMs)
+    {
+        headMs = Math.max(MINIMUM_REMOVAL_MS, Math.min(MAXIMUM_HEAD_REMOVAL_MS, headMs));
+        mHeadRemovalSamples = (int)(AUDIO_SAMPLE_RATE * headMs / 1000.0);
+    }
+
+    /**
+     * Sets the output listener for processed audio
+     */
+    public void setOutputListener(Listener<float[]> listener)
+    {
+        mOutputListener = listener;
+    }
+
+    /**
+     * Called when squelch opens (start of transmission).
+     * Begins head removal countdown.
+     */
+    public void squelchOpen()
+    {
+        mSquelchOpen = true;
+        mFirstBufferAfterOpen = true;
+        mHeadSamplesRemaining = mHeadRemovalSamples;
+        mDelayBuffer.clear();
+        mBufferedSampleCount = 0;
+    }
+
+    /**
+     * Called when squelch closes (end of transmission).
+     * Discards the tail buffer contents instead of outputting them.
+     */
+    public void squelchClose()
+    {
+        mSquelchOpen = false;
+        // Discard everything in the delay buffer — this IS the squelch tail
+        mDelayBuffer.clear();
+        mBufferedSampleCount = 0;
+    }
+
+    /**
+     * Processes an audio buffer. If tail removal is configured, buffers audio and
+     * outputs delayed audio. If squelch closes, buffered audio is discarded.
+     *
+     * @param audio buffer to process
+     */
+    public void process(float[] audio)
+    {
+        if(audio == null || audio.length == 0 || mOutputListener == null)
+        {
+            return;
+        }
+
+        // Handle head removal: skip initial samples after squelch open
+        if(mHeadSamplesRemaining > 0)
+        {
+            if(audio.length <= mHeadSamplesRemaining)
+            {
+                mHeadSamplesRemaining -= audio.length;
+                return; // Discard entire buffer
+            }
+            else
+            {
+                // Partial discard — trim the beginning
+                int keep = audio.length - mHeadSamplesRemaining;
+                float[] trimmed = new float[keep];
+                System.arraycopy(audio, mHeadSamplesRemaining, trimmed, 0, keep);
+                audio = trimmed;
+                mHeadSamplesRemaining = 0;
+            }
+        }
+
+        // If no tail removal configured, pass through directly
+        if(mTailRemovalSamples <= 0)
+        {
+            mOutputListener.receive(audio);
+            return;
+        }
+
+        // Buffer this audio
+        mDelayBuffer.addLast(audio);
+        mBufferedSampleCount += audio.length;
+
+        // Output audio that has aged past the tail removal window
+        while(mBufferedSampleCount > mTailRemovalSamples && !mDelayBuffer.isEmpty())
+        {
+            float[] oldest = mDelayBuffer.peekFirst();
+
+            if(oldest == null)
+            {
+                break;
+            }
+
+            if(mBufferedSampleCount - oldest.length >= mTailRemovalSamples)
+            {
+                // This buffer has aged out — safe to output
+                mDelayBuffer.pollFirst();
+                mBufferedSampleCount -= oldest.length;
+                mOutputListener.receive(oldest);
+            }
+            else
+            {
+                // Need to split this buffer
+                int samplesToOutput = mBufferedSampleCount - mTailRemovalSamples;
+
+                if(samplesToOutput > 0 && samplesToOutput < oldest.length)
+                {
+                    float[] output = new float[samplesToOutput];
+                    float[] keep = new float[oldest.length - samplesToOutput];
+                    System.arraycopy(oldest, 0, output, 0, samplesToOutput);
+                    System.arraycopy(oldest, samplesToOutput, keep, 0, keep.length);
+
+                    mDelayBuffer.pollFirst();
+                    mDelayBuffer.addFirst(keep);
+                    mBufferedSampleCount -= samplesToOutput;
+                    mOutputListener.receive(output);
+                }
+                break;
+            }
+        }
+    }
+
+    /**
+     * Flushes any remaining buffered audio. Call this when you want to force output
+     * of all buffered audio (e.g., at stream end with known good signal).
+     */
+    public void flush()
+    {
+        while(!mDelayBuffer.isEmpty())
+        {
+            float[] buffer = mDelayBuffer.pollFirst();
+            if(mOutputListener != null && buffer != null)
+            {
+                mOutputListener.receive(buffer);
+            }
+        }
+        mBufferedSampleCount = 0;
+    }
+
+    /**
+     * Resets all state
+     */
+    public void reset()
+    {
+        mDelayBuffer.clear();
+        mBufferedSampleCount = 0;
+        mHeadSamplesRemaining = 0;
+        mSquelchOpen = false;
+        mFirstBufferAfterOpen = true;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
@@ -435,8 +435,11 @@ public class DecoderFactory
         }
 
         DecodeConfigNBFM decodeConfigNBFM = (DecodeConfigNBFM)decodeConfig;
-        modules.add(new NBFMDecoder(decodeConfigNBFM));
-        modules.add(new NBFMDecoderState(channel.getName(), decodeConfigNBFM));
+        NBFMDecoderState decoderState = new NBFMDecoderState(channel.getName(), decodeConfigNBFM);
+        NBFMDecoder decoder = new NBFMDecoder(decodeConfigNBFM);
+        decoder.setDecoderState(decoderState);
+        modules.add(decoder);
+        modules.add(decoderState);
         modules.add(new AudioModule(aliasList, 0, 60000, decodeConfigNBFM.isAudioFilter()));
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/config/ChannelToneFilter.java
+++ b/src/main/java/io/github/dsheirer/module/decode/config/ChannelToneFilter.java
@@ -1,0 +1,271 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import io.github.dsheirer.module.decode.ctcss.CTCSSCode;
+import io.github.dsheirer.module.decode.dcs.DCSCode;
+
+/**
+ * Channel-level tone/code filter configuration. Supports CTCSS, DCS, and P25 NAC filtering.
+ * Multiple filters can be configured per channel. Audio is only passed when at least one
+ * configured filter matches the received signal.
+ */
+public class ChannelToneFilter
+{
+    /**
+     * Types of tone/code squelch supported
+     */
+    public enum ToneType
+    {
+        CTCSS("CTCSS"),
+        DCS("DCS"),
+        NAC("NAC");
+
+        private final String mLabel;
+
+        ToneType(String label)
+        {
+            mLabel = label;
+        }
+
+        @Override
+        public String toString()
+        {
+            return mLabel;
+        }
+    }
+
+    private ToneType mToneType = ToneType.CTCSS;
+    private String mValue = "";
+    private String mLabel = "";
+
+    /**
+     * Default constructor for Jackson XML deserialization
+     */
+    public ChannelToneFilter()
+    {
+    }
+
+    /**
+     * Constructs an instance
+     * @param toneType of this filter (CTCSS, DCS, or NAC)
+     * @param value the tone/code value as a string
+     * @param label user-friendly label for this filter (e.g., "Chelsea PD")
+     */
+    public ChannelToneFilter(ToneType toneType, String value, String label)
+    {
+        mToneType = toneType;
+        mValue = value;
+        mLabel = label;
+    }
+
+    /**
+     * Tone type (CTCSS, DCS, or NAC)
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "toneType")
+    public ToneType getToneType()
+    {
+        return mToneType;
+    }
+
+    public void setToneType(ToneType toneType)
+    {
+        mToneType = toneType;
+    }
+
+    /**
+     * Value for the tone/code filter.
+     * For CTCSS: the CTCSSCode enum name (e.g. "TONE_1B" for 107.2 Hz)
+     * For DCS: the DCSCode enum name (e.g. "D023N")
+     * For NAC: integer value as string (e.g. "512")
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "value")
+    public String getValue()
+    {
+        return mValue;
+    }
+
+    public void setValue(String value)
+    {
+        mValue = value;
+    }
+
+    /**
+     * User-friendly label (e.g., "Chelsea PD", "Medford FD")
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "label")
+    public String getLabel()
+    {
+        return mLabel;
+    }
+
+    public void setLabel(String label)
+    {
+        mLabel = label;
+    }
+
+    /**
+     * Returns the CTCSS code for this filter, or null if not a CTCSS filter or value is invalid.
+     */
+    @JsonIgnore
+    public CTCSSCode getCTCSSCode()
+    {
+        if(mToneType == ToneType.CTCSS && mValue != null && !mValue.isEmpty())
+        {
+            try
+            {
+                return CTCSSCode.valueOf(mValue);
+            }
+            catch(IllegalArgumentException e)
+            {
+                // Try to parse as frequency
+                try
+                {
+                    float freq = Float.parseFloat(mValue);
+                    return CTCSSCode.fromFrequency(freq);
+                }
+                catch(NumberFormatException nfe)
+                {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the DCS code for this filter, or null if not a DCS filter or value is invalid.
+     */
+    @JsonIgnore
+    public DCSCode getDCSCode()
+    {
+        if(mToneType == ToneType.DCS && mValue != null && !mValue.isEmpty())
+        {
+            try
+            {
+                return DCSCode.valueOf(mValue);
+            }
+            catch(IllegalArgumentException e)
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the NAC value for this filter, or -1 if not a NAC filter or value is invalid.
+     */
+    @JsonIgnore
+    public int getNacValue()
+    {
+        if(mToneType == ToneType.NAC && mValue != null && !mValue.isEmpty())
+        {
+            try
+            {
+                int nac = Integer.parseInt(mValue);
+                if(nac >= 0 && nac <= 4095)
+                {
+                    return nac;
+                }
+            }
+            catch(NumberFormatException e)
+            {
+                // Try hex
+                try
+                {
+                    String hex = mValue.startsWith("0x") ? mValue.substring(2) : mValue;
+                    int nac = Integer.parseInt(hex, 16);
+                    if(nac >= 0 && nac <= 4095)
+                    {
+                        return nac;
+                    }
+                }
+                catch(NumberFormatException nfe)
+                {
+                    // Invalid
+                }
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Indicates if this filter configuration is valid
+     */
+    @JsonIgnore
+    public boolean isValid()
+    {
+        return switch(mToneType)
+        {
+            case CTCSS -> getCTCSSCode() != null && getCTCSSCode() != CTCSSCode.UNKNOWN;
+            case DCS -> getDCSCode() != null;
+            case NAC -> getNacValue() >= 0;
+        };
+    }
+
+    /**
+     * Display string for this filter
+     */
+    @JsonIgnore
+    public String getDisplayString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(mToneType).append(": ");
+
+        switch(mToneType)
+        {
+            case CTCSS:
+                CTCSSCode ctcss = getCTCSSCode();
+                sb.append(ctcss != null ? ctcss.getDisplayString() : mValue);
+                break;
+            case DCS:
+                DCSCode dcs = getDCSCode();
+                sb.append(dcs != null ? dcs.toString() : mValue);
+                break;
+            case NAC:
+                int nac = getNacValue();
+                if(nac >= 0)
+                {
+                    sb.append(nac).append(" (x").append(String.format("%03X", nac)).append(")");
+                }
+                else
+                {
+                    sb.append(mValue);
+                }
+                break;
+        }
+
+        if(mLabel != null && !mLabel.isEmpty())
+        {
+            sb.append(" — ").append(mLabel);
+        }
+
+        return sb.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return getDisplayString();
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/ctcss/CTCSSCode.java
+++ b/src/main/java/io/github/dsheirer/module/decode/ctcss/CTCSSCode.java
@@ -1,0 +1,152 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.ctcss;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Standard CTCSS (Continuous Tone-Coded Squelch System) tones.
+ * Also known as PL (Private Line) tones (Motorola trademark).
+ *
+ * Frequencies and EIA/TIA standard designators from TIA-603.
+ */
+public enum CTCSSCode
+{
+    TONE_XZ(67.0f, "XZ", "67.0"),
+    TONE_WZ(69.3f, "WZ", "69.3"),
+    TONE_XA(71.9f, "XA", "71.9"),
+    TONE_WA(74.4f, "WA", "74.4"),
+    TONE_XB(77.0f, "XB", "77.0"),
+    TONE_WB(79.7f, "WB", "79.7"),
+    TONE_YZ(82.5f, "YZ", "82.5"),
+    TONE_YA(85.4f, "YA", "85.4"),
+    TONE_YB(88.5f, "YB", "88.5"),
+    TONE_ZZ(91.5f, "ZZ", "91.5"),
+    TONE_ZA(94.8f, "ZA", "94.8"),
+    TONE_ZB(97.4f, "ZB", "97.4"),
+    TONE_1Z(100.0f, "1Z", "100.0"),
+    TONE_1A(103.5f, "1A", "103.5"),
+    TONE_1B(107.2f, "1B", "107.2"),
+    TONE_2Z(110.9f, "2Z", "110.9"),
+    TONE_2A(114.8f, "2A", "114.8"),
+    TONE_2B(118.8f, "2B", "118.8"),
+    TONE_3Z(123.0f, "3Z", "123.0"),
+    TONE_3A(127.3f, "3A", "127.3"),
+    TONE_3B(131.8f, "3B", "131.8"),
+    TONE_4Z(136.5f, "4Z", "136.5"),
+    TONE_4A(141.3f, "4A", "141.3"),
+    TONE_4B(146.2f, "4B", "146.2"),
+    TONE_5Z(151.4f, "5Z", "151.4"),
+    TONE_5A(156.7f, "5A", "156.7"),
+    TONE_5B(162.2f, "5B", "162.2"),
+    TONE_6Z(167.9f, "6Z", "167.9"),
+    TONE_6A(173.8f, "6A", "173.8"),
+    TONE_6B(179.9f, "6B", "179.9"),
+    TONE_7Z(186.2f, "7Z", "186.2"),
+    TONE_7A(192.8f, "7A", "192.8"),
+    TONE_M1(203.5f, "M1", "203.5"),
+    TONE_M2(206.5f, "M2", "206.5"),
+    TONE_M3(210.7f, "M3", "210.7"),
+    TONE_M4(218.1f, "M4", "218.1"),
+    TONE_M5(225.7f, "M5", "225.7"),
+    TONE_M6(229.1f, "M6", "229.1"),
+    TONE_M7(233.6f, "M7", "233.6"),
+    TONE_8Z(241.8f, "8Z", "241.8"),
+    TONE_9Z(250.3f, "9Z", "250.3"),
+    TONE_0Z(254.1f, "0Z", "254.1"),
+    UNKNOWN(0.0f, "??", "Unknown");
+
+    /**
+     * Set of all standard (non-UNKNOWN) CTCSS codes
+     */
+    public static final Set<CTCSSCode> STANDARD_CODES;
+
+    static
+    {
+        EnumSet<CTCSSCode> codes = EnumSet.allOf(CTCSSCode.class);
+        codes.remove(UNKNOWN);
+        STANDARD_CODES = java.util.Collections.unmodifiableSet(codes);
+    }
+
+    private final float mFrequency;
+    private final String mDesignator;
+    private final String mFrequencyLabel;
+
+    CTCSSCode(float frequency, String designator, String frequencyLabel)
+    {
+        mFrequency = frequency;
+        mDesignator = designator;
+        mFrequencyLabel = frequencyLabel;
+    }
+
+    /**
+     * Tone frequency in Hz
+     */
+    public float getFrequency()
+    {
+        return mFrequency;
+    }
+
+    /**
+     * EIA/TIA standard designator (e.g. "XZ", "1A", "M7")
+     */
+    public String getDesignator()
+    {
+        return mDesignator;
+    }
+
+    /**
+     * Display string showing frequency and designator
+     */
+    public String getDisplayString()
+    {
+        return mFrequencyLabel + " Hz (" + mDesignator + ")";
+    }
+
+    @Override
+    public String toString()
+    {
+        return mFrequencyLabel + " Hz";
+    }
+
+    /**
+     * Finds the CTCSSCode closest to the given frequency within ±1 Hz tolerance.
+     * @param frequency in Hz
+     * @return matching code or UNKNOWN if no match
+     */
+    public static CTCSSCode fromFrequency(float frequency)
+    {
+        CTCSSCode best = UNKNOWN;
+        float bestDelta = Float.MAX_VALUE;
+
+        for(CTCSSCode code : STANDARD_CODES)
+        {
+            float delta = Math.abs(code.mFrequency - frequency);
+            if(delta < bestDelta)
+            {
+                bestDelta = delta;
+                best = code;
+            }
+        }
+
+        return bestDelta <= 1.0f ? best : UNKNOWN;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/CTCSSDetector.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/CTCSSDetector.java
@@ -1,0 +1,386 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.nbfm;
+
+import io.github.dsheirer.module.decode.ctcss.CTCSSCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Real-time CTCSS tone detector using the Goertzel algorithm.
+ *
+ * Analyzes demodulated FM audio to detect sub-audible CTCSS tones (67.0 - 254.1 Hz).
+ * The Goertzel algorithm is an efficient way to compute the energy at specific frequencies
+ * without performing a full FFT.
+ *
+ * Processing approach:
+ * - Collects samples into blocks (sized for ~2 cycles of the lowest target tone)
+ * - Runs Goertzel on each target frequency
+ * - Compares detected energy against a noise floor estimate
+ * - Reports the strongest matching tone if it exceeds the threshold
+ */
+public class CTCSSDetector
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(CTCSSDetector.class);
+
+    /**
+     * Minimum SNR (signal-to-noise ratio in dB) for a tone to be considered detected.
+     * CTCSS tones are typically 10-15% of peak deviation, so they're relatively weak.
+     */
+    private static final float DETECTION_THRESHOLD_DB = 6.0f;
+
+    /**
+     * Number of consecutive detections required before reporting a match.
+     * Prevents false triggers from transient energy.
+     */
+    private static final int CONFIRMATION_COUNT = 3;
+
+    /**
+     * Number of consecutive misses before declaring tone lost.
+     */
+    private static final int LOSS_COUNT = 4;
+
+    private final Set<CTCSSCode> mTargetCodes;
+    private final float[] mTargetFrequencies;
+    private final CTCSSCode[] mTargetCodeArray;
+    private final float mSampleRate;
+    private final int mBlockSize;
+
+    // Goertzel coefficients for each target frequency
+    private final float[] mCoefficients;
+
+    // Sample accumulator
+    private float[] mSampleBuffer;
+    private int mSampleIndex = 0;
+
+    // Detection state
+    private CTCSSCode mDetectedCode = null;
+    private int mConfirmationCounter = 0;
+    private int mLossCounter = 0;
+
+    // Callback
+    private CTCSSDetectorListener mListener;
+
+    /**
+     * Listener interface for CTCSS detection events
+     */
+    public interface CTCSSDetectorListener
+    {
+        void ctcssDetected(CTCSSCode code);
+        void ctcssRejected(CTCSSCode code);
+        void ctcssLost();
+    }
+
+    /**
+     * Constructs a CTCSS detector for a specific set of target tones.
+     *
+     * @param targetCodes the set of CTCSS codes to accept as matches. If null or empty, accepts all standard codes.
+     * @param sampleRate the sample rate of the input audio in Hz
+     */
+    public CTCSSDetector(Set<CTCSSCode> targetCodes, float sampleRate)
+    {
+        mSampleRate = sampleRate;
+
+        if(targetCodes == null || targetCodes.isEmpty())
+        {
+            mTargetCodes = CTCSSCode.STANDARD_CODES;
+        }
+        else
+        {
+            mTargetCodes = targetCodes;
+        }
+
+        // Always scan ALL standard CTCSS tones to prevent spectral leakage false matches.
+        // We find the strongest tone across all frequencies, then check if it's in our allowed set.
+        Set<CTCSSCode> allCodes = CTCSSCode.STANDARD_CODES;
+        mTargetCodeArray = allCodes.toArray(new CTCSSCode[0]);
+        mTargetFrequencies = new float[mTargetCodeArray.length];
+        mCoefficients = new float[mTargetCodeArray.length];
+
+        for(int i = 0; i < mTargetCodeArray.length; i++)
+        {
+            mTargetFrequencies[i] = mTargetCodeArray[i].getFrequency();
+        }
+
+        // Block size: enough samples for ~2.5 cycles of the lowest frequency we care about
+        // Lowest CTCSS tone is 67.0 Hz. At 8000 Hz sample rate: 8000/67 * 2.5 ≈ 299 samples
+        // We use a power-of-nothing block — just enough for good frequency resolution
+        float lowestFreq = Float.MAX_VALUE;
+        for(float freq : mTargetFrequencies)
+        {
+            if(freq > 0 && freq < lowestFreq)
+            {
+                lowestFreq = freq;
+            }
+        }
+
+        // Block size targets sufficient frequency resolution to discriminate closely-spaced
+        // CTCSS tones (e.g. 131.8 Hz vs 146.2 Hz = 14.4 Hz apart). Frequency resolution is
+        // sampleRate / blockSize, so we need blockSize >= sampleRate / 14 for ~1 Hz margin.
+        // We use the larger of: 5 cycles of the lowest tone, or sampleRate / 12 (for ~12 Hz resolution).
+        int blockByCycles = (int)(mSampleRate / lowestFreq * 5.0f);
+        int blockByResolution = (int)(mSampleRate / 12.0f);
+        int blockSize = Math.max(blockByCycles, blockByResolution);
+
+        // Clamp to reasonable range
+        if(blockSize < 256)
+        {
+            blockSize = 256;
+        }
+        else if(blockSize > 4096)
+        {
+            blockSize = 4096;
+        }
+
+        mBlockSize = blockSize;
+
+        mSampleBuffer = new float[mBlockSize];
+
+        // Pre-compute Goertzel coefficients: 2 * cos(2π * freq / sampleRate)
+        for(int i = 0; i < mTargetFrequencies.length; i++)
+        {
+            double normalizedFreq = mTargetFrequencies[i] / mSampleRate;
+            mCoefficients[i] = (float)(2.0 * Math.cos(2.0 * Math.PI * normalizedFreq));
+        }
+
+        LOGGER.debug("CTCSSDetector initialized: {} target tones, block size {}, sample rate {}",
+                mTargetCodeArray.length, mBlockSize, mSampleRate);
+    }
+
+    /**
+     * Sets the listener for detection events.
+     */
+    public void setListener(CTCSSDetectorListener listener)
+    {
+        mListener = listener;
+    }
+
+    /**
+     * Processes a buffer of demodulated FM audio samples.
+     * Samples are accumulated into blocks, and Goertzel analysis is performed on each complete block.
+     *
+     * @param samples demodulated audio samples
+     */
+    public void process(float[] samples)
+    {
+        if(samples == null || samples.length == 0)
+        {
+            return;
+        }
+
+        int offset = 0;
+
+        while(offset < samples.length)
+        {
+            int remaining = mBlockSize - mSampleIndex;
+            int toCopy = Math.min(remaining, samples.length - offset);
+
+            System.arraycopy(samples, offset, mSampleBuffer, mSampleIndex, toCopy);
+            mSampleIndex += toCopy;
+            offset += toCopy;
+
+            if(mSampleIndex >= mBlockSize)
+            {
+                analyzeBlock();
+                mSampleIndex = 0;
+            }
+        }
+    }
+
+    /**
+     * Analyzes the current block of samples using Goertzel algorithm for each target frequency.
+     */
+    private void analyzeBlock()
+    {
+        // Compute total energy (noise floor estimate)
+        float totalEnergy = 0;
+        for(int i = 0; i < mBlockSize; i++)
+        {
+            totalEnergy += mSampleBuffer[i] * mSampleBuffer[i];
+        }
+        totalEnergy /= mBlockSize;
+
+        // Avoid division by zero
+        if(totalEnergy < 1e-10f)
+        {
+            handleNoDetection();
+            return;
+        }
+
+        // Run Goertzel for each target frequency and find the strongest
+        float maxPower = 0;
+        int maxIndex = -1;
+
+        for(int i = 0; i < mTargetFrequencies.length; i++)
+        {
+            float power = goertzel(mSampleBuffer, mBlockSize, mCoefficients[i]);
+
+            if(power > maxPower)
+            {
+                maxPower = power;
+                maxIndex = i;
+            }
+        }
+
+        // Normalize power relative to total energy
+        float normalizedPower = maxPower / (totalEnergy * mBlockSize);
+
+        // Convert to dB
+        float snrDB = (float)(10.0 * Math.log10(normalizedPower + 1e-10));
+
+        if(maxIndex >= 0 && snrDB > DETECTION_THRESHOLD_DB)
+        {
+            CTCSSCode detected = mTargetCodeArray[maxIndex];
+            handleDetection(detected);
+        }
+        else
+        {
+            handleNoDetection();
+        }
+    }
+
+    /**
+     * Goertzel algorithm - computes the energy at a specific frequency.
+     *
+     * @param samples the input samples
+     * @param numSamples number of samples to process
+     * @param coefficient pre-computed 2*cos(2π*f/fs)
+     * @return the magnitude squared at the target frequency
+     */
+    private float goertzel(float[] samples, int numSamples, float coefficient)
+    {
+        float s0 = 0;
+        float s1 = 0;
+        float s2 = 0;
+
+        for(int i = 0; i < numSamples; i++)
+        {
+            s0 = samples[i] + coefficient * s1 - s2;
+            s2 = s1;
+            s1 = s0;
+        }
+
+        // Magnitude squared = s1^2 + s2^2 - coefficient * s1 * s2
+        return s1 * s1 + s2 * s2 - coefficient * s1 * s2;
+    }
+
+    /**
+     * Handles detection of a CTCSS tone in the current block.
+     * Only reports to the listener if the detected tone is in the allowed (target) set.
+     */
+    private void handleDetection(CTCSSCode code)
+    {
+        mLossCounter = 0;
+
+        // Only accept tones that are in our allowed set
+        if(!mTargetCodes.contains(code))
+        {
+            // Track confirmed rejections — only notify after same wrong tone seen CONFIRMATION_COUNT times
+            if(mDetectedCode == code)
+            {
+                if(mConfirmationCounter < CONFIRMATION_COUNT)
+                {
+                    mConfirmationCounter++;
+
+                    if(mConfirmationCounter >= CONFIRMATION_COUNT && mListener != null)
+                    {
+                        mListener.ctcssRejected(code);
+                    }
+                }
+                // Already confirmed rejected — don't spam listener
+            }
+            else
+            {
+                mDetectedCode = code;
+                mConfirmationCounter = 1;
+            }
+            return;
+        }
+
+        if(mDetectedCode == code)
+        {
+            // Same tone detected again — increment confirmation
+            if(mConfirmationCounter < CONFIRMATION_COUNT)
+            {
+                mConfirmationCounter++;
+
+                if(mConfirmationCounter >= CONFIRMATION_COUNT && mListener != null)
+                {
+                    mListener.ctcssDetected(code);
+                }
+            }
+            // Already confirmed — just keep reporting
+            else if(mListener != null)
+            {
+                mListener.ctcssDetected(code);
+            }
+        }
+        else
+        {
+            // Different tone — restart confirmation
+            mDetectedCode = code;
+            mConfirmationCounter = 1;
+        }
+    }
+
+    /**
+     * Handles no CTCSS tone detected in the current block.
+     */
+    private void handleNoDetection()
+    {
+        if(mDetectedCode != null)
+        {
+            mLossCounter++;
+
+            if(mLossCounter >= LOSS_COUNT)
+            {
+                mDetectedCode = null;
+                mConfirmationCounter = 0;
+
+                if(mListener != null)
+                {
+                    mListener.ctcssLost();
+                }
+            }
+        }
+    }
+
+    /**
+     * Resets the detector state.
+     */
+    public void reset()
+    {
+        mSampleIndex = 0;
+        mDetectedCode = null;
+        mConfirmationCounter = 0;
+        mLossCounter = 0;
+    }
+
+    /**
+     * Returns the currently detected CTCSS code, or null if none detected.
+     */
+    public CTCSSCode getDetectedCode()
+    {
+        return (mConfirmationCounter >= CONFIRMATION_COUNT) ? mDetectedCode : null;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/DCSDetector.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/DCSDetector.java
@@ -1,0 +1,366 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.module.decode.nbfm;
+
+import io.github.dsheirer.dsp.filter.FilterFactory;
+import io.github.dsheirer.dsp.filter.design.FilterDesignException;
+import io.github.dsheirer.dsp.filter.fir.FIRFilterSpecification;
+import io.github.dsheirer.dsp.filter.fir.real.IRealFilter;
+import io.github.dsheirer.dsp.filter.fir.remez.RemezFIRFilterDesigner;
+import io.github.dsheirer.module.decode.dcs.DCSCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * DCS (Digital-Coded Squelch) detector for channel-level tone filtering.
+ *
+ * Adapted from SDRTrunk's DCSDecoder to work as an inline detector within
+ * the NBFM decoder pipeline. Uses the same proven slope-based symbol detection
+ * approach that reliably decodes 134.4 bps DCS from FM-demodulated audio.
+ *
+ * Designed for the decimated sample rate of the NBFM decoder pipeline.
+ */
+public class DCSDetector
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(DCSDetector.class);
+
+    private static final float DCS_BAUD_RATE = 134.4f;
+    private static final int CODE_MASK = 0x7FFFFF;
+    private static final int MAX_ONES_SEQUENCE = 6;
+    private static final int CONFIRMATION_COUNT = 2;
+    private static final int LOSS_CODEWORDS = 4;
+    private static final int SLOPE_CALCULATION_PERIOD = 30;
+    private static final double SLOPE_CALCULATION_SUM_XX = 2247.5;
+
+    private final Set<DCSCode> mTargetCodes;
+    private final float mSampleRate;
+    private final float mBaudLength;
+    private final float mSlopeThreshold;
+    private final int mPostTransitionSkip;
+    private final int mIdealTransitionMin;
+    private final int mIdealTransitionMax;
+    private final int mOverlap;
+
+    private IRealFilter mLowPassFilter;
+
+    private boolean mSymbol = false;
+    private float mBaudCounter = 0f;
+    private float mMaxSlope = 0;
+    private float[] mResidual;
+    private int mCode = 0;
+    private int mExcessiveOneSequenceCounter = 0;
+    private int mSamplesToSkip = 0;
+
+    private DCSCode mDetectedCode = null;
+    private int mConfirmationCounter = 0;
+    private int mCodewordsSinceMatch = 0;
+
+    private DCSDetectorListener mListener;
+
+    public interface DCSDetectorListener
+    {
+        void dcsDetected(DCSCode code);
+        void dcsLost();
+    }
+
+    public DCSDetector(Set<DCSCode> targetCodes, float sampleRate)
+    {
+        mTargetCodes = targetCodes;
+        mSampleRate = sampleRate;
+        mBaudLength = sampleRate / DCS_BAUD_RATE;
+
+        float scale = sampleRate / 8000.0f;
+        mSlopeThreshold = 0.002750f / scale;
+        mPostTransitionSkip = (int)(30 * scale);
+        mIdealTransitionMin = (int)(11 * scale);
+        mIdealTransitionMax = (int)(19 * scale);
+        mOverlap = (int)Math.ceil(mBaudLength);
+        mResidual = new float[mOverlap];
+
+        try
+        {
+            FIRFilterSpecification specification = FIRFilterSpecification.lowPassBuilder()
+                    .sampleRate((int)sampleRate)
+                    .gridDensity(16)
+                    .oddLength(true)
+                    .passBandCutoff(200)
+                    .passBandAmplitude(1.0)
+                    .passBandRipple(0.01)
+                    .stopBandStart(300)
+                    .stopBandAmplitude(0.0)
+                    .stopBandRipple(0.03)
+                    .build();
+
+            RemezFIRFilterDesigner designer = new RemezFIRFilterDesigner(specification);
+
+            if(designer.isValid())
+            {
+                mLowPassFilter = FilterFactory.getRealFilter(designer.getImpulseResponse());
+            }
+            else
+            {
+                LOGGER.warn("DCS low-pass filter design failed - using fallback");
+                mLowPassFilter = FilterFactory.getRealFilter(
+                        FilterFactory.getLowPass(sampleRate, 200, 300, 60,
+                                io.github.dsheirer.dsp.window.WindowType.HAMMING, true));
+            }
+        }
+        catch(FilterDesignException e)
+        {
+            LOGGER.warn("DCS filter design exception - using fallback", e);
+            mLowPassFilter = FilterFactory.getRealFilter(
+                    FilterFactory.getLowPass(sampleRate, 200, 300, 60,
+                            io.github.dsheirer.dsp.window.WindowType.HAMMING, true));
+        }
+
+        LOGGER.debug("DCSDetector initialized: sample rate={}, baud length={}", sampleRate, mBaudLength);
+    }
+
+    public void setListener(DCSDetectorListener listener)
+    {
+        mListener = listener;
+    }
+
+    public void process(float[] samples)
+    {
+        if(samples == null || samples.length == 0)
+        {
+            return;
+        }
+
+        float[] filtered = mLowPassFilter.filter(samples);
+        float[] buffer = new float[filtered.length + mOverlap];
+        int timingAdjust;
+
+        try
+        {
+            System.arraycopy(mResidual, 0, buffer, 0, mResidual.length);
+            System.arraycopy(filtered, 0, buffer, mResidual.length, filtered.length);
+
+            if(filtered.length >= mOverlap)
+            {
+                System.arraycopy(filtered, filtered.length - mOverlap, mResidual, 0, mOverlap);
+            }
+
+            for(int bufferPointer = 0; bufferPointer < samples.length; bufferPointer++)
+            {
+                if(bufferPointer + SLOPE_CALCULATION_PERIOD >= buffer.length)
+                {
+                    break;
+                }
+
+                if(mSamplesToSkip > 0)
+                {
+                    mSamplesToSkip--;
+                }
+                else
+                {
+                    float slope = calculateSlope(buffer, bufferPointer);
+
+                    if(mSymbol)
+                    {
+                        if(slope > mMaxSlope && mMaxSlope < -mSlopeThreshold)
+                        {
+                            mSymbol = false;
+
+                            if(mBaudCounter < mIdealTransitionMin)
+                            {
+                                timingAdjust = 1;
+                            }
+                            else if(mBaudCounter > mIdealTransitionMax)
+                            {
+                                timingAdjust = -1;
+                            }
+                            else
+                            {
+                                timingAdjust = 0;
+                            }
+
+                            mBaudCounter += timingAdjust;
+                            mSamplesToSkip = mPostTransitionSkip + timingAdjust;
+                        }
+                        else if(slope < mMaxSlope)
+                        {
+                            mMaxSlope = slope;
+                        }
+                    }
+                    else
+                    {
+                        if(slope < mMaxSlope && mMaxSlope > mSlopeThreshold)
+                        {
+                            mSymbol = true;
+
+                            if(mBaudCounter < mIdealTransitionMin)
+                            {
+                                timingAdjust = 1;
+                            }
+                            else if(mBaudCounter > mIdealTransitionMax)
+                            {
+                                timingAdjust = -1;
+                            }
+                            else
+                            {
+                                timingAdjust = 0;
+                            }
+
+                            mBaudCounter += timingAdjust;
+                            mSamplesToSkip = mPostTransitionSkip + timingAdjust;
+                        }
+                        else if(slope > mMaxSlope)
+                        {
+                            mMaxSlope = slope;
+                        }
+                    }
+                }
+
+                mBaudCounter++;
+
+                if(mBaudCounter > mBaudLength)
+                {
+                    mCode = (Integer.rotateLeft(mCode, 1) + (mSymbol ? 1 : 0)) & CODE_MASK;
+
+                    if(DCSCode.hasValue(mCode))
+                    {
+                        handleDetection(DCSCode.fromValue(mCode));
+                    }
+                    else
+                    {
+                        handleNoDetection();
+                    }
+
+                    mBaudCounter -= mBaudLength;
+
+                    if(mSymbol)
+                    {
+                        mExcessiveOneSequenceCounter++;
+                        if(mExcessiveOneSequenceCounter > MAX_ONES_SEQUENCE)
+                        {
+                            mSymbol = false;
+                            mMaxSlope = -1f;
+                            mExcessiveOneSequenceCounter = 0;
+                        }
+                    }
+                    else
+                    {
+                        mExcessiveOneSequenceCounter = 0;
+                    }
+                }
+            }
+        }
+        catch(Exception e)
+        {
+            LOGGER.warn("Unexpected error while processing DCS samples", e);
+        }
+    }
+
+    private float calculateSlope(float[] samples, int offset)
+    {
+        double xbar = 0;
+        double ybar = samples[offset];
+        double sumXY = 0;
+        double fact1, dx, dy;
+
+        for(int x = 1; x < SLOPE_CALCULATION_PERIOD; x++)
+        {
+            fact1 = 1.0 + x;
+            dx = x - xbar;
+            dy = samples[offset + x] - ybar;
+            sumXY += dx * dy * (x / (1.0 + x));
+            xbar += dx / fact1;
+            ybar += dy / fact1;
+        }
+
+        return (float)(sumXY / SLOPE_CALCULATION_SUM_XX);
+    }
+
+    private void handleDetection(DCSCode code)
+    {
+        if(code == null || code == DCSCode.UNKNOWN)
+        {
+            return;
+        }
+
+        if(mTargetCodes != null && !mTargetCodes.isEmpty() && !mTargetCodes.contains(code))
+        {
+            return;
+        }
+
+        mCodewordsSinceMatch = 0;
+
+        if(mDetectedCode == code)
+        {
+            if(mConfirmationCounter < CONFIRMATION_COUNT)
+            {
+                mConfirmationCounter++;
+                if(mConfirmationCounter >= CONFIRMATION_COUNT && mListener != null)
+                {
+                    mListener.dcsDetected(code);
+                }
+            }
+            else if(mListener != null)
+            {
+                mListener.dcsDetected(code);
+            }
+        }
+        else
+        {
+            mDetectedCode = code;
+            mConfirmationCounter = 1;
+        }
+    }
+
+    private void handleNoDetection()
+    {
+        if(mDetectedCode != null)
+        {
+            mCodewordsSinceMatch++;
+            if(mCodewordsSinceMatch >= (LOSS_CODEWORDS * 23))
+            {
+                mDetectedCode = null;
+                mConfirmationCounter = 0;
+                if(mListener != null)
+                {
+                    mListener.dcsLost();
+                }
+            }
+        }
+    }
+
+    public void reset()
+    {
+        mSymbol = false;
+        mBaudCounter = 0;
+        mMaxSlope = 0;
+        mCode = 0;
+        mExcessiveOneSequenceCounter = 0;
+        mSamplesToSkip = 0;
+        mDetectedCode = null;
+        mConfirmationCounter = 0;
+        mCodewordsSinceMatch = 0;
+        mResidual = new float[mOverlap];
+    }
+
+    public DCSCode getDetectedCode()
+    {
+        return (mConfirmationCounter >= CONFIRMATION_COUNT) ? mDetectedCode : null;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoder.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2025 Dennis Sheirer
+ * Copyright (C) 2014-2026 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,9 +34,13 @@ import io.github.dsheirer.dsp.fm.IDemodulator;
 import io.github.dsheirer.dsp.squelch.INoiseSquelchController;
 import io.github.dsheirer.dsp.squelch.NoiseSquelch;
 import io.github.dsheirer.dsp.squelch.NoiseSquelchState;
+import io.github.dsheirer.dsp.squelch.SquelchTailRemover;
 import io.github.dsheirer.dsp.window.WindowType;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.SquelchControlDecoder;
+import io.github.dsheirer.module.decode.config.ChannelToneFilter;
+import io.github.dsheirer.module.decode.ctcss.CTCSSCode;
+import io.github.dsheirer.module.decode.dcs.DCSCode;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.sample.complex.ComplexSamples;
 import io.github.dsheirer.sample.complex.IComplexSamplesListener;
@@ -46,15 +50,27 @@ import io.github.dsheirer.source.SourceEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
- * NBFM decoder with integrated noise squelch.  Demodulates complex sample buffers and feeds unfiltered, demodulated
- * audio to Noise Squelch.  Squelch operates on the noise level with open and close thresholds to pass low-noise audio
- * and block high-noise audio.  Audio is filtered and resampled to 8 kHz for downstream consumers.
+ * NBFM decoder with integrated noise squelch, channel-level tone filtering, FM de-emphasis,
+ * and squelch tail removal.
+ *
+ * Audio chain:
+ *   ComplexSamples → Decimate → Baseband Filter → FM Demod → De-emphasis → NoiseSquelch
+ *   → ToneGate → SquelchTailRemover → Resample(8kHz) → Output
+ *
+ * When tone filtering is enabled, audio only passes when noise squelch is open AND a
+ * matching CTCSS/DCS tone is detected.
  */
 public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventListener, IComplexSamplesListener,
         Listener<ComplexSamples>, IRealBufferProvider, IDecoderStateEventProvider, INoiseSquelchController
 {
     private final static Logger mLog = LoggerFactory.getLogger(NBFMDecoder.class);
+    private NBFMDecoderState mDecoderState;
     private static final double DEMODULATED_AUDIO_SAMPLE_RATE = 8000.0;
     private final IDemodulator mDemodulator = FmDemodulatorFactory.getFmDemodulator();
     private final SourceEventProcessor mSourceEventProcessor = new SourceEventProcessor();
@@ -68,6 +84,28 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
     private RealResampler mResampler;
     private final double mChannelBandwidth;
 
+    // === NEW: FM de-emphasis ===
+    private float mDeemphasisAlpha = 0;
+    private float mPreviousDeemphasis = 0;
+    private boolean mDeemphasisEnabled = false;
+
+    // === NEW: Squelch tail remover ===
+    private SquelchTailRemover mSquelchTailRemover;
+    private boolean mSquelchTailRemovalEnabled = false;
+
+    // === NEW: Tone gating ===
+    private boolean mToneFilterEnabled = false;
+    private Set<CTCSSCode> mAllowedCTCSSCodes = EnumSet.noneOf(CTCSSCode.class);
+    private Set<DCSCode> mAllowedDCSCodes = new HashSet<>();
+    private volatile CTCSSCode mDetectedCTCSS = null;
+    private volatile DCSCode mDetectedDCS = null;
+    private volatile boolean mToneMatched = false;
+    private int mSquelchClosedSamples = 0;
+    private int mSquelchHoldoverSamples = 0; // Set in setSampleRate()
+    private CTCSSDetector mCTCSSDetector = null;
+    private DCSDetector mDCSDetector = null;
+    private int mToneDetectorSkipCounter = 0;
+
     /**
      * Constructs an instance
      *
@@ -77,80 +115,367 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
     {
         super(config);
 
-        //Save channel bandwidth to setup channel baseband filter.
         mChannelBandwidth = config.getBandwidth().getValue();
         mNoiseSquelch = new NoiseSquelch(config.getSquelchNoiseOpenThreshold(), config.getSquelchNoiseCloseThreshold(),
                 config.getSquelchHysteresisOpenThreshold(), config.getSquelchHysteresisCloseThreshold());
 
-        //Send squelch controlled audio to the resampler and notify the decoder state that the call continues.
+        // Configure de-emphasis
+        configureDeemphasis(config.getDeemphasis());
+
+        // Configure squelch tail removal
+        if(config.isSquelchTailRemovalEnabled())
+        {
+            mSquelchTailRemovalEnabled = true;
+            mSquelchTailRemover = new SquelchTailRemover(
+                    config.getSquelchTailRemovalMs(),
+                    config.getSquelchHeadRemovalMs()
+            );
+        }
+
+        // Configure tone filtering
+        configureToneFilters(config);
+
+        // Audio pipeline: NoiseSquelch → De-emphasis → (ToneGate) → (TailRemover) → Resampler → Output
         mNoiseSquelch.setAudioListener(audio -> {
-            mResampler.resample(audio);
+            if(mToneFilterEnabled && !mToneMatched)
+            {
+                // Tone filtering enabled but no match — block audio
+                return;
+            }
+
+            // Apply de-emphasis AFTER squelch (de-emphasis before squelch would
+            // attenuate high-frequency noise and prevent squelch from closing)
+            if(mDeemphasisEnabled)
+            {
+                audio = applyDeemphasis(audio);
+            }
+
+            if(mSquelchTailRemovalEnabled && mSquelchTailRemover != null)
+            {
+                mSquelchTailRemover.process(audio);
+            }
+            else
+            {
+                mResampler.resample(audio);
+            }
+
             notifyCallContinuation();
         });
 
-        //Notify the decoder state of call starts and ends
+        // Squelch state changes → notify decoder state + tail remover
         mNoiseSquelch.setSquelchStateListener(squelchState -> {
             if(squelchState == SquelchState.SQUELCH)
             {
+                if(mSquelchTailRemovalEnabled && mSquelchTailRemover != null)
+                {
+                    mSquelchTailRemover.squelchClose();
+                }
                 notifyCallEnd();
             }
             else
             {
-                notifyCallStart();
+                if(mSquelchTailRemovalEnabled && mSquelchTailRemover != null)
+                {
+                    mSquelchTailRemover.squelchOpen();
+                }
+                // When tone filtering is enabled, delay call start until tone is matched.
+                // The call start will be triggered from ctcssDetected/dcsDetected instead.
+                if(!mToneFilterEnabled)
+                {
+                    notifyCallStart();
+                }
             }
         });
     }
 
     /**
-     * Decoder type.
-     * @return type
+     * Sets the decoder state reference so the decoder can push detected tone updates.
+     * @param decoderState the NBFM decoder state to receive tone notifications
      */
+    public void setDecoderState(NBFMDecoderState decoderState)
+    {
+        mDecoderState = decoderState;
+    }
+
+    /**
+     * Configures FM de-emphasis filter parameters based on the selected mode
+     */
+    private void configureDeemphasis(DecodeConfigNBFM.DeemphasisMode mode)
+    {
+        if(mode != null && mode != DecodeConfigNBFM.DeemphasisMode.NONE && mode.getMicroseconds() > 0)
+        {
+            mDeemphasisEnabled = true;
+            // Alpha will be recalculated when sample rate is known
+            // For now, store the time constant
+            mDeemphasisAlpha = 0; // Will be set in setSampleRate()
+        }
+        else
+        {
+            mDeemphasisEnabled = false;
+        }
+    }
+
+    /**
+     * Applies single-pole IIR de-emphasis filter to demodulated audio.
+     * This restores flat frequency response from pre-emphasized FM transmission.
+     */
+    private float[] applyDeemphasis(float[] samples)
+    {
+        if(!mDeemphasisEnabled || mDeemphasisAlpha <= 0)
+        {
+            return samples;
+        }
+
+        float[] output = new float[samples.length];
+        float prev = mPreviousDeemphasis;
+
+        for(int i = 0; i < samples.length; i++)
+        {
+            output[i] = mDeemphasisAlpha * samples[i] + (1.0f - mDeemphasisAlpha) * prev;
+            prev = output[i];
+        }
+
+        mPreviousDeemphasis = prev;
+        return output;
+    }
+
+    /**
+     * Configures the set of allowed tones from the channel decode configuration
+     */
+    private void configureToneFilters(DecodeConfigNBFM config)
+    {
+        mToneFilterEnabled = config.isToneFilterEnabled();
+
+        if(mToneFilterEnabled)
+        {
+            List<ChannelToneFilter> filters = config.getToneFilters();
+            for(ChannelToneFilter filter : filters)
+            {
+                if(!filter.isValid())
+                {
+                    continue;
+                }
+
+                switch(filter.getToneType())
+                {
+                    case CTCSS:
+                        CTCSSCode ctcss = filter.getCTCSSCode();
+                        if(ctcss != null && ctcss != CTCSSCode.UNKNOWN)
+                        {
+                            mAllowedCTCSSCodes.add(ctcss);
+                        }
+                        break;
+                    case DCS:
+                        DCSCode dcs = filter.getDCSCode();
+                        if(dcs != null)
+                        {
+                            mAllowedDCSCodes.add(dcs);
+                        }
+                        break;
+                    case NAC:
+                        // NAC filters are for P25, not NBFM — ignore here
+                        break;
+                }
+            }
+
+            // If we configured tone filtering but have no valid tones, disable it
+            if(mAllowedCTCSSCodes.isEmpty() && mAllowedDCSCodes.isEmpty())
+            {
+                mLog.warn("Tone filtering enabled but no valid CTCSS/DCS codes configured — disabling tone filter");
+                mToneFilterEnabled = false;
+            }
+            else
+            {
+                mLog.info("NBFM tone filtering enabled: {} CTCSS codes, {} DCS codes",
+                        mAllowedCTCSSCodes.size(), mAllowedDCSCodes.size());
+
+                // Create CTCSS detector if we have CTCSS codes to detect
+                // Note: detector is initialized with 8000 Hz sample rate; it will be
+                // recreated in setSampleRate() if the actual rate differs
+                if(!mAllowedCTCSSCodes.isEmpty())
+                {
+                    createCTCSSDetector(8000.0f);
+                }
+
+                // Create DCS detector if we have DCS codes to detect
+                if(!mAllowedDCSCodes.isEmpty())
+                {
+                    createDCSDetector(8000.0f);
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates the CTCSS Goertzel detector at the specified sample rate.
+     * @param sampleRate of the demodulated audio
+     */
+    private void createCTCSSDetector(float sampleRate)
+    {
+        mCTCSSDetector = new CTCSSDetector(mAllowedCTCSSCodes, sampleRate);
+        mCTCSSDetector.setListener(new CTCSSDetector.CTCSSDetectorListener()
+        {
+            @Override
+            public void ctcssDetected(CTCSSCode code)
+            {
+                NBFMDecoder.this.ctcssDetected(code);
+            }
+
+            @Override
+            public void ctcssRejected(CTCSSCode code)
+            {
+                if(mDecoderState != null && code != null)
+                {
+                    mDecoderState.setRejectedCTCSS(code);
+                }
+            }
+
+            @Override
+            public void ctcssLost()
+            {
+                NBFMDecoder.this.toneLost();
+            }
+        });
+    }
+
+    /**
+     * Creates the DCS detector at the specified sample rate.
+     * @param sampleRate of the demodulated audio
+     */
+    private void createDCSDetector(float sampleRate)
+    {
+        mDCSDetector = new DCSDetector(mAllowedDCSCodes, sampleRate);
+        mDCSDetector.setListener(new DCSDetector.DCSDetectorListener()
+        {
+            @Override
+            public void dcsDetected(DCSCode code)
+            {
+                NBFMDecoder.this.dcsDetected(code);
+            }
+
+            @Override
+            public void dcsLost()
+            {
+                NBFMDecoder.this.toneLost();
+            }
+        });
+    }
+
+    /**
+     * Called by CTCSS decoder when a tone is detected. If tone filtering is enabled,
+     * this updates the tone match state.
+     * @param code the detected CTCSS tone code
+     */
+    public void ctcssDetected(CTCSSCode code)
+    {
+        mDetectedCTCSS = code;
+        if(mToneFilterEnabled && code != null && mAllowedCTCSSCodes.contains(code))
+        {
+            if(!mToneMatched)
+            {
+                mToneMatched = true;
+                // Tone just matched — now fire the deferred call start
+                notifyCallStart();
+            }
+        }
+
+        // Push to decoder state for activity summary display
+        if(mDecoderState != null && code != null)
+        {
+            mDecoderState.setDetectedCTCSS(code);
+        }
+    }
+
+    /**
+     * Called by DCS decoder when a code is detected. If tone filtering is enabled,
+     * this updates the tone match state.
+     * @param code the detected DCS code
+     */
+    public void dcsDetected(DCSCode code)
+    {
+        mDetectedDCS = code;
+        if(mToneFilterEnabled && code != null && mAllowedDCSCodes.contains(code))
+        {
+            if(!mToneMatched)
+            {
+                mToneMatched = true;
+                notifyCallStart();
+            }
+        }
+
+        // Push to decoder state for activity summary display
+        if(mDecoderState != null && code != null)
+        {
+            mDecoderState.setDetectedDCS(code);
+        }
+    }
+
+    /**
+     * Called when tone is lost (no longer detected). Resets tone match state.
+     */
+    public void toneLost()
+    {
+        mDetectedCTCSS = null;
+        mDetectedDCS = null;
+        mToneMatched = false;
+
+        // Notify decoder state
+        if(mDecoderState != null)
+        {
+            mDecoderState.setToneLost();
+        }
+    }
+
+    /**
+     * Indicates if a matching tone is currently detected
+     */
+    public boolean isToneMatched()
+    {
+        return !mToneFilterEnabled || mToneMatched;
+    }
+
+    /**
+     * Returns the currently detected CTCSS code, or null
+     */
+    public CTCSSCode getDetectedCTCSS()
+    {
+        return mDetectedCTCSS;
+    }
+
+    /**
+     * Returns the currently detected DCS code, or null
+     */
+    public DCSCode getDetectedDCS()
+    {
+        return mDetectedDCS;
+    }
+
     @Override
     public DecoderType getDecoderType()
     {
         return DecoderType.NBFM;
     }
 
-    /**
-     * Decode configuration for this decoder.
-     * @return configuration
-     */
     @Override
     public DecodeConfigNBFM getDecodeConfiguration()
     {
         return (DecodeConfigNBFM)super.getDecodeConfiguration();
     }
 
-    /**
-     * Register the noise squelch state listener.  This will normally be a GUI noise squelch state view/controller.
-     * @param listener to receive states or pass null to de-register a listener.
-     */
     @Override
     public void setNoiseSquelchStateListener(Listener<NoiseSquelchState> listener)
     {
         mNoiseSquelch.setNoiseSquelchStateListener(listener);
     }
 
-    /**
-     * Applies new open and close noise threshold values for the noise squelch.
-     * @param open for the open noise variance calculation in range 0.1 - 0.5 where open <= close value.
-     * @param close for the close noise variance calculation. in range 0.1 - 0.5 where close >= open.
-     */
     @Override
     public void setNoiseThreshold(float open, float close)
     {
         mNoiseSquelch.setNoiseThreshold(open, close);
-
-        //Update the channel configuration and schedule a playlist save.
         getDecodeConfiguration().setSquelchNoiseOpenThreshold(open);
         getDecodeConfiguration().setSquelchNoiseCloseThreshold(close);
     }
 
-    /**
-     * Sets the open and close hysteresis thresholds in units of 10 milliseconds.
-     * @param open in range 1-10, recommend: 4 where open <= close
-     * @param close in range 1-10, recommend: 6 where close >= open.
-     */
     @Override
     public void setHysteresisThreshold(int open, int close)
     {
@@ -159,28 +484,18 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
         getDecodeConfiguration().setSquelchHysteresisCloseThreshold(close);
     }
 
-    /**
-     * Sets the squelch override state to temporarily bypass/override squelch control and pass all audio.
-     * @param override (true) or (false) to turn off squelch override.
-     */
     @Override
     public void setSquelchOverride(boolean override)
     {
         mNoiseSquelch.setSquelchOverride(override);
     }
 
-    /**
-     * Implements the ISourceEventListener interface
-     */
     @Override
     public Listener<SourceEvent> getSourceEventListener()
     {
         return mSourceEventProcessor;
     }
 
-    /**
-     * Module interface methods - unused.
-     */
     @Override
     public void reset() {}
 
@@ -188,13 +503,14 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
     public void start() {}
 
     @Override
-    public void stop() {}
+    public void stop()
+    {
+        if(mSquelchTailRemover != null)
+        {
+            mSquelchTailRemover.reset();
+        }
+    }
 
-    /**
-     * Broadcasts the demodulated, resampled to 8 kHz audio samples to the registered listener.
-     *
-     * @param demodulatedSamples to broadcast
-     */
     protected void broadcast(float[] demodulatedSamples)
     {
         if(mResampledBufferListener != null)
@@ -203,38 +519,24 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
         }
     }
 
-    /**
-     * Implements the IRealBufferProvider interface to register a listener for demodulated audio samples.
-     *
-     * @param listener to receive demodulated, resampled audio sample buffers.
-     */
     @Override
     public void setBufferListener(Listener<float[]> listener)
     {
         mResampledBufferListener = listener;
     }
 
-    /**
-     * Implements the IRealBufferProvider interface to deregister a listener from receiving demodulated audio samples.
-     */
     @Override
     public void removeBufferListener()
     {
         mResampledBufferListener = null;
     }
 
-    /**
-     * Implements the IComplexSampleListener interface to receive a stream of complex sample buffers.
-     */
     @Override
     public Listener<ComplexSamples> getComplexSamplesListener()
     {
         return this;
     }
 
-    /**
-     * Implements the Listener<ComplexSample> interface to receive a stream of complex I/Q sample buffers
-     */
     @Override
     public void receive(ComplexSamples samples)
     {
@@ -252,51 +554,67 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
 
         float[] demodulated = mDemodulator.demodulate(filteredI, filteredQ);
 
+        // Run tone detectors on demodulated audio BEFORE noise squelch processing
+        // (squelch high-pass filter removes sub-audible tones).
+        // Only skip when squelch is closed (no signal = no tone to detect).
+        if((mCTCSSDetector != null || mDCSDetector != null) && !mNoiseSquelch.isSquelched())
+        {
+            if(mCTCSSDetector != null)
+            {
+                mCTCSSDetector.process(demodulated);
+            }
+            if(mDCSDetector != null)
+            {
+                mDCSDetector.process(demodulated);
+            }
+        }
+
         mNoiseSquelch.process(demodulated);
 
-        //Once we process the sample buffer, if the ending state is squelch closed, update the decoder state that we
-        // are idle.
         if(mNoiseSquelch.isSquelched())
         {
+            // Don't immediately clear tone match — squelch may briefly close during
+            // a transmission (noise spikes, signal fading). Track how long squelch
+            // has been closed and only clear after sustained silence.
+            if(mToneFilterEnabled)
+            {
+                mSquelchClosedSamples += demodulated.length;
+
+                // Clear tone match after ~500ms of sustained squelch (transmission truly ended)
+                if(mSquelchClosedSamples > mSquelchHoldoverSamples)
+                {
+                    mToneMatched = false;
+                }
+            }
             notifyIdle();
+        }
+        else
+        {
+            // Squelch is open — reset the closed counter
+            mSquelchClosedSamples = 0;
         }
     }
 
-    /**
-     * Broadcasts a call start state event
-     */
     private void notifyCallStart()
     {
         broadcast(new DecoderStateEvent(this, DecoderStateEvent.Event.START, State.CALL, 0));
     }
 
-    /**
-     * Broadcasts a call continuation state event
-     */
     private void notifyCallContinuation()
     {
         broadcast(new DecoderStateEvent(this, DecoderStateEvent.Event.CONTINUATION, State.CALL, 0));
     }
 
-    /**
-     * Broadcasts a call end state event
-     */
     private void notifyCallEnd()
     {
         broadcast(new DecoderStateEvent(this, DecoderStateEvent.Event.END, State.CALL, 0));
     }
 
-    /**
-     * Broadcasts an idle notification
-     */
     private void notifyIdle()
     {
         broadcast(new DecoderStateEvent(this, DecoderStateEvent.Event.CONTINUATION, State.IDLE, 0));
     }
 
-    /**
-     * Broadcasts the decoder state event to an optional registered listener
-     */
     private void broadcast(DecoderStateEvent event)
     {
         if(mDecoderStateEventListener != null)
@@ -305,28 +623,18 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
         }
     }
 
-    /**
-     * Sets the decoder state listener
-     */
     @Override
     public void setDecoderStateListener(Listener<DecoderStateEvent> listener)
     {
         mDecoderStateEventListener = listener;
     }
 
-    /**
-     * Removes the decoder state event listener
-     */
     @Override
     public void removeDecoderStateListener()
     {
         mDecoderStateEventListener = null;
     }
 
-    /**
-     * Updates the decoder to process complex sample buffers at the specified sample rate.
-     * @param sampleRate of the incoming complex sample buffer stream.
-     */
     private void setSampleRate(double sampleRate)
     {
         int decimationRate = 0;
@@ -357,12 +665,41 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
 
         mNoiseSquelch.setSampleRate(decimatedSampleRate);
 
+        // === NEW: Calculate de-emphasis alpha for this sample rate ===
+        if(mDeemphasisEnabled)
+        {
+            DecodeConfigNBFM.DeemphasisMode mode = getDecodeConfiguration().getDeemphasis();
+            if(mode != null && mode.getMicroseconds() > 0)
+            {
+                double tau = mode.getMicroseconds() / 1_000_000.0; // Convert µs to seconds
+                double dt = 1.0 / decimatedSampleRate;
+                mDeemphasisAlpha = (float)(dt / (tau + dt));
+                mLog.info("FM de-emphasis configured: τ={}µs, α={}, sample rate={}",
+                        mode.getMicroseconds(), String.format("%.6f", mDeemphasisAlpha), decimatedSampleRate);
+            }
+        }
+
+        // Recreate CTCSS detector at the actual decimated sample rate
+        if(mToneFilterEnabled && !mAllowedCTCSSCodes.isEmpty())
+        {
+            createCTCSSDetector((float) decimatedSampleRate);
+        }
+
+        // Recreate DCS detector at the actual decimated sample rate
+        if(mToneFilterEnabled && !mAllowedDCSCodes.isEmpty())
+        {
+            createDCSDetector((float) decimatedSampleRate);
+        }
+
+        // Tone match holdover: 500ms of sustained squelch before clearing tone match
+        mSquelchHoldoverSamples = (int)(decimatedSampleRate * 0.5);
+
         int passBandStop = (int) (mChannelBandwidth * .8);
         int stopBandStart = (int) mChannelBandwidth;
 
         float[] coefficients = null;
 
-        FIRFilterSpecification specification = FIRFilterSpecification.lowPassBuilder().sampleRate(decimatedSampleRate * 2).gridDensity(16).oddLength(true).passBandCutoff(passBandStop).passBandAmplitude(1.0).passBandRipple(0.01).stopBandStart(stopBandStart).stopBandAmplitude(0.0).stopBandRipple(0.005) //Approximately 90 dB attenuation
+        FIRFilterSpecification specification = FIRFilterSpecification.lowPassBuilder().sampleRate(decimatedSampleRate * 2).gridDensity(16).oddLength(true).passBandCutoff(passBandStop).passBandAmplitude(1.0).passBandRipple(0.01).stopBandStart(stopBandStart).stopBandAmplitude(0.0).stopBandRipple(0.005)
                 .build();
 
         try
@@ -385,6 +722,12 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
 
         mResampler = new RealResampler(decimatedSampleRate, DEMODULATED_AUDIO_SAMPLE_RATE, 4192, 512);
         mResampler.setListener(NBFMDecoder.this::broadcast);
+
+        // === NEW: Connect squelch tail remover to resampler ===
+        if(mSquelchTailRemovalEnabled && mSquelchTailRemover != null)
+        {
+            mSquelchTailRemover.setOutputListener(audio -> mResampler.resample(audio));
+        }
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoderState.java
@@ -1,6 +1,6 @@
 /*
  * *****************************************************************************
- * Copyright (C) 2014-2023 Dennis Sheirer
+ * Copyright (C) 2014-2026 Dennis Sheirer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,9 +26,17 @@ import io.github.dsheirer.identifier.Role;
 import io.github.dsheirer.identifier.string.SimpleStringIdentifier;
 import io.github.dsheirer.module.decode.DecoderType;
 import io.github.dsheirer.module.decode.analog.AnalogDecoderState;
+import io.github.dsheirer.module.decode.config.ChannelToneFilter;
+import io.github.dsheirer.module.decode.ctcss.CTCSSCode;
+import io.github.dsheirer.module.decode.dcs.DCSCode;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
- * NBFM decoder state
+ * NBFM decoder state - tracks channel tone filtering configuration and detected tones
  */
 public class NBFMDecoderState extends AnalogDecoderState
 {
@@ -36,16 +44,37 @@ public class NBFMDecoderState extends AnalogDecoderState
     private Identifier mChannelNameIdentifier;
     private Identifier mTalkgroupIdentifier;
 
+    // Tone filter configuration (from DecodeConfigNBFM)
+    private boolean mToneFilterEnabled = false;
+    private List<ChannelToneFilter> mConfiguredFilters = new ArrayList<>();
+
+    // De-emphasis configuration
+    private DecodeConfigNBFM.DeemphasisMode mDeemphasisMode = DecodeConfigNBFM.DeemphasisMode.NONE;
+
+    // Current status
+    private volatile String mToneStatus = "No tone detected";
+
+    // Per-tone detection counts: key = display string, value = [acceptCount, rejectCount]
+    private final Map<String, int[]> mToneCounts = new LinkedHashMap<>();
+
     /**
      * Constructs an instance
      * @param channelName to use for this channel
-     * @param decodeConfig with talkgroup identifier
+     * @param decodeConfig with talkgroup identifier and tone filter settings
      */
     public NBFMDecoderState(String channelName, DecodeConfigNBFM decodeConfig)
     {
         mChannelName = (channelName != null && !channelName.isEmpty()) ? channelName : "NBFM CHANNEL";
         mChannelNameIdentifier = new SimpleStringIdentifier(mChannelName, IdentifierClass.CONFIGURATION, Form.CHANNEL_NAME, Role.ANY);
         mTalkgroupIdentifier = new NBFMTalkgroup(decodeConfig.getTalkgroup());
+
+        mToneFilterEnabled = decodeConfig.isToneFilterEnabled();
+        if(mToneFilterEnabled && decodeConfig.getToneFilters() != null)
+        {
+            mConfiguredFilters.addAll(decodeConfig.getToneFilters());
+        }
+
+        mDeemphasisMode = decodeConfig.getDeemphasis();
     }
 
     @Override
@@ -66,13 +95,135 @@ public class NBFMDecoderState extends AnalogDecoderState
         return mTalkgroupIdentifier;
     }
 
+    /**
+     * Called by NBFMDecoder when a matching CTCSS tone is detected (allowed)
+     */
+    public void setDetectedCTCSS(CTCSSCode code)
+    {
+        if(code != null)
+        {
+            mToneStatus = "CTCSS: " + code.getDisplayString() + " [ALLOWED]";
+            incrementCount(code.getDisplayString(), true);
+        }
+    }
+
+    /**
+     * Called by NBFMDecoder when a matching DCS code is detected (allowed)
+     */
+    public void setDetectedDCS(DCSCode code)
+    {
+        if(code != null)
+        {
+            mToneStatus = "DCS: " + code.toString() + " [ALLOWED]";
+            incrementCount("DCS " + code.toString(), true);
+        }
+    }
+
+    /**
+     * Called by NBFMDecoder when a non-matching CTCSS tone is detected (rejected)
+     */
+    public void setRejectedCTCSS(CTCSSCode code)
+    {
+        if(code != null)
+        {
+            mToneStatus = "CTCSS: " + code.getDisplayString() + " [REJECTED]";
+            incrementCount(code.getDisplayString(), false);
+        }
+    }
+
+    /**
+     * Called by NBFMDecoder when a non-matching DCS code is detected (rejected)
+     */
+    public void setRejectedDCS(DCSCode code)
+    {
+        if(code != null)
+        {
+            mToneStatus = "DCS: " + code.toString() + " [REJECTED]";
+            incrementCount("DCS " + code.toString(), false);
+        }
+    }
+
+    /**
+     * Called by NBFMDecoder when tone is lost
+     */
+    public void setToneLost()
+    {
+        mToneStatus = "No tone detected";
+    }
+
+    private void incrementCount(String toneLabel, boolean accepted)
+    {
+        synchronized(mToneCounts)
+        {
+            int[] counts = mToneCounts.computeIfAbsent(toneLabel, k -> new int[]{0, 0});
+            if(accepted)
+            {
+                counts[0]++;
+            }
+            else
+            {
+                counts[1]++;
+            }
+        }
+    }
+
     @Override
     public String getActivitySummary()
     {
         StringBuilder sb = new StringBuilder();
-        sb.append("Activity Summary\n");
-        sb.append("\tDecoder: NBFM");
-        sb.append("\n\n");
+        sb.append("Activity Summary - Decoder:NBFM\n");
+
+        if(mDeemphasisMode != DecodeConfigNBFM.DeemphasisMode.NONE)
+        {
+            sb.append("\nDe-emphasis: ").append(mDeemphasisMode.getMicroseconds()).append("µs");
+        }
+
+        sb.append("\n\nTone Filter: ");
+        if(mToneFilterEnabled)
+        {
+            sb.append("ENABLED\n");
+            sb.append("Configured Filter: ");
+            if(!mConfiguredFilters.isEmpty())
+            {
+                sb.append(mConfiguredFilters.get(0).getDisplayString());
+            }
+            sb.append("\n");
+        }
+        else
+        {
+            sb.append("Disabled\n");
+        }
+
+        sb.append("\nCurrent Status: ").append(mToneStatus).append("\n");
+
+        synchronized(mToneCounts)
+        {
+            if(!mToneCounts.isEmpty())
+            {
+                sb.append("\nDetected Tones:\n");
+                for(Map.Entry<String, int[]> entry : mToneCounts.entrySet())
+                {
+                    int accepted = entry.getValue()[0];
+                    int rejected = entry.getValue()[1];
+                    String status;
+                    if(accepted > 0 && rejected == 0)
+                    {
+                        status = "ALLOWED (" + accepted + ")";
+                    }
+                    else if(rejected > 0 && accepted == 0)
+                    {
+                        status = "REJECTED (" + rejected + ")";
+                    }
+                    else
+                    {
+                        status = "ALLOWED (" + accepted + ") REJECTED (" + rejected + ")";
+                    }
+                    sb.append("\t").append(entry.getKey()).append(" - ").append(status).append("\n");
+                }
+            }
+        }
+
+        sb.append("\n");
         return sb.toString();
     }
 }


### PR DESCRIPTION
- CTCSS tone detection using Goertzel algorithm (42 standard tones)
- DCS code detection with standard and inverted codes
- Per-channel tone filter configuration in NBFM editor
- Squelch tail/head removal (configurable ms trim)
- FM de-emphasis selection (750us NA / 530us CEPT / None)
- ChannelToneFilter config class with XML persistence
- Tone Filter and Squelch Tail Removal UI panels
