### PR TITLE
Clear frequency band map when switching P25 control channels

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -199,6 +199,7 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
 
             mTS1ChannelGrantEventMap.clear();
             mTS2ChannelGrantEventMap.clear();
+            mFrequencyBandMap.clear();
 
             //Remove the control channel from the previous frequency
             mAllocatedTrafficChannelMap.remove(previous);

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageProcessor.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1MessageProcessor.java
@@ -330,14 +330,7 @@ public class P25P1MessageProcessor implements Listener<IMessage>
         if(message instanceof IFrequencyBand)
         {
             IFrequencyBand bandIdentifier = (IFrequencyBand)message;
-
-            //Only store the frequency band if it's new so we don't hold on to more than one instance of the
-            //frequency band message.  Otherwise, we'll hold on to several instances of each message as they get
-            //injected into other messages with channel information.
-            if(!mFrequencyBandMap.containsKey(bandIdentifier.getIdentifier()))
-            {
-                mFrequencyBandMap.put(bandIdentifier.getIdentifier(), bandIdentifier);
-            }
+            mFrequencyBandMap.put(bandIdentifier.getIdentifier(), bandIdentifier);
         }
     }
 


### PR DESCRIPTION
The decoder was reusing frequency data from the old control channel when switching to a new one. Cleared the map on channel switch and simplified the storage logic to always update instead of trying to avoid duplicates. Fixes #2298