### PR TITLE
Patch #2342 (Playlist column in Playlist Editor not sorting)

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/playlist/manager/PlaylistManagerEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/playlist/manager/PlaylistManagerEditor.java
@@ -34,6 +34,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import javafx.application.Platform;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -189,6 +190,14 @@ public class PlaylistManagerEditor extends HBox
                     }
                 }
             });
+
+            pathColumn.setCellValueFactory(param -> 
+            new SimpleStringProperty(param.getValue().toString()));
+
+            pathColumn.setComparator(String.CASE_INSENSITIVE_ORDER);
+            pathColumn.setSortable(true);
+
+
             pathColumn.setPrefWidth(650);
 
             mPlaylistTableView.getColumns().addAll(iconColumn, pathColumn);


### PR DESCRIPTION
**Issue**
[https://github.com/DSheirer/sdrtrunk/issues/2342](https://github.com/DSheirer/sdrtrunk/issues/2342)

**What Changed**
`PlaylistManagerEditor.java` - Patched a bug where when clicking the header of the Playlist column in the Playlist Editor>Playlists Tab, the column would change icons (as if sorted) but not modify the sort order.

Overall, a relatively simple fix! I checked the other tabs across the Playlist Editor and they don't seem to have this issue. Looks like this one is isolated.

I tried to follow the same general styling as was already in the file (e.g., imports at the top alphabetically, tabs/spaces), but let me know if I need to change anything. Thanks for building such a cool app!