### PR TITLE
NXDN: traffic channel alias resolution and SCRAMBLE brute-force decryption

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/nxdn/NXDNTrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nxdn/NXDNTrafficChannelManager.java
@@ -29,6 +29,7 @@ import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.identifier.IdentifierCollection;
 import io.github.dsheirer.identifier.MutableIdentifierCollection;
 import io.github.dsheirer.identifier.alias.TalkerAliasManager;
+import io.github.dsheirer.identifier.configuration.AliasListConfigurationIdentifier;
 import io.github.dsheirer.identifier.encryption.EncryptionKeyIdentifier;
 import io.github.dsheirer.identifier.radio.RadioIdentifier;
 import io.github.dsheirer.module.decode.event.DecodeEvent;
@@ -291,6 +292,11 @@ public class NXDNTrafficChannelManager extends TrafficChannelManager implements 
             {
                 NXDNChannelEventTracker tracker = getTrackerRemoveIfStale(channel.getDownlinkFrequency(), timestamp);
                 MutableIdentifierCollection ic = new MutableIdentifierCollection(identifiers);
+                //Include the parent channel alias list so the event logger can resolve TO aliases
+                if(mParentChannel.getAliasListName() != null && !mParentChannel.getAliasListName().isEmpty())
+                {
+                    ic.update(AliasListConfigurationIdentifier.create(mParentChannel.getAliasListName()));
+                }
                 if(tracker != null)
                 {
                     if(tracker.isSameCallCheckingToAndFrom(ic, timestamp))
@@ -495,6 +501,11 @@ public class NXDNTrafficChannelManager extends TrafficChannelManager implements 
             NXDNChannelEventTracker tracker = getTrackerRemoveIfStale(frequency, timestamp);
             MutableIdentifierCollection ic = new MutableIdentifierCollection(identifiers);
             mTalkerAliasManager.enrich(ic);
+            //Include the parent channel alias list so the event logger can resolve TO aliases for group calls
+            if(mParentChannel.getAliasListName() != null && !mParentChannel.getAliasListName().isEmpty())
+            {
+                ic.update(AliasListConfigurationIdentifier.create(mParentChannel.getAliasListName()));
+            }
             if(tracker != null)
             {
                 if(tracker.isSameCallCheckingToAndFrom(ic, timestamp))

--- a/src/main/java/io/github/dsheirer/module/decode/nxdn/audio/NXDNAudioModule.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nxdn/audio/NXDNAudioModule.java
@@ -30,22 +30,66 @@ import io.github.dsheirer.module.decode.nxdn.layer3.call.TransmissionRelease;
 import io.github.dsheirer.module.decode.nxdn.layer3.call.VoiceCall;
 import io.github.dsheirer.module.decode.nxdn.layer3.call.VoiceCallWithOptionalLocation;
 import io.github.dsheirer.module.decode.nxdn.layer3.type.AudioCodec;
+import io.github.dsheirer.module.decode.nxdn.layer3.type.CipherType;
 import io.github.dsheirer.preference.UserPreferences;
 import io.github.dsheirer.sample.Listener;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import jmbe.iface.IAudioCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * NXDN AMBE audio module
+ * NXDN AMBE audio module with SCRAMBLE cipher brute-force support.
+ *
+ * For unencrypted calls, audio is decoded and played in real-time.
+ * For SCRAMBLE-encrypted calls:
+ *   - If the key for this key-ID is already known (from a previous brute force), decryption
+ *     happens in real-time and audio is played live.
+ *   - If the key is unknown, frames are buffered. After the call ends a background brute force
+ *     tries all 32767 possible 15-bit keys. The key with the highest decoded audio energy is
+ *     stored in a per-session cache so subsequent calls with the same key-ID play immediately.
  */
 public class NXDNAudioModule extends AmbeAudioModule
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(NXDNAudioModule.class);
+
+    /** Maximum number of encrypted frames to buffer for post-call brute force. */
+    private static final int MAX_BUFFERED_FRAMES = 200;
+
+    /** Minimum RMS energy (per sample) for a decoded frame to be considered non-silence. */
+    private static final float MIN_ENERGY_THRESHOLD = 0.001f;
+
+    /** Session-level cache: keyId → scrambler key.  Shared across all audio module instances. */
+    private static final Map<Integer, Integer> sScrambleKeyCache = new HashMap<>();
+
+    private static final ExecutorService sBruteForceExecutor =
+            Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r, "NXDN-BruteForce");
+                t.setDaemon(true);
+                return t;
+            });
+
     private final SquelchStateListener mSquelchStateListener = new SquelchStateListener();
     private final NonClippingGain mGain = new NonClippingGain(5.0f, 0.95f);
     private final List<Audio> mCachedAudioMessages = new ArrayList<>();
+
+    /** Encrypted frames buffered for post-call brute force. */
+    private final List<byte[]> mEncryptedFrameBuffer = new ArrayList<>();
+
     private boolean mEncryptedCall = false;
     private boolean mEncryptedCallStateEstablished = false;
     private AudioCodec mAudioCodec;
+    private CipherType mCipherType = CipherType.UNENCRYPTED;
+    private int mKeyId = 0;
+
+    /** Live scrambler register state – valid only when mLiveDecryptionActive is true. */
+    private int[] mLiveRegister = new int[]{0};
+    private boolean mLiveDecryptionActive = false;
 
     /**
      * Constructs an instance
@@ -97,27 +141,79 @@ public class NXDNAudioModule extends AmbeAudioModule
             {
                 if(message instanceof VoiceCall voiceCall)
                 {
-                    mEncryptedCall = voiceCall.getEncryptionKeyIdentifier().isEncrypted();
-                    mEncryptedCallStateEstablished = true;
-                    mAudioCodec = voiceCall.getCallOption().getCodec();
-                    processCachedAudio();
+                    var encKey = voiceCall.getEncryptionKeyIdentifier();
+                    setupCallState(encKey.isEncrypted(),
+                            encKey.getValue() != null ? encKey.getValue().getAlgorithm() : 0,
+                            encKey.getValue() != null ? encKey.getValue().getKey() : 0,
+                            voiceCall.getCallOption().getCodec());
                 }
                 else if(message instanceof VoiceCallWithOptionalLocation voiceCall)
                 {
-                    mEncryptedCall = voiceCall.getEncryptionKeyIdentifier().isEncrypted();
-                    mEncryptedCallStateEstablished = true;
-                    mAudioCodec = voiceCall.getCallOption().getCodec();
-                    processCachedAudio();
+                    var encKey = voiceCall.getEncryptionKeyIdentifier();
+                    setupCallState(encKey.isEncrypted(),
+                            encKey.getValue() != null ? encKey.getValue().getAlgorithm() : 0,
+                            encKey.getValue() != null ? encKey.getValue().getKey() : 0,
+                            voiceCall.getCallOption().getCodec());
                 }
                 else if(message instanceof Disconnect || message instanceof TransmissionRelease)
                 {
-                    closeAudioSegment();
-                    mCachedAudioMessages.clear();
-                    mEncryptedCall = false;
-                    mEncryptedCallStateEstablished = false;
+                    handleCallEnd();
                 }
             }
         }
+    }
+
+    /**
+     * Sets up the call state once the VoiceCall message is received.
+     */
+    private void setupCallState(boolean encrypted, int algorithm, int keyId, AudioCodec codec)
+    {
+        mEncryptedCall = encrypted;
+        mEncryptedCallStateEstablished = true;
+        mAudioCodec = codec;
+        mCipherType = CipherType.fromValue(algorithm);
+        mKeyId = keyId;
+        mLiveDecryptionActive = false;
+
+        if(mEncryptedCall && mCipherType == CipherType.SCRAMBLE)
+        {
+            Integer cachedKey = sScrambleKeyCache.get(mKeyId);
+            if(cachedKey != null)
+            {
+                LOGGER.info("NXDN SCRAMBLE: using cached key {} for key-ID {}", cachedKey, mKeyId);
+                mLiveRegister[0] = cachedKey & 0x7FFF;
+                mLiveDecryptionActive = true;
+            }
+            else
+            {
+                LOGGER.info("NXDN SCRAMBLE: key-ID {} unknown – buffering frames for brute force", mKeyId);
+            }
+        }
+
+        processCachedAudio();
+    }
+
+    /**
+     * Triggers end-of-call cleanup and, for unsolved SCRAMBLE calls, a background brute force.
+     */
+    private void handleCallEnd()
+    {
+        if(mEncryptedCall && mCipherType == CipherType.SCRAMBLE && !mLiveDecryptionActive
+                && !mEncryptedFrameBuffer.isEmpty())
+        {
+            List<byte[]> framesToCrack = new ArrayList<>(mEncryptedFrameBuffer);
+            int keyIdForCrack = mKeyId;
+            IAudioCodec codec = getAudioCodec();
+
+            sBruteForceExecutor.submit(() -> bruteForce(framesToCrack, keyIdForCrack, codec));
+        }
+
+        closeAudioSegment();
+        mCachedAudioMessages.clear();
+        mEncryptedFrameBuffer.clear();
+        mEncryptedCall = false;
+        mEncryptedCallStateEstablished = false;
+        mLiveDecryptionActive = false;
     }
 
     /**
@@ -134,12 +230,20 @@ public class NXDNAudioModule extends AmbeAudioModule
     }
 
     /**
-     * Processes an audio packet by decoding the IMBE audio frames and rebroadcasting them as PCM audio packets.
+     * Processes an audio packet.  For unencrypted or live-decryptable SCRAMBLE calls the AMBE frames
+     * are decoded and sent downstream.  For buffered-but-not-yet-cracked SCRAMBLE calls the raw
+     * encrypted frames are stored for post-call brute force.
      */
     private void processAudio(Audio audio)
     {
-        if(!mEncryptedCall && mAudioCodec != null && mAudioCodec.equals(AudioCodec.HALF_RATE)) //Full rate not yet supported
+        if(mAudioCodec == null || !mAudioCodec.equals(AudioCodec.HALF_RATE))
         {
+            return; // Full-rate not yet supported
+        }
+
+        if(!mEncryptedCall)
+        {
+            // Unencrypted – decode and play directly
             for(byte[] frame : audio.getAudioFrames())
             {
                 float[] generatedAudio = getAudioCodec().getAudio(frame);
@@ -147,16 +251,109 @@ public class NXDNAudioModule extends AmbeAudioModule
                 addAudio(generatedAudio);
             }
         }
-        else
+        else if(mCipherType == CipherType.SCRAMBLE && mLiveDecryptionActive)
         {
-            //Encrypted audio processing not supported
+            // Known key – decrypt and play in real-time
+            for(byte[] frame : audio.getAudioFrames())
+            {
+                byte[] decrypted = NXDNVoiceScrambler.descrambleFrame(frame, mLiveRegister);
+                float[] generatedAudio = getAudioCodec().getAudio(decrypted);
+                generatedAudio = mGain.apply(generatedAudio);
+                addAudio(generatedAudio);
+            }
+        }
+        else if(mCipherType == CipherType.SCRAMBLE)
+        {
+            // Unknown key – buffer frames for post-call brute force
+            for(byte[] frame : audio.getAudioFrames())
+            {
+                if(mEncryptedFrameBuffer.size() < MAX_BUFFERED_FRAMES)
+                {
+                    mEncryptedFrameBuffer.add(frame.clone());
+                }
+            }
         }
     }
 
     /**
-     * Wrapper for squelch state to process end of call actions.  At call end the encrypted call state established
-     * flag is reset so that the encrypted audio state for the next call can be properly detected and we send an
-     * END audio packet so that downstream processors like the audio recorder can properly close out a call sequence.
+     * Background brute force: tries all 32767 possible 15-bit SCRAMBLE keys against the buffered
+     * encrypted frames.  Decodes several frames per key with the JMBE codec and picks the key whose
+     * decoded audio has the highest RMS energy (i.e. sounds most like speech).
+     *
+     * On success the key is stored in the session cache so future calls with the same key-ID play live.
+     *
+     * @param frames      buffered encrypted AMBE frames from the call
+     * @param keyId       key identifier from the signaling layer
+     * @param codec       AMBE codec instance used to decode test frames
+     */
+    private static void bruteForce(List<byte[]> frames, int keyId, IAudioCodec codec)
+    {
+        if(frames.isEmpty() || codec == null)
+        {
+            return;
+        }
+
+        LOGGER.info("NXDN SCRAMBLE brute force starting for key-ID {} ({} frames buffered)…", keyId, frames.size());
+
+        // Use up to 5 frames near the start for faster testing
+        int testCount = Math.min(5, frames.size());
+        List<byte[]> testFrames = frames.subList(0, testCount);
+
+        int bestKey = -1;
+        float bestEnergy = 0.0f;
+
+        for(int key = 1; key <= 32767; key++)
+        {
+            List<byte[]> decrypted = NXDNVoiceScrambler.descramble(testFrames, key);
+
+            codec.reset();
+            float energy = 0.0f;
+            int sampleCount = 0;
+
+            for(byte[] frame : decrypted)
+            {
+                float[] audio = codec.getAudio(frame);
+                if(audio != null)
+                {
+                    for(float s : audio)
+                    {
+                        energy += s * s;
+                    }
+                    sampleCount += audio.length;
+                }
+            }
+
+            float rms = sampleCount > 0 ? (float)Math.sqrt(energy / sampleCount) : 0.0f;
+
+            if(rms > bestEnergy)
+            {
+                bestEnergy = rms;
+                bestKey = key;
+            }
+
+            if(key % 4096 == 0)
+            {
+                LOGGER.debug("NXDN SCRAMBLE brute force progress: {}/32767 (best so far key={} rms={:.4f})",
+                        key, bestKey, bestEnergy);
+            }
+        }
+
+        if(bestKey > 0 && bestEnergy >= MIN_ENERGY_THRESHOLD)
+        {
+            LOGGER.info("NXDN SCRAMBLE brute force FOUND key={} (RMS energy={}) for key-ID {}",
+                    bestKey, bestEnergy, keyId);
+            sScrambleKeyCache.put(keyId, bestKey);
+        }
+        else
+        {
+            LOGGER.warn("NXDN SCRAMBLE brute force for key-ID {} did not find a confident key " +
+                    "(best key={} RMS={}). Call may have been too short or cipher type mismatch.",
+                    keyId, bestKey, bestEnergy);
+        }
+    }
+
+    /**
+     * Wrapper for squelch state to process end of call actions.
      */
     public class SquelchStateListener implements Listener<SquelchStateEvent>
     {
@@ -165,10 +362,7 @@ public class NXDNAudioModule extends AmbeAudioModule
         {
             if(event.getSquelchState() == SquelchState.SQUELCH)
             {
-                closeAudioSegment();
-                mEncryptedCallStateEstablished = false;
-                mEncryptedCall = false;
-                mCachedAudioMessages.clear();
+                handleCallEnd();
             }
         }
     }


### PR DESCRIPTION
## Summary

Two improvements to the NXDN decoder on the `7-nxdn-decoder` branch:

**1. Alias resolution for traffic channel TO identifiers**

`NXDNTrafficChannelManager` now propagates the parent control channel's alias list name into the traffic channel's identifier collection. Previously, called-party (TO) talkgroup identifiers on traffic channels could not be resolved to aliases in the event logger because the alias list context was missing.

**2. SCRAMBLE cipher brute-force decryption**

`NXDNAudioModule` gains optional brute-force decryption for NXDN SCRAMBLE-encrypted calls (15-bit key space, 32,767 possible keys):

- **Unknown key**: audio frames are buffered during the call. After the call ends, a single background thread tries all 32,767 keys and picks the one that produces the highest RMS energy decoded audio (most speech-like result).
- **Known key** (cached from a previous brute force): decryption happens in real-time and audio plays live, identical to unencrypted calls.
- Keys are cached per key-ID for the session lifetime so repeat calls with the same key are handled immediately.
- Unencrypted calls are unaffected.

## Test plan

- [ ] Aliased talkgroup names appear correctly for TO identifiers in the NXDN event log
- [ ] Unencrypted NXDN audio decodes and plays normally
- [ ] SCRAMBLE-encrypted call: frames buffer during call, brute force runs after call ends, audio plays back
- [ ] Second SCRAMBLE call with same key-ID: plays in real-time (cached key)
- [ ] No performance impact on unencrypted calls from the brute-force code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)