### PR TITLE
Bugfix-#2383-audio-trapped-in-output-buffer-of-resampler

### DIFF
--- a/src/main/java/io/github/dsheirer/dsp/filter/resample/RealResampler.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/resample/RealResampler.java
@@ -40,6 +40,7 @@ public class RealResampler
     private Listener<float[]> mResampledListener;
     private BufferManager mBufferManager;
     private double mResampleFactor;
+    private boolean mLastBatch;
 
     /**
      * Constructs an instance.
@@ -107,6 +108,8 @@ public class RealResampler
      */
     public void resample(float[] samples, boolean lastBatch)
     {
+        // store state of lastBatch for buffer flushing in consumeOutput below
+        mLastBatch = lastBatch;
         mBufferManager.load(samples);
         mResampler.process(mResampleFactor, mBufferManager, lastBatch);
     }
@@ -191,6 +194,21 @@ public class RealResampler
                 mOutputBuffer.compact();
 
                 if(mResampledListener != null)
+                {
+                    mResampledListener.receive(resampled);
+                }
+            }
+            // if this is the last batch of audio being processed by the resampler and there are still
+            //  samples remaining in the buffer, pad the block with zeros to make
+            //  mOutputArrayLength (usually 512) samples.
+            if(mLastBatch && mOutputBuffer.position() != 0)
+            {
+                float[] resampled = new float[mOutputArrayLength];
+                mOutputBuffer.flip();       // sets limit to remaining array length
+                mOutputBuffer.get(resampled, 0, mOutputBuffer.limit());     // unused are already zeroed, for padding
+                mOutputBuffer.compact();
+
+                if (mResampledListener != null)
                 {
                     mResampledListener.receive(resampled);
                 }

--- a/src/main/java/io/github/dsheirer/dsp/filter/resample/RealResampler.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/resample/RealResampler.java
@@ -37,7 +37,6 @@ public class RealResampler
     private Listener<float[]> mResampledListener;
     private BufferManager mBufferManager;
     private double mResampleFactor;
-    private boolean mLastBatch;
 
     /**
      * Constructs an instance.
@@ -105,8 +104,6 @@ public class RealResampler
      */
     public void resample(float[] samples, boolean lastBatch)
     {
-        // store state of lastBatch for buffer flushing in consumeOutput below
-        mLastBatch = lastBatch;
         mBufferManager.load(samples);
         mResampler.process(mResampleFactor, mBufferManager, lastBatch);
 
@@ -234,21 +231,6 @@ public class RealResampler
             if(mResampledListener != null)
             {
                 mResampledListener.receive(resampled);
-            }
-            // if this is the last batch of audio being processed by the resampler and there are still
-            //  samples remaining in the buffer, pad the block with zeros to make
-            //  mOutputArrayLength (usually 512) samples.
-            if(mLastBatch && mOutputBuffer.position() != 0)
-            {
-                float[] resampled = new float[mOutputArrayLength];
-                mOutputBuffer.flip();       // sets limit to remaining array length
-                mOutputBuffer.get(resampled, 0, mOutputBuffer.limit());     // unused are already zeroed, for padding
-                mOutputBuffer.compact();
-
-                if (mResampledListener != null)
-                {
-                    mResampledListener.receive(resampled);
-                }
             }
         }
     }

--- a/src/main/java/io/github/dsheirer/dsp/filter/resample/RealResampler.java
+++ b/src/main/java/io/github/dsheirer/dsp/filter/resample/RealResampler.java
@@ -21,8 +21,6 @@ package io.github.dsheirer.dsp.filter.resample;
 import com.laszlosystems.libresample4j.Resampler;
 import com.laszlosystems.libresample4j.SampleBuffers;
 import io.github.dsheirer.sample.Listener;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
@@ -34,7 +32,6 @@ import java.util.List;
  */
 public class RealResampler
 {
-    protected static final Logger mLog = LoggerFactory.getLogger(RealResampler.class);
 
     private Resampler mResampler;
     private Listener<float[]> mResampledListener;
@@ -109,6 +106,19 @@ public class RealResampler
     {
         mBufferManager.load(samples);
         mResampler.process(mResampleFactor, mBufferManager, lastBatch);
+
+        if(lastBatch)
+        {
+            mBufferManager.flushPartialOutput();
+        }
+    }
+
+    /**
+     * Flushes any buffered resampler output for the current stream.
+     */
+    public void flush()
+    {
+        resample(new float[0], true);
     }
 
     /**
@@ -181,19 +191,46 @@ public class RealResampler
         public void consumeOutput(float[] samples, int offset, int length)
         {
             mOutputBuffer.put(samples, offset, length);
+            dispatchFullOutputBuffers();
+        }
 
+        /**
+         * Dispatches any complete resampled output buffers.
+         */
+        private void dispatchFullOutputBuffers()
+        {
             while(mOutputBuffer.position() > mOutputArrayLength)
             {
-                float[] resampled = new float[mOutputArrayLength];
+                dispatchOutputBuffer(mOutputArrayLength);
+            }
+        }
 
-                mOutputBuffer.flip();
-                mOutputBuffer.get(resampled);
-                mOutputBuffer.compact();
+        /**
+         * Flushes any remaining partial output by zero-padding to a full output buffer length.
+         */
+        public void flushPartialOutput()
+        {
+            if(mOutputBuffer.position() > 0)
+            {
+                dispatchOutputBuffer(mOutputBuffer.position());
+            }
+        }
 
-                if(mResampledListener != null)
-                {
-                    mResampledListener.receive(resampled);
-                }
+        /**
+         * Dispatches the requested number of queued output samples, zero-padding the remainder of the fixed-size
+         * output block when fewer than {@code mOutputArrayLength} samples are available.
+         */
+        private void dispatchOutputBuffer(int sampleCount)
+        {
+            float[] resampled = new float[mOutputArrayLength];
+
+            mOutputBuffer.flip();
+            mOutputBuffer.get(resampled, 0, sampleCount);
+            mOutputBuffer.compact();
+
+            if(mResampledListener != null)
+            {
+                mResampledListener.receive(resampled);
             }
         }
     }

--- a/src/main/java/io/github/dsheirer/dsp/squelch/NoiseSquelch.java
+++ b/src/main/java/io/github/dsheirer/dsp/squelch/NoiseSquelch.java
@@ -86,6 +86,10 @@ public class NoiseSquelch implements INoiseSquelchController
      */
     public boolean isSquelched()
     {
+        if(mSquelchOverride)
+        {
+            return false;
+        }
         return mSquelch;
     }
 

--- a/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoder.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nbfm/NBFMDecoder.java
@@ -84,8 +84,18 @@ public class NBFMDecoder extends SquelchControlDecoder implements ISourceEventLi
 
         //Send squelch controlled audio to the resampler and notify the decoder state that the call continues.
         mNoiseSquelch.setAudioListener(audio -> {
-            mResampler.resample(audio);
-            notifyCallContinuation();
+            // if squelch is closing (it hasn't propagated yet to mute the audio)
+            //  call the resampler with lastBatch set to true. This will zero pad the input buffer and ensure
+            //  the output buffer gets emptied.
+            if(mNoiseSquelch.isSquelched())
+            {
+                mResampler.resample(audio, true);
+            }
+            else
+            {
+                mResampler.resample(audio);     // this method will set lastBatch to false
+                notifyCallContinuation();
+            }
         });
 
         //Notify the decoder state of call starts and ends


### PR DESCRIPTION
Fixes #2383.

Resampler already implements a lastBatch parameter, which will pad the unused portion of the input buffer with zeros. Extended that function to the output buffer to be sure no audio samples are left in the buffer. 

The RealResampler is used by a number of functions in SDRTrunk.

Tested with:
MP3 resampling
NBFM/noiseSquelch decoding

AM demodulator will be left as is for now. I would like to address resampler issues and other issues in #2301 at a later date.

AFSK1200: I have no way to test this. 