### PR TITLE
Add JVM autoprovisioning in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,11 +66,6 @@ java {
     }
 }
 
-sourceSets {
-    main.java.srcDirs 'src/main'
-    test.java.srcDirs 'src/test'
-}
-
 test {
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ version = project.findProperty('projectVersion')
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
+        vendor = JvmVendorSpec.BELLSOFT
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
 rootProject.name = 'sdr-trunk'


### PR DESCRIPTION
gradle has the ability to [auto-provision jvm's](https://docs.gradle.org/current/userguide/toolchains.html), so i put together this PR to do this. i use a different jdk (without javafx) by default and found it slightly annoying having to switch back and forth. it appears if you have the proper matching jdk installed it will not provision one, so your local environment and CI will be just as they were.