### PR TITLE
Add NBFM squelch tail setting

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/squelch/NoiseSquelch.java
+++ b/src/main/java/io/github/dsheirer/dsp/squelch/NoiseSquelch.java
@@ -61,6 +61,8 @@ public class NoiseSquelch implements INoiseSquelchController
     private int mHysteresisCount = 0;
     private int mSquelchStateBroadcastCounter = 0;
     private int mSquelchOpenIndex = 0;
+    private int mSquelchTailSamples = 0;
+    private int mSquelchTailCounter = 0;
     private int mAudioBufferFilterDelay;
     private IRealFilter mHighPassFilter;
     private Listener<float[]> mAudioListener;
@@ -102,6 +104,24 @@ public class NoiseSquelch implements INoiseSquelchController
         {
             broadcast(SquelchState.UNSQUELCH);
         }
+    }
+
+    /**
+     * Sets the squelch tail duration in milliseconds.
+     * @param tailMs duration in milliseconds (0 to disable)
+     * @param sampleRate current sample rate to calculate samples
+     */
+    public void setSquelchTail(int tailMs, double sampleRate)
+    {
+        if(tailMs > 0 && sampleRate > 0)
+        {
+            mSquelchTailSamples = (int)(sampleRate * tailMs / 1000.0);
+        }
+        else
+        {
+            mSquelchTailSamples = 0;
+        }
+        mSquelchTailCounter = 0;
     }
 
     /**
@@ -304,6 +324,13 @@ public class NoiseSquelch implements INoiseSquelchController
                 {
                     mSquelch = true;
                     mHysteresisCount = 0;
+
+                    // Start squelch tail counter if enabled
+                    if(mSquelchTailSamples > 0)
+                    {
+                        mSquelchTailCounter = mSquelchTailSamples;
+                    }
+
                     squelchCloseIndex = findTransition(x);
 
                     //Broadcast the partial audio segment ending at the transition point.
@@ -315,12 +342,16 @@ public class NoiseSquelch implements INoiseSquelchController
                             broadcast(mSquelchOpenIndex, squelchCloseIndex);
                         }
 
-                        broadcast(SquelchState.SQUELCH);
+                        // Only broadcast squelch if no tail, otherwise tail handler will do it
+                        if(mSquelchTailSamples <= 0)
+                        {
+                            broadcast(SquelchState.SQUELCH);
+                        }
                     }
 
                     mSquelchOpenIndex = 0;
                 }
-                else if(mSquelch && !mSquelchOverride)
+                else if(mSquelch && !mSquelchOverride && mSquelchTailCounter <= 0)
                 {
                     int start = x - (mVarianceWindowSize * mHysteresisOpenThreshold) + 1;
                     int end = start + mVarianceWindowSize;
@@ -352,6 +383,21 @@ public class NoiseSquelch implements INoiseSquelchController
             //Dispatch audio after processing the audio buffer if we end in an un-squelch state.
             broadcast(mSquelchOpenIndex, samples.length);
             mSquelchOpenIndex = 0;
+        }
+        else if(mSquelchTailCounter > 0)
+        {
+            // Squelch tail - continue broadcasting audio briefly after squelch closes
+            // Broadcast from the end of the audio buffer where the newest samples are
+            int bufferEnd = mAudioBuffer.length;
+            int bufferStart = bufferEnd - samples.length;
+            broadcast(bufferStart, bufferEnd);
+            mSquelchTailCounter -= samples.length;
+
+            if(mSquelchTailCounter <= 0)
+            {
+                mSquelchTailCounter = 0;
+                broadcast(SquelchState.SQUELCH);
+            }
         }
     }
 

--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/NBFMConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/NBFMConfigurationEditor.java
@@ -47,6 +47,8 @@ import javafx.collections.ListChangeListener;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.scene.control.Label;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
 import javafx.scene.control.TitledPane;
@@ -73,6 +75,7 @@ public class NBFMConfigurationEditor extends ChannelConfigurationEditor
     private TextFormatter<Integer> mTalkgroupTextFormatter;
     private ToggleSwitch mBasebandRecordSwitch;
     private SegmentedButton mBandwidthButton;
+    private Spinner<Integer> mSquelchTailSpinner;
 
     private SourceConfigurationEditor mSourceConfigurationEditor;
     private AuxDecoderConfigurationEditor mAuxDecoderConfigurationEditor;
@@ -146,6 +149,14 @@ public class NBFMConfigurationEditor extends ChannelConfigurationEditor
 
             GridPane.setConstraints(getAudioFilterEnable(), 2, 1);
             gridPane.getChildren().add(getAudioFilterEnable());
+
+            Label tailLabel = new Label("Squelch Tail (ms)");
+            GridPane.setHalignment(tailLabel, HPos.RIGHT);
+            GridPane.setConstraints(tailLabel, 0, 2);
+            gridPane.getChildren().add(tailLabel);
+
+            GridPane.setConstraints(getSquelchTailSpinner(), 1, 2);
+            gridPane.getChildren().add(getSquelchTailSpinner());
 
             mDecoderPane.setContent(gridPane);
 
@@ -268,6 +279,25 @@ public class NBFMConfigurationEditor extends ChannelConfigurationEditor
         }
 
         return mAudioFilterEnable;
+    }
+
+    /**
+     * Spinner for squelch tail time in milliseconds.
+     * @return spinner control
+     */
+    private Spinner<Integer> getSquelchTailSpinner()
+    {
+        if(mSquelchTailSpinner == null)
+        {
+            mSquelchTailSpinner = new Spinner<>();
+            mSquelchTailSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 500, 0, 10));
+            mSquelchTailSpinner.setPrefWidth(80);
+            mSquelchTailSpinner.setEditable(true);
+            mSquelchTailSpinner.setTooltip(new Tooltip("Squelch tail duration to mimic radio squelch crash (0-500ms)"));
+            mSquelchTailSpinner.valueProperty().addListener((observable, oldValue, newValue) -> modifiedProperty().set(true));
+        }
+
+        return mSquelchTailSpinner;
     }
 
     private SegmentedButton getBandwidthButton()
@@ -412,6 +442,8 @@ public class NBFMConfigurationEditor extends ChannelConfigurationEditor
             updateTextFormatter(decodeConfigNBFM.getTalkgroup());
             getAudioFilterEnable().setDisable(false);
             getAudioFilterEnable().setSelected(decodeConfigNBFM.isAudioFilter());
+            getSquelchTailSpinner().setDisable(false);
+            getSquelchTailSpinner().getValueFactory().setValue(decodeConfigNBFM.getSquelchTailMs());
         }
         else
         {
@@ -426,6 +458,8 @@ public class NBFMConfigurationEditor extends ChannelConfigurationEditor
             getTalkgroupField().setDisable(true);
             getAudioFilterEnable().setDisable(true);
             getAudioFilterEnable().setSelected(false);
+            getSquelchTailSpinner().setDisable(true);
+            getSquelchTailSpinner().getValueFactory().setValue(0);
         }
     }
 
@@ -461,6 +495,7 @@ public class NBFMConfigurationEditor extends ChannelConfigurationEditor
 
         config.setTalkgroup(talkgroup);
         config.setAudioFilter(getAudioFilterEnable().isSelected());
+        config.setSquelchTailMs(getSquelchTailSpinner().getValue());
         getItem().setDecodeConfiguration(config);
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/DecodeConfigNBFM.java
@@ -35,6 +35,7 @@ public class DecodeConfigNBFM extends DecodeConfigAnalog
     private float mSquelchNoiseCloseThreshold = NoiseSquelch.DEFAULT_NOISE_CLOSE_THRESHOLD;
     private int mSquelchHysteresisOpenThreshold = NoiseSquelch.DEFAULT_HYSTERESIS_OPEN_THRESHOLD;
     private int mSquelchHysteresisCloseThreshold = NoiseSquelch.DEFAULT_HYSTERESIS_CLOSE_THRESHOLD;
+    private int mSquelchTailMs = 0;
 
     /**
      * Constructs an instance
@@ -188,5 +189,29 @@ public class DecodeConfigNBFM extends DecodeConfigAnalog
         }
 
         mSquelchHysteresisCloseThreshold = close;
+    }
+
+    /**
+     * Squelch tail duration in milliseconds (0-500). Brief audio tail after squelch closes
+     * to mimic traditional radio squelch crash sound.
+     * @return tail duration in milliseconds
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "squelchTailMs")
+    public int getSquelchTailMs()
+    {
+        return mSquelchTailMs;
+    }
+
+    /**
+     * Sets the squelch tail duration in milliseconds.
+     * @param tailMs tail duration (0-500ms)
+     */
+    public void setSquelchTailMs(int tailMs)
+    {
+        if(tailMs < 0 || tailMs > 500)
+        {
+            throw new IllegalArgumentException("Squelch tail must be between 0 and 500ms: " + tailMs);
+        }
+        mSquelchTailMs = tailMs;
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoder.java
@@ -67,6 +67,7 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
     private Listener<DecoderStateEvent> mDecoderStateEventListener;
     private RealResampler mResampler;
     private final double mChannelBandwidth;
+    private final int mSquelchTailMs;
 
     /**
      * Constructs an instance
@@ -79,6 +80,7 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
 
         //Save channel bandwidth to setup channel baseband filter.
         mChannelBandwidth = config.getBandwidth().getValue();
+        mSquelchTailMs = config.getSquelchTailMs();
         mNoiseSquelch = new NoiseSquelch(config.getSquelchNoiseOpenThreshold(), config.getSquelchNoiseCloseThreshold(),
                 config.getSquelchHysteresisOpenThreshold(), config.getSquelchHysteresisCloseThreshold());
 
@@ -356,6 +358,7 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
         }
 
         mNoiseSquelch.setSampleRate(decimatedSampleRate);
+        mNoiseSquelch.setSquelchTail(mSquelchTailMs, decimatedSampleRate);
 
         int passBandStop = (int) (mChannelBandwidth * .8);
         int stopBandStart = (int) mChannelBandwidth;


### PR DESCRIPTION
- Adds squelch tail setting in NBFM channel Decoder
- Variable 0-500ms in 10ms increments
- Gives a more realistic squelch crash sound by holding squelch open briefly after radio traffic stops

Mostly a QoL improvement to make railroad scanner traffic sound more radio-esque