### PR TITLE
Add P25P1 Decoder NAC channel filter

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P1ConfigurationEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/channel/P25P1ConfigurationEditor.java
@@ -45,6 +45,7 @@ import javafx.geometry.Insets;
 import javafx.scene.control.Label;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.TextField;
 import javafx.scene.control.TitledPane;
 import javafx.scene.control.Toggle;
 import javafx.scene.control.ToggleButton;
@@ -74,6 +75,8 @@ public class P25P1ConfigurationEditor extends ChannelConfigurationEditor
     private SegmentedButton mModulationSegmentedButton;
     private ToggleButton mC4FMToggleButton;
     private ToggleButton mLSMToggleButton;
+    private TextField mNacFilterField;
+    private ToggleSwitch mNacFilterEnable;
 
     /**
      * Constructs an instance
@@ -148,6 +151,22 @@ public class P25P1ConfigurationEditor extends ChannelConfigurationEditor
             Label modulationHelpLabel = new Label("C4FM: repeaters and non-simulcast trunked systems.  LSM: simulcast trunked systems.");
             GridPane.setConstraints(modulationHelpLabel, 0, 1, 6, 1);
             gridPane.getChildren().add(modulationHelpLabel);
+
+            // NAC Filter row
+            GridPane.setConstraints(getNacFilterEnable(), 0, 2);
+            gridPane.getChildren().add(getNacFilterEnable());
+
+            Label nacFilterLabel = new Label("NAC Filter");
+            GridPane.setHalignment(nacFilterLabel, HPos.LEFT);
+            GridPane.setConstraints(nacFilterLabel, 1, 2);
+            gridPane.getChildren().add(nacFilterLabel);
+
+            GridPane.setConstraints(getNacFilterField(), 2, 2);
+            gridPane.getChildren().add(getNacFilterField());
+
+            Label nacHelpLabel = new Label("Enter NAC in hex (e.g., 293) - only process traffic matching this NAC");
+            GridPane.setConstraints(nacHelpLabel, 3, 2, 3, 1);
+            gridPane.getChildren().add(nacHelpLabel);
 
             mDecoderPane.setContent(gridPane);
         }
@@ -283,6 +302,36 @@ public class P25P1ConfigurationEditor extends ChannelConfigurationEditor
         return mIgnoreDataCallsButton;
     }
 
+    private ToggleSwitch getNacFilterEnable()
+    {
+        if(mNacFilterEnable == null)
+        {
+            mNacFilterEnable = new ToggleSwitch();
+            mNacFilterEnable.setDisable(true);
+            mNacFilterEnable.setTooltip(new Tooltip("Enable NAC filtering - only process traffic with matching NAC"));
+            mNacFilterEnable.selectedProperty().addListener((observable, oldValue, newValue) -> {
+                modifiedProperty().set(true);
+                getNacFilterField().setDisable(!newValue);
+            });
+        }
+
+        return mNacFilterEnable;
+    }
+
+    private TextField getNacFilterField()
+    {
+        if(mNacFilterField == null)
+        {
+            mNacFilterField = new TextField();
+            mNacFilterField.setDisable(true);
+            mNacFilterField.setPrefWidth(80);
+            mNacFilterField.setTooltip(new Tooltip("NAC value in hexadecimal (000-FFF)"));
+            mNacFilterField.textProperty().addListener((observable, oldValue, newValue) -> modifiedProperty().set(true));
+        }
+
+        return mNacFilterField;
+    }
+
     private Spinner<Integer> getTrafficChannelPoolSizeSpinner()
     {
         if(mTrafficChannelPoolSizeSpinner == null)
@@ -326,6 +375,7 @@ public class P25P1ConfigurationEditor extends ChannelConfigurationEditor
     {
         getIgnoreDataCallsButton().setDisable(config == null);
         getTrafficChannelPoolSizeSpinner().setDisable(config == null);
+        getNacFilterEnable().setDisable(config == null);
 
         if(config instanceof DecodeConfigP25Phase1)
         {
@@ -342,11 +392,28 @@ public class P25P1ConfigurationEditor extends ChannelConfigurationEditor
                 getC4FMToggleButton().setSelected(false);
                 getLSMToggleButton().setSelected(true);
             }
+
+            // NAC Filter
+            if(decodeConfig.hasNacFilter())
+            {
+                getNacFilterEnable().setSelected(true);
+                getNacFilterField().setDisable(false);
+                getNacFilterField().setText(String.format("%03X", decodeConfig.getNacFilter()));
+            }
+            else
+            {
+                getNacFilterEnable().setSelected(false);
+                getNacFilterField().setDisable(true);
+                getNacFilterField().setText("");
+            }
         }
         else
         {
             getIgnoreDataCallsButton().setSelected(false);
             getTrafficChannelPoolSizeSpinner().getValueFactory().setValue(0);
+            getNacFilterEnable().setSelected(false);
+            getNacFilterField().setDisable(true);
+            getNacFilterField().setText("");
         }
     }
 
@@ -367,6 +434,32 @@ public class P25P1ConfigurationEditor extends ChannelConfigurationEditor
         config.setIgnoreDataCalls(getIgnoreDataCallsButton().isSelected());
         config.setTrafficChannelPoolSize(getTrafficChannelPoolSizeSpinner().getValue());
         config.setModulation(getC4FMToggleButton().isSelected() ? Modulation.C4FM : Modulation.CQPSK);
+
+        // NAC Filter
+        if(getNacFilterEnable().isSelected() && !getNacFilterField().getText().isEmpty())
+        {
+            try
+            {
+                int nac = Integer.parseInt(getNacFilterField().getText().trim(), 16);
+                if(nac >= 0 && nac <= 0xFFF)
+                {
+                    config.setNacFilter(nac);
+                }
+                else
+                {
+                    config.setNacFilter(null);
+                }
+            }
+            catch(NumberFormatException e)
+            {
+                config.setNacFilter(null);
+            }
+        }
+        else
+        {
+            config.setNacFilter(null);
+        }
+
         getItem().setDecodeConfiguration(config);
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
+++ b/src/main/java/io/github/dsheirer/module/decode/DecoderFactory.java
@@ -302,7 +302,12 @@ public class DecoderFactory
             mLog.warn("Expected non-null traffic channel manager for channel " + channel.getName());
         }
 
-        modules.add(new P25P1AudioModule(userPreferences, aliasList));
+        P25P1AudioModule p25P1AudioModule = new P25P1AudioModule(userPreferences, aliasList);
+        if(channel.getDecodeConfiguration() instanceof DecodeConfigP25Phase1 p25Phase1Config)
+        {
+            p25P1AudioModule.setNacFilter(p25Phase1Config.getNacFilter());
+        }
+        modules.add(p25P1AudioModule);
 
         //Add a channel rotation monitor when we have multiple control channel frequencies specified
         if(channel.getSourceConfiguration() instanceof SourceConfigTunerMultipleFrequency sctmf &&

--- a/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P1AudioModule.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/audio/P25P1AudioModule.java
@@ -24,6 +24,8 @@ import io.github.dsheirer.audio.squelch.SquelchState;
 import io.github.dsheirer.audio.squelch.SquelchStateEvent;
 import io.github.dsheirer.dsp.gain.NonClippingGain;
 import io.github.dsheirer.message.IMessage;
+import io.github.dsheirer.module.decode.p25.identifier.APCO25Nac;
+import io.github.dsheirer.module.decode.p25.phase1.message.P25P1Message;
 import io.github.dsheirer.module.decode.p25.phase1.message.hdu.HDUMessage;
 import io.github.dsheirer.module.decode.p25.phase1.message.ldu.LDU1Message;
 import io.github.dsheirer.module.decode.p25.phase1.message.ldu.LDU2Message;
@@ -41,10 +43,25 @@ public class P25P1AudioModule extends ImbeAudioModule
     private SquelchStateListener mSquelchStateListener = new SquelchStateListener();
     private NonClippingGain mGain = new NonClippingGain(5.0f, 0.95f);
     private List<LDUMessage> mCachedLDUMessages = new ArrayList<>();
+    private Integer mNacFilter = null;
 
     public P25P1AudioModule(UserPreferences userPreferences, AliasList aliasList)
     {
         super(userPreferences, aliasList);
+    }
+
+    /**
+     * Sets the NAC filter value. When set to a positive value, voice/header frames whose decoded NAC does not match
+     * are dropped before audio decoding, so that co-channel traffic with a different NAC is not voiced into this
+     * call's audio segment. This mirrors the NAC filter applied in P25P1DecoderState, but is required separately here
+     * because the audio module receives the message stream in parallel with the decoder state - the decoder-state
+     * filter alone does not gate the audio path.
+     *
+     * @param nacFilter to match, or null/zero to disable audio-path NAC filtering.
+     */
+    public void setNacFilter(Integer nacFilter)
+    {
+        mNacFilter = nacFilter;
     }
 
     @Override
@@ -79,6 +96,18 @@ public class P25P1AudioModule extends ImbeAudioModule
      */
     public void receive(IMessage message)
     {
+        //NAC gate: when a NAC filter is configured, drop voice/header frames whose decoded NAC does not match so
+        //that co-channel traffic with a different NAC is not decoded into this call's audio. Frames whose NID did
+        //not cleanly decode to a NAC (interferer collisions, deep fades) fall through and are passed, matching the
+        //decoder-state filter semantics, to avoid choppy audio on a legitimate single-transmitter call.
+        if(mNacFilter != null && mNacFilter > 0 && message instanceof P25P1Message p25Message)
+        {
+            if(p25Message.getNAC() instanceof APCO25Nac nac && nac.getValue() != mNacFilter.intValue())
+            {
+                return;
+            }
+        }
+
         if(hasAudioCodec())
         {
             if(mEncryptedCallStateEstablished)

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/DecodeConfigP25.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/DecodeConfigP25.java
@@ -18,7 +18,7 @@
  */
 package io.github.dsheirer.module.decode.p25.phase1;
 
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -34,6 +34,7 @@ public abstract class DecodeConfigP25 extends DecodeConfiguration
 {
     private int mTrafficChannelPoolSize = TRAFFIC_CHANNEL_LIMIT_DEFAULT;
     private boolean mIgnoreDataCalls = false;
+    private Integer mNacFilter = null;
 
     public DecodeConfigP25()
     {
@@ -49,7 +50,6 @@ public abstract class DecodeConfigP25 extends DecodeConfiguration
     {
         mIgnoreDataCalls = ignore;
     }
-
 
     @JacksonXmlProperty(isAttribute = true, localName = "traffic_channel_pool_size")
     public int getTrafficChannelPoolSize()
@@ -68,5 +68,34 @@ public abstract class DecodeConfigP25 extends DecodeConfiguration
     public void setTrafficChannelPoolSize(int size)
     {
         mTrafficChannelPoolSize = size;
+    }
+
+    /**
+     * NAC filter value. When set, only messages with matching NAC will be processed.
+     * @return NAC filter value or null if disabled
+     */
+    @JacksonXmlProperty(isAttribute = true, localName = "nac_filter")
+    public Integer getNacFilter()
+    {
+        return mNacFilter;
+    }
+
+    /**
+     * Sets the NAC filter value.
+     * @param nac to filter on, or null to disable filtering
+     */
+    public void setNacFilter(Integer nac)
+    {
+        mNacFilter = nac;
+    }
+
+    /**
+     * Indicates if NAC filtering is enabled.
+     * @return true if a NAC filter is configured
+     */
+    @JsonIgnore
+    public boolean hasNacFilter()
+    {
+        return mNacFilter != null && mNacFilter > 0;
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderState.java
@@ -57,6 +57,7 @@ import io.github.dsheirer.module.decode.p25.IServiceOptionsProvider;
 import io.github.dsheirer.module.decode.p25.P25DecodeEvent;
 import io.github.dsheirer.module.decode.p25.P25TrafficChannelManager;
 import io.github.dsheirer.module.decode.p25.identifier.channel.APCO25Channel;
+import io.github.dsheirer.module.decode.p25.identifier.APCO25Nac;
 import io.github.dsheirer.module.decode.p25.phase1.message.IFrequencyBand;
 import io.github.dsheirer.module.decode.p25.phase1.message.P25P1Message;
 import io.github.dsheirer.module.decode.p25.phase1.message.hdu.HDUMessage;
@@ -192,6 +193,7 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
     private final Listener<ChannelEvent> mChannelEventListener;
     private final P25TrafficChannelManager mTrafficChannelManager;
     private ServiceOptions mCurrentServiceOptions;
+    private final Integer mNacFilter;
 
     /**
      * Constructs an APCO-25 decoder state with an optional traffic channel manager.
@@ -201,7 +203,9 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
     public P25P1DecoderState(Channel channel, P25TrafficChannelManager trafficChannelManager)
     {
         mChannel = channel;
-        mModulation = ((DecodeConfigP25Phase1)channel.getDecodeConfiguration()).getModulation();
+        DecodeConfigP25Phase1 config = (DecodeConfigP25Phase1)channel.getDecodeConfiguration();
+        mModulation = config.getModulation();
+        mNacFilter = config.getNacFilter();
         mNetworkConfigurationMonitor = new P25P1NetworkConfigurationMonitor(mModulation);
 
         if(trafficChannelManager != null)
@@ -277,6 +281,20 @@ public class P25P1DecoderState extends DecoderState implements IChannelEventList
     {
         if(iMessage instanceof P25P1Message message)
         {
+            // NAC filtering - discard messages that don't match configured NAC
+            if(mNacFilter != null && mNacFilter > 0)
+            {
+                Identifier nacIdentifier = message.getNAC();
+                if(nacIdentifier instanceof APCO25Nac nac)
+                {
+                    if(nac.getValue() != mNacFilter.intValue())
+                    {
+                        // NAC doesn't match - discard this message
+                        return;
+                    }
+                }
+            }
+
             getIdentifierCollection().update(message.getNAC());
 
             switch(message.getDUID())


### PR DESCRIPTION
- Adds "NAC Filter" toggle to P25P1 decoder section
- Value in hex (000-FFF)
- Prevents channel locking on or passing audio if NAC does not match

Was made to reduce/eliminate trunking co-channel interference. Decoder still continues to run on that channel, but this should prevent any rogue/unintended audio from co-channels to pass (unknown if this would produce unintended side effects, yet..)

Open to constructive feedback
