### PR TITLE
Fix RTL-SDR and USB tuner detection on macOS without sudo

### DIFF
--- a/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
@@ -126,6 +126,7 @@ import io.github.dsheirer.source.tuner.sdrplay.rspDx.RspDxTunerConfiguration;
 import io.github.dsheirer.source.tuner.sdrplay.rspDx.RspDxTunerController;
 import io.github.dsheirer.source.tuner.sdrplay.rspDx.RspDxTunerEditor;
 import io.github.dsheirer.source.tuner.ui.TunerEditor;
+import io.github.dsheirer.source.tuner.usb.USBTunerController;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
@@ -377,14 +378,14 @@ public class TunerFactory
         {
             case AIRSPY:
             {
-                AirspyTunerController c = new AirspyTunerController(bus, portAddress, tunerErrorListener);
-                if(sharedContext != null) c.setSharedContext(sharedContext);
+                AirspyTunerController c = configureUsbTunerController(new AirspyTunerController(bus, portAddress,
+                        tunerErrorListener), tunerClass, sharedContext);
                 return new AirspyTuner(c, tunerErrorListener, channelizerType);
             }
             case AIRSPY_HF:
             {
-                AirspyHfTunerController c = new AirspyHfTunerController(bus, portAddress, tunerErrorListener);
-                if(sharedContext != null) c.setSharedContext(sharedContext);
+                AirspyHfTunerController c = configureUsbTunerController(new AirspyHfTunerController(bus, portAddress,
+                        tunerErrorListener), tunerClass, sharedContext);
                 return new AirspyHfTuner(c, tunerErrorListener, channelizerType);
             }
             case FUNCUBE_DONGLE_PRO:
@@ -409,25 +410,38 @@ public class TunerFactory
             }
             case HACKRF:
             {
-                HackRFTunerController c = new HackRFTunerController(bus, portAddress, tunerErrorListener);
-                if(sharedContext != null) c.setSharedContext(sharedContext);
+                HackRFTunerController c = configureUsbTunerController(new HackRFTunerController(bus, portAddress,
+                        tunerErrorListener), tunerClass, sharedContext);
                 return new HackRFTuner(c, tunerErrorListener, channelizerType);
             }
             case HYDRASDR:
             {
-                HydraSdrTunerController c = new HydraSdrTunerController(bus, portAddress, tunerErrorListener);
-                if(sharedContext != null) c.setSharedContext(sharedContext);
+                HydraSdrTunerController c = configureUsbTunerController(new HydraSdrTunerController(bus, portAddress,
+                        tunerErrorListener), tunerClass, sharedContext);
                 return new HydraSdrTuner(c, tunerErrorListener, channelizerType);
             }
             case RTL2832:
             {
-                RTL2832TunerController c = new RTL2832TunerController(bus, portAddress, tunerErrorListener);
-                if(sharedContext != null) c.setSharedContext(sharedContext);
+                RTL2832TunerController c = configureUsbTunerController(new RTL2832TunerController(bus, portAddress,
+                        tunerErrorListener), tunerClass, sharedContext);
                 return new RTL2832Tuner(c, tunerErrorListener, channelizerType);
             }
             default:
                 throw new SourceException("Unrecognized tuner class [" + tunerClass + "]");
         }
+    }
+
+    private static <T extends USBTunerController> T configureUsbTunerController(T controller, TunerClass tunerClass,
+                                                                                 Context sharedContext)
+    {
+        controller.setTunerClass(tunerClass);
+
+        if(sharedContext != null)
+        {
+            controller.setSharedContext(sharedContext);
+        }
+
+        return controller;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
@@ -130,6 +130,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.usb4java.Context;
 
 import javax.sound.sampled.TargetDataLine;
 
@@ -355,13 +356,39 @@ public class TunerFactory
     public static Tuner getUsbTuner(TunerClass tunerClass, String portAddress, int bus, ITunerErrorListener tunerErrorListener,
                                     ChannelizerType channelizerType) throws SourceException
     {
+        return getUsbTuner(tunerClass, portAddress, bus, tunerErrorListener, channelizerType, null);
+    }
+
+    /**
+     * Create a USB tuner, optionally sharing an existing libusb context.
+     * @param tunerClass to instantiate
+     * @param portAddress usb
+     * @param bus usb
+     * @param tunerErrorListener to listen for errors from the tuner
+     * @param channelizerType for the tuner
+     * @param sharedContext existing libusb context to reuse, or null to create a new one
+     * @return instantiated tuner
+     * @throws SourceException if the tuner class is unrecognized
+     */
+    public static Tuner getUsbTuner(TunerClass tunerClass, String portAddress, int bus, ITunerErrorListener tunerErrorListener,
+                                    ChannelizerType channelizerType, Context sharedContext) throws SourceException
+    {
         switch(tunerClass)
         {
             case AIRSPY:
-                return new AirspyTuner(new AirspyTunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
+            {
+                AirspyTunerController c = new AirspyTunerController(bus, portAddress, tunerErrorListener);
+                if(sharedContext != null) c.setSharedContext(sharedContext);
+                return new AirspyTuner(c, tunerErrorListener, channelizerType);
+            }
             case AIRSPY_HF:
-                return new AirspyHfTuner(new AirspyHfTunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
+            {
+                AirspyHfTunerController c = new AirspyHfTunerController(bus, portAddress, tunerErrorListener);
+                if(sharedContext != null) c.setSharedContext(sharedContext);
+                return new AirspyHfTuner(c, tunerErrorListener, channelizerType);
+            }
             case FUNCUBE_DONGLE_PRO:
+            {
                 TargetDataLine tdl1 = MixerManager.getTunerTargetDataLine(MixerTunerType.FUNCUBE_DONGLE_PRO);
                 if(tdl1 != null)
                 {
@@ -369,7 +396,9 @@ public class TunerFactory
                     return new FCDTuner(controller, tunerErrorListener);
                 }
                 throw new SourceException("Unable to find matching tuner sound card mixer");
+            }
             case FUNCUBE_DONGLE_PRO_PLUS:
+            {
                 TargetDataLine tdl2 = MixerManager.getTunerTargetDataLine(MixerTunerType.FUNCUBE_DONGLE_PRO_PLUS);
                 if(tdl2 != null)
                 {
@@ -377,12 +406,25 @@ public class TunerFactory
                     return new FCDTuner(controller, tunerErrorListener);
                 }
                 throw new SourceException("Unable to find matching tuner sound card mixer");
+            }
             case HACKRF:
-                return new HackRFTuner(new HackRFTunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
+            {
+                HackRFTunerController c = new HackRFTunerController(bus, portAddress, tunerErrorListener);
+                if(sharedContext != null) c.setSharedContext(sharedContext);
+                return new HackRFTuner(c, tunerErrorListener, channelizerType);
+            }
             case HYDRASDR:
-                return new HydraSdrTuner(new HydraSdrTunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
+            {
+                HydraSdrTunerController c = new HydraSdrTunerController(bus, portAddress, tunerErrorListener);
+                if(sharedContext != null) c.setSharedContext(sharedContext);
+                return new HydraSdrTuner(c, tunerErrorListener, channelizerType);
+            }
             case RTL2832:
-                return new RTL2832Tuner(new RTL2832TunerController(bus, portAddress, tunerErrorListener), tunerErrorListener, channelizerType);
+            {
+                RTL2832TunerController c = new RTL2832TunerController(bus, portAddress, tunerErrorListener);
+                if(sharedContext != null) c.setSharedContext(sharedContext);
+                return new RTL2832Tuner(c, tunerErrorListener, channelizerType);
+            }
             default:
                 throw new SourceException("Unrecognized tuner class [" + tunerClass + "]");
         }

--- a/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/TunerFactory.java
@@ -345,35 +345,24 @@ public class TunerFactory
     }
 
     /**
-     * Create a USB tuner
+     * Create a USB tuner using the application-owned libusb context.
      * @param tunerClass to instantiate
      * @param portAddress usb
      * @param bus usb
      * @param tunerErrorListener to listen for errors from the tuner
      * @param channelizerType for the tuner
-     * @return instantiated tuner
-     * @throws SourceException if the tuner class is unrecognized
-     */
-    public static Tuner getUsbTuner(TunerClass tunerClass, String portAddress, int bus, ITunerErrorListener tunerErrorListener,
-                                    ChannelizerType channelizerType) throws SourceException
-    {
-        return getUsbTuner(tunerClass, portAddress, bus, tunerErrorListener, channelizerType, null);
-    }
-
-    /**
-     * Create a USB tuner, optionally sharing an existing libusb context.
-     * @param tunerClass to instantiate
-     * @param portAddress usb
-     * @param bus usb
-     * @param tunerErrorListener to listen for errors from the tuner
-     * @param channelizerType for the tuner
-     * @param sharedContext existing libusb context to reuse, or null to create a new one
+     * @param sharedContext application-owned libusb context to reuse
      * @return instantiated tuner
      * @throws SourceException if the tuner class is unrecognized
      */
     public static Tuner getUsbTuner(TunerClass tunerClass, String portAddress, int bus, ITunerErrorListener tunerErrorListener,
                                     ChannelizerType channelizerType, Context sharedContext) throws SourceException
     {
+        if(sharedContext == null)
+        {
+            throw new SourceException("Shared libusb context is required for USB tuner [" + tunerClass + "]");
+        }
+
         switch(tunerClass)
         {
             case AIRSPY:
@@ -394,6 +383,7 @@ public class TunerFactory
                 if(tdl1 != null)
                 {
                     FCD1TunerController controller = new FCD1TunerController(tdl1, bus, portAddress, tunerErrorListener);
+                    controller.setSharedContext(sharedContext);
                     return new FCDTuner(controller, tunerErrorListener);
                 }
                 throw new SourceException("Unable to find matching tuner sound card mixer");
@@ -404,6 +394,7 @@ public class TunerFactory
                 if(tdl2 != null)
                 {
                     FCD2TunerController controller = new FCD2TunerController(tdl2, bus, portAddress, tunerErrorListener);
+                    controller.setSharedContext(sharedContext);
                     return new FCDTuner(controller, tunerErrorListener);
                 }
                 throw new SourceException("Unable to find matching tuner sound card mixer");
@@ -432,14 +423,10 @@ public class TunerFactory
     }
 
     private static <T extends USBTunerController> T configureUsbTunerController(T controller, TunerClass tunerClass,
-                                                                                 Context sharedContext)
+                                                                                 Context sharedContext) throws SourceException
     {
         controller.setTunerClass(tunerClass);
-
-        if(sharedContext != null)
-        {
-            controller.setSharedContext(sharedContext);
-        }
+        controller.setSharedContext(sharedContext);
 
         return controller;
     }

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
@@ -189,18 +189,11 @@ public abstract class FCDTunerController extends TunerController
                 int bus = LibUsb.getBusNumber(device);
                 int port = LibUsb.getPortNumber(device);
 
-                if(port > 0)
-                {
-                    String portAddress = TunerManager.getPortAddress(device);
+                String portAddress = TunerManager.getPortAddress(device);
 
-                    if(mBus == bus && mPortAddress != null && mPortAddress.equals(portAddress))
-                    {
-                        foundDevice = device;
-                    }
-                    else
-                    {
-                        LibUsb.unrefDevice(device);
-                    }
+                if(mBus == bus && mPortAddress != null && mPortAddress.equals(portAddress))
+                {
+                    foundDevice = device;
                 }
                 else
                 {

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
@@ -58,7 +58,7 @@ public abstract class FCDTunerController extends TunerController
 
     private int mBus;
     private String mPortAddress;
-    private Context mDeviceContext = new Context();
+    private Context mDeviceContext;
     private Device mDevice;
     private DeviceDescriptor mDeviceDescriptor = new DeviceDescriptor();
     private DeviceHandle mDeviceHandle = new DeviceHandle();
@@ -102,6 +102,15 @@ public abstract class FCDTunerController extends TunerController
                 new ComplexShortAdapter());
         mComplexMixer.setBufferSampleCount(getBufferSampleCount());
         mComplexMixer.setBufferListener(mNativeBufferBroadcaster);
+    }
+
+    /**
+     * Sets the application-owned libusb context from TunerManager.
+     * Must be called before start().
+     */
+    public void setSharedContext(Context context)
+    {
+        mDeviceContext = context;
     }
 
     @Override
@@ -225,16 +234,10 @@ public abstract class FCDTunerController extends TunerController
     {
         if(mDeviceContext == null)
         {
-            throw new SourceException("Device cannot be reused once it has been shutdown");
+            throw new SourceException("Shared libusb context is required before starting USB tuner");
         }
 
-        int status = LibUsb.init(mDeviceContext);
-
-        if(status != LibUsb.SUCCESS)
-        {
-            throw new SourceException("Can't initialize libusb library - " + LibUsb.errorName(status));
-        }
-
+        int status;
         mDevice = findDevice();
         mDeviceDescriptor = new DeviceDescriptor();
         status = LibUsb.getDeviceDescriptor(mDevice, mDeviceDescriptor);
@@ -331,7 +334,6 @@ public abstract class FCDTunerController extends TunerController
         mDeviceDescriptor = null;
         mDeviceHandle = null;
         mDevice = null;
-        LibUsb.exit(mDeviceContext);
         mDeviceContext = null;
     }
 

--- a/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/fcd/FCDTunerController.java
@@ -191,37 +191,50 @@ public abstract class FCDTunerController extends TunerController
         DeviceList deviceList = new DeviceList();
         int count = LibUsb.getDeviceList(mDeviceContext, deviceList);
 
-        if(count >= 0)
+        try
         {
-            for(Device device: deviceList)
+            if(count >= 0)
             {
-                int bus = LibUsb.getBusNumber(device);
-                int port = LibUsb.getPortNumber(device);
-
-                String portAddress = TunerManager.getPortAddress(device);
-
-                if(mBus == bus && mPortAddress != null && mPortAddress.equals(portAddress))
+                for(Device device: deviceList)
                 {
-                    foundDevice = device;
-                }
-                else
-                {
-                    LibUsb.unrefDevice(device);
+                    int bus = LibUsb.getBusNumber(device);
+                    int port = LibUsb.getPortNumber(device);
+
+                    String portAddress = TunerManager.getPortAddress(device);
+
+                    if(mBus == bus && mPortAddress != null && mPortAddress.equals(portAddress))
+                    {
+                        if(foundDevice != null)
+                        {
+                            LibUsb.unrefDevice(foundDevice);
+                        }
+
+                        foundDevice = device;
+                    }
+                    else
+                    {
+                        LibUsb.unrefDevice(device);
+                    }
                 }
             }
-        }
-        else
-        {
-            throw new SourceException("LibUsb couldn't discover USB device [" + mBus + ":" + mPortAddress +
-                    "] from device list" + (count < 0 ? " - error: " + LibUsb.errorName(count) : ""));
-        }
+            else
+            {
+                throw new SourceException("LibUsb couldn't discover USB device [" + mBus + ":" + mPortAddress +
+                        "] from device list" + (count < 0 ? " - error: " + LibUsb.errorName(count) : ""));
+            }
 
-        if(foundDevice == null)
-        {
-            throw new SourceException("LibUsb couldn't find the matching USB device");
-        }
+            if(foundDevice == null)
+            {
+                throw new SourceException("LibUsb couldn't find the matching USB device");
+            }
 
-        return foundDevice;
+            return foundDevice;
+        }
+        finally
+        {
+            // Individual device references are released during iteration; retain only the matching device for open().
+            LibUsb.freeDeviceList(deviceList, false);
+        }
     }
 
     /**
@@ -244,15 +257,26 @@ public abstract class FCDTunerController extends TunerController
 
         if(status != LibUsb.SUCCESS)
         {
+            LibUsb.unrefDevice(mDevice);
+            mDevice = null;
             mDeviceDescriptor = null;
             throw new SourceException("Can't obtain tuner's device descriptor - " + LibUsb.errorName(status));
         }
 
         mDeviceHandle = new DeviceHandle();
-        status = LibUsb.open(mDevice, mDeviceHandle);
+        try
+        {
+            status = LibUsb.open(mDevice, mDeviceHandle);
+        }
+        finally
+        {
+            // open() retains its own device reference when successful.
+            LibUsb.unrefDevice(mDevice);
+        }
 
         if(status != LibUsb.SUCCESS)
         {
+            mDevice = null;
             mDeviceHandle = null;
             mDeviceDescriptor = null;
 

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredUSBTuner.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/DiscoveredUSBTuner.java
@@ -25,6 +25,7 @@ import io.github.dsheirer.source.tuner.TunerClass;
 import io.github.dsheirer.source.tuner.TunerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.usb4java.Context;
 
 /**
  * A USB tuner that is discovered during the USB device traversal process that has a VID and PID that match a known
@@ -37,6 +38,7 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
     private int mBus;
     private String mPortAddress;
     private ChannelizerType mChannelizerType;
+    private Context mSharedLibUsbContext;
 
     /**
      * Constructs an instance
@@ -50,6 +52,14 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
         mBus = bus;
         mPortAddress = portAddress;
         mChannelizerType = channelizerType;
+    }
+
+    /**
+     * Sets the shared libusb context from TunerManager to avoid dual-context interference on macOS.
+     */
+    public void setSharedLibUsbContext(Context context)
+    {
+        mSharedLibUsbContext = context;
     }
 
     /**
@@ -104,7 +114,7 @@ public class DiscoveredUSBTuner extends DiscoveredTuner
         {
             try
             {
-                mTuner = TunerFactory.getUsbTuner(getTunerClass(), getPortAddress(), getBus(), this, mChannelizerType);
+                mTuner = TunerFactory.getUsbTuner(getTunerClass(), getPortAddress(), getBus(), this, mChannelizerType, mSharedLibUsbContext);
                 mTuner.start();
             }
             catch(SourceException se)

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/TunerManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/TunerManager.java
@@ -227,33 +227,32 @@ public class TunerManager implements IDiscoveredTunerStatusListener
                         int bus = LibUsb.getBusNumber(device);
                         int port = LibUsb.getPortNumber(device);
 
-                        if(port > 0)
+                        DeviceDescriptor deviceDescriptor = new DeviceDescriptor();
+                        int status = LibUsb.getDeviceDescriptor(device, deviceDescriptor);
+
+                        if(status == LibUsb.SUCCESS)
                         {
-                            DeviceDescriptor deviceDescriptor = new DeviceDescriptor();
-                            int status = LibUsb.getDeviceDescriptor(device, deviceDescriptor);
+                            TunerClass tunerClass = TunerClass.lookup(deviceDescriptor.idVendor(),
+                                    deviceDescriptor.idProduct());
 
-                            if(status == LibUsb.SUCCESS)
+                            String portAddress = getPortAddress(device);
+
+                            if(tunerClass.isSupportedUsbTuner())
                             {
-                                TunerClass tunerClass = TunerClass.lookup(deviceDescriptor.idVendor(),
-                                        deviceDescriptor.idProduct());
-
-                                String portAddress = getPortAddress(device);
-
-                                if(tunerClass.isSupportedUsbTuner())
-                                {
-                                    mLog.info("Discovered tuner at USB Bus [" + bus + "] Port [" + portAddress +
-                                            "] Tuner Class [" + tunerClass + "]");
-                                    ChannelizerType channelizerType = mUserPreferences.getTunerPreference().getChannelizerType();
-                                    DiscoveredUSBTuner discoveredUSBTuner = new DiscoveredUSBTuner(tunerClass, bus,
-                                            portAddress, channelizerType);
-                                    discoveredUSBTuners.add(discoveredUSBTuner);
-                                }
+                                mLog.info("Discovered tuner at USB Bus [" + bus + "] Port [" + portAddress +
+                                        "] Tuner Class [" + tunerClass + "]");
+                                ChannelizerType channelizerType = mUserPreferences.getTunerPreference().getChannelizerType();
+                                DiscoveredUSBTuner discoveredUSBTuner = new DiscoveredUSBTuner(tunerClass, bus,
+                                        portAddress, channelizerType);
+                                discoveredUSBTuner.setSharedLibUsbContext(mLibUsbApplicationContext);
+                                discoveredUSBTuners.add(discoveredUSBTuner);
                             }
-                            else
-                            {
-                                mLog.error("LibUsb - unable to get device descriptor for device on bus [" + bus +
-                                        "] port [" + port + "] - status [" + status + "] - " + LibUsb.errorName(status));
-                            }
+                        }
+                        else if(port > 0)
+                        {
+                            //Only log descriptor errors for non-root devices (port 0 = root hub, expected to fail)
+                            mLog.error("LibUsb - unable to get device descriptor for device on bus [" + bus +
+                                    "] port [" + port + "] - status [" + status + "] - " + LibUsb.errorName(status));
                         }
 
                         //Unref the device - it will be rediscovered under the device context when it is started
@@ -718,54 +717,51 @@ public class TunerManager implements IDiscoveredTunerStatusListener
         {
             int bus = LibUsb.getBusNumber(device);
             int port = LibUsb.getPortNumber(device);
+            String portAddress = getPortAddress(device);
 
-            if(port > 0)
+            switch(event)
             {
-                String portAddress = getPortAddress(device);
+                case LibUsb.HOTPLUG_EVENT_DEVICE_ARRIVED:
+                    DeviceDescriptor deviceDescriptor = new DeviceDescriptor();
+                    int status = LibUsb.getDeviceDescriptor(device, deviceDescriptor);
 
-                switch(event)
-                {
-                    case LibUsb.HOTPLUG_EVENT_DEVICE_ARRIVED:
-                        DeviceDescriptor deviceDescriptor = new DeviceDescriptor();
-                        int status = LibUsb.getDeviceDescriptor(device, deviceDescriptor);
+                    if(status == LibUsb.SUCCESS)
+                    {
+                        TunerClass tunerClass = TunerClass.lookup(deviceDescriptor.idVendor(), deviceDescriptor.idProduct());
 
-                        if(status == LibUsb.SUCCESS)
+                        if(tunerClass.isSupportedUsbTuner())
                         {
-                            TunerClass tunerClass = TunerClass.lookup(deviceDescriptor.idVendor(), deviceDescriptor.idProduct());
+                            mLog.info("Tuner plug-in detected at USB Bus [" + bus + "] Port [" + port +
+                                    "] Tuner Class [" + tunerClass + "]");
+                            ChannelizerType channelizerType = mUserPreferences.getTunerPreference().getChannelizerType();
+                            DiscoveredUSBTuner discoveredUSBTuner = new DiscoveredUSBTuner(tunerClass, bus,
+                                    portAddress, channelizerType);
+                            discoveredUSBTuner.setSharedLibUsbContext(mLibUsbApplicationContext);
 
-                            if(tunerClass.isSupportedUsbTuner())
+                            if(tunerClass.isFuncubeTuner())
                             {
-                                mLog.info("Tuner plug-in detected at USB Bus [" + bus + "] Port [" + port +
-                                        "] Tuner Class [" + tunerClass + "]");
-                                ChannelizerType channelizerType = mUserPreferences.getTunerPreference().getChannelizerType();
-                                DiscoveredUSBTuner discoveredUSBTuner = new DiscoveredUSBTuner(tunerClass, bus,
-                                        portAddress, channelizerType);
-
-                                if(tunerClass.isFuncubeTuner())
-                                {
-                                    //Funcube tuners take a few moments to init the sound card interface.  Delay adding
-                                    //the tuner so that it can be started correctly.
-                                    ThreadPool.SCHEDULED.schedule(() ->
-                                    {
-                                        addUsbTuner(discoveredUSBTuner);
-                                    }, 2, TimeUnit.SECONDS);
-                                }
-                                else
+                                //Funcube tuners take a few moments to init the sound card interface.  Delay adding
+                                //the tuner so that it can be started correctly.
+                                ThreadPool.SCHEDULED.schedule(() ->
                                 {
                                     addUsbTuner(discoveredUSBTuner);
-                                }
+                                }, 2, TimeUnit.SECONDS);
+                            }
+                            else
+                            {
+                                addUsbTuner(discoveredUSBTuner);
                             }
                         }
-                        break;
-                    case LibUsb.HOTPLUG_EVENT_DEVICE_LEFT:
-                        DiscoveredTuner removed = removeUsbTuner(bus, portAddress);
+                    }
+                    break;
+                case LibUsb.HOTPLUG_EVENT_DEVICE_LEFT:
+                    DiscoveredTuner removed = removeUsbTuner(bus, portAddress);
 
-                        if(removed != null)
-                        {
-                            mLog.info("Tuner Unplugged: " + removed.getId());
-                        }
-                        break;
-                }
+                    if(removed != null)
+                    {
+                        mLog.info("Tuner Unplugged: " + removed.getId());
+                    }
+                    break;
             }
 
             return HOTPLUG_CONTINUE_EVENT_SUPPORT;

--- a/src/main/java/io/github/dsheirer/source/tuner/manager/TunerManager.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/manager/TunerManager.java
@@ -48,8 +48,10 @@ import io.github.dsheirer.util.ThreadPool;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -75,7 +77,9 @@ public class TunerManager implements IDiscoveredTunerStatusListener
     private final TunerConfigurationManager mTunerConfigurationManager;
     private final HotplugEventSupport mHotplugEventSupport = new HotplugEventSupport();
     private final Context mLibUsbApplicationContext = new Context();
-    private boolean mLibUsbInitialized = false;
+    private final Object mDelayedFuncubeStartLock = new Object();
+    private final Map<String, ScheduledFuture<?>> mDelayedFuncubeStarts = new HashMap<>();
+    private volatile boolean mLibUsbInitialized = false;
     private SDRplay mSDRplay;
 
     /**
@@ -177,6 +181,20 @@ public class TunerManager implements IDiscoveredTunerStatusListener
      */
     public void stop()
     {
+        boolean libUsbInitialized;
+
+        synchronized(mDelayedFuncubeStartLock)
+        {
+            libUsbInitialized = mLibUsbInitialized;
+
+            if(libUsbInitialized)
+            {
+                mLibUsbInitialized = false;
+                cancelDelayedFuncubeStarts();
+                mHotplugEventSupport.stop();
+            }
+        }
+
         //Stop all tuners
         mDiscoveredTunerModel.releaseDiscoveredTuners();
 
@@ -188,11 +206,9 @@ public class TunerManager implements IDiscoveredTunerStatusListener
         }
 
         //Shutdown LibUsb
-        if(mLibUsbInitialized)
+        if(libUsbInitialized)
         {
-            mHotplugEventSupport.stop();
             LibUsb.exit(mLibUsbApplicationContext);
-            mLibUsbInitialized = false;
         }
     }
 
@@ -325,6 +341,98 @@ public class TunerManager implements IDiscoveredTunerStatusListener
     private DiscoveredTuner removeUsbTuner(int bus, String portAddress)
     {
         return mDiscoveredTunerModel.removeUsbTuner(bus, portAddress);
+    }
+
+    /**
+     * Schedules delayed Funcube startup and ties it to this manager's libusb lifecycle.
+     */
+    private void scheduleFuncubeTunerStart(DiscoveredUSBTuner discoveredUSBTuner)
+    {
+        String deviceKey = getUsbDeviceKey(discoveredUSBTuner.getBus(), discoveredUSBTuner.getPortAddress());
+
+        synchronized(mDelayedFuncubeStartLock)
+        {
+            if(!mLibUsbInitialized)
+            {
+                return;
+            }
+
+            ScheduledFuture<?> existing = mDelayedFuncubeStarts.remove(deviceKey);
+
+            if(existing != null)
+            {
+                existing.cancel(false);
+            }
+
+            DelayedFuncubeTunerStart delayedStart = new DelayedFuncubeTunerStart(deviceKey, discoveredUSBTuner);
+            ScheduledFuture<?> future = ThreadPool.SCHEDULED.schedule(delayedStart, 2, TimeUnit.SECONDS);
+            delayedStart.setFuture(future);
+            mDelayedFuncubeStarts.put(deviceKey, future);
+        }
+    }
+
+    /**
+     * Cancels a delayed Funcube startup for a USB device that has been unplugged.
+     */
+    private void cancelDelayedFuncubeStart(int bus, String portAddress)
+    {
+        synchronized(mDelayedFuncubeStartLock)
+        {
+            ScheduledFuture<?> future = mDelayedFuncubeStarts.remove(getUsbDeviceKey(bus, portAddress));
+
+            if(future != null)
+            {
+                future.cancel(false);
+            }
+        }
+    }
+
+    /**
+     * Cancels all delayed Funcube startups before the shared libusb context is released.
+     */
+    private void cancelDelayedFuncubeStarts()
+    {
+        for(ScheduledFuture<?> future: mDelayedFuncubeStarts.values())
+        {
+            future.cancel(false);
+        }
+
+        mDelayedFuncubeStarts.clear();
+    }
+
+    private String getUsbDeviceKey(int bus, String portAddress)
+    {
+        return bus + ":" + portAddress;
+    }
+
+    private class DelayedFuncubeTunerStart implements Runnable
+    {
+        private final String mDeviceKey;
+        private final DiscoveredUSBTuner mDiscoveredUSBTuner;
+        private ScheduledFuture<?> mFuture;
+
+        private DelayedFuncubeTunerStart(String deviceKey, DiscoveredUSBTuner discoveredUSBTuner)
+        {
+            mDeviceKey = deviceKey;
+            mDiscoveredUSBTuner = discoveredUSBTuner;
+        }
+
+        private void setFuture(ScheduledFuture<?> future)
+        {
+            mFuture = future;
+        }
+
+        @Override
+        public void run()
+        {
+            synchronized(mDelayedFuncubeStartLock)
+            {
+                if(mLibUsbInitialized && mDelayedFuncubeStarts.remove(mDeviceKey, mFuture))
+                {
+                    addUsbTuner(mDiscoveredUSBTuner);
+                }
+            }
+        }
     }
 
     /**
@@ -715,6 +823,11 @@ public class TunerManager implements IDiscoveredTunerStatusListener
         @Override
         public int processEvent(Context context, Device device, int event, Object userData)
         {
+            if(!mLibUsbInitialized)
+            {
+                return HOTPLUG_CONTINUE_EVENT_SUPPORT;
+            }
+
             int bus = LibUsb.getBusNumber(device);
             int port = LibUsb.getPortNumber(device);
             String portAddress = getPortAddress(device);
@@ -740,12 +853,8 @@ public class TunerManager implements IDiscoveredTunerStatusListener
 
                             if(tunerClass.isFuncubeTuner())
                             {
-                                //Funcube tuners take a few moments to init the sound card interface.  Delay adding
-                                //the tuner so that it can be started correctly.
-                                ThreadPool.SCHEDULED.schedule(() ->
-                                {
-                                    addUsbTuner(discoveredUSBTuner);
-                                }, 2, TimeUnit.SECONDS);
+                                //Funcube tuners take a few moments to init the sound card interface.
+                                scheduleFuncubeTunerStart(discoveredUSBTuner);
                             }
                             else
                             {
@@ -755,7 +864,14 @@ public class TunerManager implements IDiscoveredTunerStatusListener
                     }
                     break;
                 case LibUsb.HOTPLUG_EVENT_DEVICE_LEFT:
-                    DiscoveredTuner removed = removeUsbTuner(bus, portAddress);
+                    cancelDelayedFuncubeStart(bus, portAddress);
+
+                    DiscoveredTuner removed = null;
+
+                    if(mDiscoveredTunerModel.hasUsbTuner(bus, portAddress))
+                    {
+                        removed = removeUsbTuner(bus, portAddress);
+                    }
 
                     if(removed != null)
                     {

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -79,6 +79,12 @@ public class RTL2832TunerController extends USBTunerController
     }
 
     @Override
+    protected int getUSBVendorId()
+    {
+        return 0x0BDA; //Realtek - used to disambiguate when port addresses are empty (macOS)
+    }
+
+    @Override
     protected INativeBufferFactory getNativeBufferFactory()
     {
         return mNativeBufferFactory;
@@ -147,29 +153,11 @@ public class RTL2832TunerController extends USBTunerController
     @Override
     protected void deviceStart() throws SourceException
     {
-        //Perform dummy write to see if device needs reset
-        boolean resetRequired = false;
-
-        try
+        //Perform dummy write to see if device needs reset (skip on macOS - device is always fresh after start())
+        boolean isMacOS = System.getProperty("os.name", "").contains("Mac");
+        if(!isMacOS)
         {
-            writeRegister(Block.USB, Address.USB_SYSCTL, 0x09, 1);
-        }
-        catch(LibUsbException lue)
-        {
-            if(lue.getErrorCode() < 0)
-            {
-                resetRequired = true;
-            }
-            else
-            {
-                mLog.error("Error performing test write to RTL2832 device - " + LibUsb.errorName(lue.getErrorCode()));
-            }
-        }
-
-        if(resetRequired)
-        {
-            int status = LibUsb.resetDevice(getDeviceHandle());
-            mLog.info("Resetting device - status: " + LibUsb.errorName(status));
+            boolean resetRequired = false;
 
             try
             {
@@ -177,12 +165,36 @@ public class RTL2832TunerController extends USBTunerController
             }
             catch(LibUsbException lue)
             {
-                mLog.error("Couldnt' reset RTL2832 device - setting error");
-                throw new SourceException("unable to reset USB device - " + LibUsb.errorName(status));
+                if(lue.getErrorCode() < 0)
+                {
+                    resetRequired = true;
+                }
+                else
+                {
+                    mLog.error("Error performing test write to RTL2832 device - " + LibUsb.errorName(lue.getErrorCode()));
+                }
+            }
+
+            if(resetRequired)
+            {
+                int status = LibUsb.resetDevice(getDeviceHandle());
+                mLog.info("Resetting device - status: " + LibUsb.errorName(status));
+
+                try
+                {
+                    writeRegister(Block.USB, Address.USB_SYSCTL, 0x09, 1);
+                }
+                catch(LibUsbException lue)
+                {
+                    mLog.error("Couldnt' reset RTL2832 device - setting error");
+                    throw new SourceException("unable to reset USB device - " + LibUsb.errorName(status));
+                }
             }
         }
 
+        initBaseband();
 
+        //Read EEPROM after initBaseband() - the I2C bus must be initialized before EEPROM register writes succeed.
         byte[] eeprom = null;
 
         try
@@ -209,8 +221,6 @@ public class RTL2832TunerController extends USBTunerController
             mLog.error("error while constructing device descriptor using descriptor byte array " +
                 (eeprom == null ? "[null]" : Arrays.toString(eeprom)), e);
         }
-
-        initBaseband();
 
         TunerType tunerType = identifyTunerType();
 
@@ -1333,7 +1343,7 @@ public class RTL2832TunerController extends USBTunerController
 
         public String getVendorLabel()
         {
-            return mLabels.get(0);
+            return mLabels.size() > 0 ? mLabels.get(0) : "";
         }
 
         public String getProductID()
@@ -1344,7 +1354,7 @@ public class RTL2832TunerController extends USBTunerController
 
         public String getProductLabel()
         {
-            return mLabels.get(1);
+            return mLabels.size() > 1 ? mLabels.get(1) : "";
         }
 
         public boolean hasSerial()
@@ -1491,7 +1501,8 @@ public class RTL2832TunerController extends USBTunerController
          */
         public boolean isV4Dongle()
         {
-            return mController.getDescriptor().isRtlSdrV4();
+            Descriptor d = mController.getDescriptor();
+            return d != null && d.isRtlSdrV4();
         }
 
         /**

--- a/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/rtl/RTL2832TunerController.java
@@ -79,12 +79,6 @@ public class RTL2832TunerController extends USBTunerController
     }
 
     @Override
-    protected int getUSBVendorId()
-    {
-        return 0x0BDA; //Realtek - used to disambiguate when port addresses are empty (macOS)
-    }
-
-    @Override
     protected INativeBufferFactory getNativeBufferFactory()
     {
         return mNativeBufferFactory;

--- a/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
@@ -28,6 +28,7 @@ import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.manager.TunerManager;
 import io.github.dsheirer.util.ThreadPool;
 import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedTransferQueue;
@@ -59,6 +60,7 @@ public abstract class USBTunerController extends TunerController
     protected int mBus;
     protected String mPortAddress;
     private Context mDeviceContext = new Context();
+    private boolean mOwnsDeviceContext = true; //false when context is shared from TunerManager
     private Device mDevice;
     private DeviceHandle mDeviceHandle;
     private DeviceDescriptor mDeviceDescriptor;
@@ -106,9 +108,30 @@ public abstract class USBTunerController extends TunerController
     }
 
     /**
+     * Sets a shared libusb context from TunerManager instead of creating a new one.
+     * Using a shared context avoids dual-context interference on macOS where the first context
+     * caches device handles that block the second context from fully opening the device.
+     * Must be called before start().
+     */
+    public void setSharedContext(Context context)
+    {
+        mDeviceContext = context;
+        mOwnsDeviceContext = false;
+    }
+
+    /**
      * Tuner type for this USB controller
      */
     public abstract TunerType getTunerType();
+
+    /**
+     * USB Vendor ID (VID) for this tuner, used to disambiguate devices when port numbers are unavailable (e.g. macOS).
+     * Subclasses should override to return their specific VID. Returns -1 to skip VID filtering.
+     */
+    protected int getUSBVendorId()
+    {
+        return -1;
+    }
 
     /**
      * Factory for converting received streaming sample data into native buffers, as provided by sub-class.
@@ -150,11 +173,17 @@ public abstract class USBTunerController extends TunerController
             throw new SourceException("Device cannot be reused once it has been shutdown");
         }
 
-        int status = LibUsb.init(mDeviceContext);
+        boolean isMacOS = System.getProperty("os.name", "").contains("Mac");
+        int status = LibUsb.SUCCESS;
 
-        if(status != LibUsb.SUCCESS)
+        if(mOwnsDeviceContext)
         {
-            throw new SourceException("Can't initialize libusb library - " + LibUsb.errorName(status));
+            status = LibUsb.init(mDeviceContext);
+
+            if(status != LibUsb.SUCCESS)
+            {
+                throw new SourceException("Can't initialize libusb library - " + LibUsb.errorName(status));
+            }
         }
 
         mDevice = findDevice();
@@ -198,6 +227,13 @@ public abstract class USBTunerController extends TunerController
         }
 
         //Detach the kernel driver if active and detach is supported.  Otherwise, let the claim interface fail.
+        //Note: do NOT call setAutoDetachKernelDriver on macOS — it enables USBInterfaceOpenSeize which
+        //causes LIBUSB_ERROR_ACCESS when no kernel driver holds the interface (macOS-specific IOKit behavior).
+        if(!isMacOS)
+        {
+            LibUsb.setAutoDetachKernelDriver(mDeviceHandle, true);
+        }
+
         status = LibUsb.kernelDriverActive(mDeviceHandle, USB_INTERFACE);
 
         if(status == 1) //kernel driver is attached and detach operation is supported
@@ -213,40 +249,67 @@ public abstract class USBTunerController extends TunerController
             }
         }
 
-        //Set the configuration which also invokes a soft reset on the device
-        status = LibUsb.setConfiguration(mDeviceHandle, USB_CONFIGURATION);
-
-        if(status == LibUsb.ERROR_BUSY)
+        //Set the configuration which also invokes a soft reset on the device.
+        //On macOS: skip setConfiguration if the device is already in the desired configuration.
+        //Calling setConfiguration(1) on macOS even when already configured causes IOKit to re-enumerate
+        //the device, which leaves endpoint 0 stalled and causes subsequent control transfers to fail
+        //with LIBUSB_ERROR_PIPE. librtlsdr uses the same check-then-set pattern.
+        boolean skipSetConfiguration = false;
+        if(isMacOS)
         {
-            mLog.error("Unable to set USB configuration on tuner - device is busy (in use by another application)");
-            mDeviceHandle = null;
-            mDeviceDescriptor = null;
-            throw new SourceException("USB tuner is in-use by another application");
-        }
-        else if(status != LibUsb.SUCCESS)
-        {
-            mDeviceHandle = null;
-            mDeviceDescriptor = null;
-            throw new SourceException("Can't set configuration (ie reset) on the USB tuner - " + LibUsb.errorName(status));
+            IntBuffer currentConfig = IntBuffer.allocate(1);
+            int getConfigStatus = LibUsb.getConfiguration(mDeviceHandle, currentConfig);
+            if(getConfigStatus == LibUsb.SUCCESS && currentConfig.get(0) == USB_CONFIGURATION)
+            {
+                mLog.debug("setConfiguration: device already in config {} on macOS - skipping", USB_CONFIGURATION);
+                skipSetConfiguration = true;
+            }
         }
 
-        //Claim the interface
+        if(!skipSetConfiguration)
+        {
+            status = LibUsb.setConfiguration(mDeviceHandle, USB_CONFIGURATION);
+
+            if(status == LibUsb.ERROR_BUSY)
+            {
+                mLog.debug("setConfiguration: device already in use - continuing");
+            }
+            else if(status == LibUsb.ERROR_NO_DEVICE)
+            {
+                mLog.debug("setConfiguration: device re-enumerating (macOS normal) - continuing");
+            }
+            else if(status != LibUsb.SUCCESS)
+            {
+                mDeviceHandle = null;
+                mDeviceDescriptor = null;
+                throw new SourceException("Can't set configuration (ie reset) on the USB tuner - " + LibUsb.errorName(status));
+            }
+        }
+
         status = LibUsb.claimInterface(mDeviceHandle, USB_INTERFACE);
 
-        if(status == LibUsb.ERROR_BUSY)
+        if(status == LibUsb.ERROR_ACCESS)
         {
+            mLog.error("Can't claim interface on USB tuner - LIBUSB_ERROR_ACCESS (try replugging the device)");
             mDeviceHandle = null;
             mDeviceDescriptor = null;
-            throw new SourceException("USB tuner is in-use by another application");
+            throw new SourceException("Can't claim interface on USB tuner - " + LibUsb.errorName(status));
+        }
+        else if(status == LibUsb.ERROR_BUSY)
+        {
+            mLog.error("USB tuner interface is in-use by another application");
+            mDeviceHandle = null;
+            mDeviceDescriptor = null;
+            throw new SourceException("USB tuner interface is in-use by another application");
         }
         else if(status != LibUsb.SUCCESS)
         {
+            mLog.error("Can't claim interface on USB tuner - " + LibUsb.errorName(status));
             mDeviceHandle = null;
             mDeviceDescriptor = null;
             throw new SourceException("Can't claim interface on USB tuner - " + LibUsb.errorName(status));
         }
 
-        //Set running true for deviceStart() operations that require it.
         mRunning = true;
 
         try
@@ -303,7 +366,10 @@ public abstract class USBTunerController extends TunerController
             mDeviceDescriptor = null;
         }
 
-        LibUsb.exit(mDeviceContext);
+        if(mOwnsDeviceContext)
+        {
+            LibUsb.exit(mDeviceContext);
+        }
         mDeviceContext = null;
     }
 
@@ -380,6 +446,8 @@ public abstract class USBTunerController extends TunerController
         DeviceList deviceList = new DeviceList();
         int count = LibUsb.getDeviceList(mDeviceContext, deviceList);
 
+        int targetVendorId = getUSBVendorId();
+
         if(count >= 0)
         {
             for(Device device: deviceList)
@@ -387,13 +455,31 @@ public abstract class USBTunerController extends TunerController
                 int bus = LibUsb.getBusNumber(device);
                 int port = LibUsb.getPortNumber(device);
 
-                if(port > 0)
+                if(port >= 0)
                 {
                     String portAddress = TunerManager.getPortAddress(device);
 
                     if(mBus == bus && mPortAddress != null && mPortAddress.equals(portAddress))
                     {
-                        foundDevice = device;
+                        //When port addresses are unavailable (all empty on macOS), also check VID to avoid
+                        //matching hub/root devices before the actual tuner.
+                        if(targetVendorId >= 0)
+                        {
+                            DeviceDescriptor desc = new DeviceDescriptor();
+                            int descStatus = LibUsb.getDeviceDescriptor(device, desc);
+                            if(descStatus == LibUsb.SUCCESS && (desc.idVendor() & 0xFFFF) == targetVendorId)
+                            {
+                                foundDevice = device;
+                            }
+                            else
+                            {
+                                LibUsb.unrefDevice(device);
+                            }
+                        }
+                        else
+                        {
+                            foundDevice = device;
+                        }
                     }
                     else
                     {

--- a/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
@@ -23,6 +23,7 @@ import io.github.dsheirer.buffer.INativeBufferFactory;
 import io.github.dsheirer.sample.Listener;
 import io.github.dsheirer.source.SourceException;
 import io.github.dsheirer.source.tuner.ITunerErrorListener;
+import io.github.dsheirer.source.tuner.TunerClass;
 import io.github.dsheirer.source.tuner.TunerController;
 import io.github.dsheirer.source.tuner.TunerType;
 import io.github.dsheirer.source.tuner.manager.TunerManager;
@@ -59,6 +60,7 @@ public abstract class USBTunerController extends TunerController
 
     protected int mBus;
     protected String mPortAddress;
+    private TunerClass mTunerClass = TunerClass.UNKNOWN;
     private Context mDeviceContext = new Context();
     private boolean mOwnsDeviceContext = true; //false when context is shared from TunerManager
     private Device mDevice;
@@ -120,18 +122,18 @@ public abstract class USBTunerController extends TunerController
     }
 
     /**
+     * Sets the tuner class expected for this controller so that device matching can validate the
+     * descriptor when a platform reports incomplete USB topology information.
+     */
+    public void setTunerClass(TunerClass tunerClass)
+    {
+        mTunerClass = tunerClass != null ? tunerClass : TunerClass.UNKNOWN;
+    }
+
+    /**
      * Tuner type for this USB controller
      */
     public abstract TunerType getTunerType();
-
-    /**
-     * USB Vendor ID (VID) for this tuner, used to disambiguate devices when port numbers are unavailable (e.g. macOS).
-     * Subclasses should override to return their specific VID. Returns -1 to skip VID filtering.
-     */
-    protected int getUSBVendorId()
-    {
-        return -1;
-    }
 
     /**
      * Factory for converting received streaming sample data into native buffers, as provided by sub-class.
@@ -446,8 +448,6 @@ public abstract class USBTunerController extends TunerController
         DeviceList deviceList = new DeviceList();
         int count = LibUsb.getDeviceList(mDeviceContext, deviceList);
 
-        int targetVendorId = getUSBVendorId();
-
         if(count >= 0)
         {
             for(Device device: deviceList)
@@ -461,13 +461,14 @@ public abstract class USBTunerController extends TunerController
 
                     if(mBus == bus && mPortAddress != null && mPortAddress.equals(portAddress))
                     {
-                        //When port addresses are unavailable (all empty on macOS), also check VID to avoid
-                        //matching hub/root devices before the actual tuner.
-                        if(targetVendorId >= 0)
+                        //When port addresses are unavailable (all empty on macOS), verify the tuner class too
+                        //so that multiple USB devices on the same bus don't match the wrong controller.
+                        if(mTunerClass != TunerClass.UNKNOWN)
                         {
                             DeviceDescriptor desc = new DeviceDescriptor();
                             int descStatus = LibUsb.getDeviceDescriptor(device, desc);
-                            if(descStatus == LibUsb.SUCCESS && (desc.idVendor() & 0xFFFF) == targetVendorId)
+                            if(descStatus == LibUsb.SUCCESS &&
+                                    TunerClass.lookup(desc.idVendor(), desc.idProduct()) == mTunerClass)
                             {
                                 foundDevice = device;
                             }

--- a/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
+++ b/src/main/java/io/github/dsheirer/source/tuner/usb/USBTunerController.java
@@ -61,8 +61,7 @@ public abstract class USBTunerController extends TunerController
     protected int mBus;
     protected String mPortAddress;
     private TunerClass mTunerClass = TunerClass.UNKNOWN;
-    private Context mDeviceContext = new Context();
-    private boolean mOwnsDeviceContext = true; //false when context is shared from TunerManager
+    private Context mDeviceContext;
     private Device mDevice;
     private DeviceHandle mDeviceHandle;
     private DeviceDescriptor mDeviceDescriptor;
@@ -110,15 +109,12 @@ public abstract class USBTunerController extends TunerController
     }
 
     /**
-     * Sets a shared libusb context from TunerManager instead of creating a new one.
-     * Using a shared context avoids dual-context interference on macOS where the first context
-     * caches device handles that block the second context from fully opening the device.
+     * Sets the application-owned libusb context from TunerManager.
      * Must be called before start().
      */
     public void setSharedContext(Context context)
     {
         mDeviceContext = context;
-        mOwnsDeviceContext = false;
     }
 
     /**
@@ -172,21 +168,11 @@ public abstract class USBTunerController extends TunerController
     {
         if(mDeviceContext == null)
         {
-            throw new SourceException("Device cannot be reused once it has been shutdown");
+            throw new SourceException("Shared libusb context is required before starting USB tuner");
         }
 
         boolean isMacOS = System.getProperty("os.name", "").contains("Mac");
         int status = LibUsb.SUCCESS;
-
-        if(mOwnsDeviceContext)
-        {
-            status = LibUsb.init(mDeviceContext);
-
-            if(status != LibUsb.SUCCESS)
-            {
-                throw new SourceException("Can't initialize libusb library - " + LibUsb.errorName(status));
-            }
-        }
 
         mDevice = findDevice();
 
@@ -368,10 +354,6 @@ public abstract class USBTunerController extends TunerController
             mDeviceDescriptor = null;
         }
 
-        if(mOwnsDeviceContext)
-        {
-            LibUsb.exit(mDeviceContext);
-        }
         mDeviceContext = null;
     }
 


### PR DESCRIPTION
## Summary

Fixes USB tuner detection and initialization on macOS without requiring `sudo`. This was tested on macOS 15 Sequoia (Apple Silicon / aarch64) with an RTL-SDR Blog V4 dongle, where the same device already worked with Homebrew `rtl_test` as a normal user.

## Root causes and fixes

**Device enumeration and matching when macOS reports port 0 / empty port chains**
- macOS IOKit reports `port = 0` for USB devices, so the old `port > 0` guards excluded devices from discovery and hot-plug handling.
- Fixed by removing the `port > 0` filter in `TunerManager`, `FCDTunerController`, and `USBTunerController.findDevice()`.
- When macOS reports an empty port chain for every device on a bus, matching by bus + port string alone is ambiguous. The shared USB controller path now validates the expected `TunerClass` from the device descriptor before selecting a device.
- `TunerFactory` now passes the expected tuner class into each `USBTunerController`, so the same matching logic applies consistently to RTL-SDR, Airspy, Airspy HF+, HackRF, and HydraSDR.

**`LIBUSB_ERROR_ACCESS` on `claimInterface`**
- `setAutoDetachKernelDriver(true)` enables `USBInterfaceOpenSeize` on macOS IOKit, which causes `LIBUSB_ERROR_ACCESS` when no kernel driver holds the interface.
- Fixed by skipping `setAutoDetachKernelDriver` on macOS.

**`LIBUSB_ERROR_PIPE` after redundant `setConfiguration(1)`**
- Calling `setConfiguration(1)` when the device is already in configuration 1 causes macOS to re-enumerate the device, which leaves endpoint 0 stalled and breaks later control transfers with `LIBUSB_ERROR_PIPE`.
- Fixed by reading the current configuration first and skipping the call when the device is already configured.

**Shared libusb context**
- `TunerManager` discovers devices in one libusb context, but the old startup path opened tuners in a second context. On macOS that caused the second open path to misbehave and later control transfers to fail.
- Fixed by sharing `TunerManager`'s libusb context with `USBTunerController`.

**RTL-SDR startup robustness**
- The RTL startup path now initializes the baseband before reading EEPROM so the I2C bus is ready.
- The macOS startup path skips the reset probe sequence that is unnecessary after a fresh macOS open.
- Descriptor access now guards against null/empty EEPROM data instead of throwing `NullPointerException` / `IndexOutOfBoundsException`.

## Validation

- [x] `./gradlew compileJava`
- [x] RTL-SDR Blog V4 detected and initialized on macOS 15 Sequoia (Apple Silicon) without `sudo`
- [ ] Verify on Linux
- [ ] Verify on Windows
- [ ] Verify hot-plug behavior on macOS with additional USB tuner hardware
- [ ] Verify Airspy / Airspy HF+ / HackRF / HydraSDR on macOS
