### PR TITLE
Add safe opt-in talker alias CSV export

### DIFF
--- a/src/main/java/io/github/dsheirer/gui/preference/application/ApplicationPreferenceEditor.java
+++ b/src/main/java/io/github/dsheirer/gui/preference/application/ApplicationPreferenceEditor.java
@@ -45,6 +45,7 @@ public class ApplicationPreferenceEditor extends HBox
     private Label mAutoStartTimeoutLabel;
     private Spinner<Integer> mTimeoutSpinner;
     private ToggleSwitch mAutomaticDiagnosticMonitoringToggle;
+    private ToggleSwitch mTalkerAliasCsvExportToggle;
 
     /**
      * Constructs an instance
@@ -88,6 +89,17 @@ public class ApplicationPreferenceEditor extends HBox
             GridPane.setHalignment(getTimeoutSpinner(), HPos.RIGHT);
             mEditorPane.add(getTimeoutSpinner(), 0, ++row);
             mEditorPane.add(new Label("seconds"), 1, row);
+
+            Separator aliasSeparator = new Separator(Orientation.HORIZONTAL);
+            GridPane.setHgrow(aliasSeparator, Priority.ALWAYS);
+            mEditorPane.add(aliasSeparator, 0, ++row, 3, 1);
+
+            mEditorPane.add(new Label("Talker Alias Export"), 0, ++row, 2, 1);
+            GridPane.setHalignment(getTalkerAliasCsvExportToggle(), HPos.RIGHT);
+            mEditorPane.add(getTalkerAliasCsvExportToggle(), 0, ++row);
+            Label aliasExportLabel = new Label("Export observed DMR, NXDN, and P25 talker aliases to local CSV files");
+            aliasExportLabel.setWrapText(true);
+            mEditorPane.add(aliasExportLabel, 1, row, 2, 1);
 
             ColumnConstraints c1 = new ColumnConstraints();
             c1.setPercentWidth(30);
@@ -138,5 +150,18 @@ public class ApplicationPreferenceEditor extends HBox
         }
 
         return mAutomaticDiagnosticMonitoringToggle;
+    }
+
+    private ToggleSwitch getTalkerAliasCsvExportToggle()
+    {
+        if(mTalkerAliasCsvExportToggle == null)
+        {
+            mTalkerAliasCsvExportToggle = new ToggleSwitch();
+            mTalkerAliasCsvExportToggle.setSelected(mApplicationPreference.isTalkerAliasCsvExportEnabled());
+            mTalkerAliasCsvExportToggle.selectedProperty().addListener((observable, oldValue, enabled) ->
+                mApplicationPreference.setTalkerAliasCsvExportEnabled(enabled));
+        }
+
+        return mTalkerAliasCsvExportToggle;
     }
 }

--- a/src/main/java/io/github/dsheirer/identifier/alias/TalkerAliasManager.java
+++ b/src/main/java/io/github/dsheirer/identifier/alias/TalkerAliasManager.java
@@ -24,11 +24,21 @@ import io.github.dsheirer.identifier.IdentifierCollection;
 import io.github.dsheirer.identifier.MutableIdentifierCollection;
 import io.github.dsheirer.identifier.Role;
 import io.github.dsheirer.identifier.radio.RadioIdentifier;
+import io.github.dsheirer.preference.application.ApplicationPreference;
+import io.github.dsheirer.util.ThreadPool;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Talker alias cache manager.  Collects observed talker aliases and inserts them into an identifier collection when
@@ -38,13 +48,27 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class TalkerAliasManager
 {
+    private static final Logger mLog = LoggerFactory.getLogger(TalkerAliasManager.class);
+    private static final Map<Path,Object> EXPORT_LOCKS = new ConcurrentHashMap<>();
     private Map<Integer,TalkerAliasIdentifier> mAliasMap = new ConcurrentHashMap<>();
+    private final Path mExportFile;
 
     /**
      * Constructs an instance
      */
     public TalkerAliasManager()
     {
+        mExportFile = null;
+    }
+
+    /**
+     * Constructs an instance that exports newly observed and changed aliases to a CSV file.
+     * @param exportDirectory parent directory for the CSV file
+     * @param sourceName system or channel name used for the file name
+     */
+    public TalkerAliasManager(Path exportDirectory, String sourceName)
+    {
+        mExportFile = exportDirectory.resolve(safeFileName(sourceName) + ".csv");
     }
 
     /**
@@ -57,8 +81,55 @@ public class TalkerAliasManager
     {
         if(identifier.getRole() == Role.FROM)
         {
-            mAliasMap.put(identifier.getValue(), alias);
+            TalkerAliasIdentifier previous = mAliasMap.put(identifier.getValue(), alias);
+
+            if(identifier.getValue() > 0 && mExportFile != null && !Objects.equals(alias, previous) &&
+                ApplicationPreference.readTalkerAliasCsvExportEnabled())
+            {
+                int radio = identifier.getValue();
+                String aliasText = alias.toString().replaceFirst("^TA-", "");
+                ThreadPool.CACHED.execute(() -> appendCsv(radio, aliasText));
+            }
         }
+    }
+
+    void appendCsv(int radio, String alias)
+    {
+        synchronized(EXPORT_LOCKS.computeIfAbsent(mExportFile, ignored -> new Object()))
+        {
+            try
+            {
+                Files.createDirectories(mExportFile.getParent());
+                boolean writeHeader = Files.notExists(mExportFile) || Files.size(mExportFile) == 0;
+                StringBuilder content = new StringBuilder();
+
+                if(writeHeader)
+                {
+                    content.append("radio,alias\n");
+                }
+
+                content.append(radio).append(',').append(csv(alias)).append('\n');
+                Files.writeString(mExportFile, content, StandardCharsets.UTF_8, StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND);
+            }
+            catch(IOException ioe)
+            {
+                mLog.warn("Unable to export talker alias CSV [{}]", mExportFile, ioe);
+            }
+        }
+    }
+
+    static String csv(String value)
+    {
+        String escaped = value == null ? "" : value.replace("\"", "\"\"");
+        return '"' + escaped + '"';
+    }
+
+    static String safeFileName(String value)
+    {
+        String safe = value == null ? "Talker Aliases" : value.replaceFirst("^T-", "")
+            .replaceAll("[\\\\/:*?\"<>|\\p{Cntrl}]", "_").trim();
+        return safe.isEmpty() ? "Talker Aliases" : safe;
     }
 
     /**

--- a/src/main/java/io/github/dsheirer/identifier/alias/TalkerAliasManager.java
+++ b/src/main/java/io/github/dsheirer/identifier/alias/TalkerAliasManager.java
@@ -52,6 +52,7 @@ public class TalkerAliasManager
     private static final Map<Path,Object> EXPORT_LOCKS = new ConcurrentHashMap<>();
     private Map<Integer,TalkerAliasIdentifier> mAliasMap = new ConcurrentHashMap<>();
     private final Path mExportFile;
+    private volatile boolean mAliasExportEnabled;
 
     /**
      * Constructs an instance
@@ -59,6 +60,7 @@ public class TalkerAliasManager
     public TalkerAliasManager()
     {
         mExportFile = null;
+        mAliasExportEnabled = false;
     }
 
     /**
@@ -68,7 +70,24 @@ public class TalkerAliasManager
      */
     public TalkerAliasManager(Path exportDirectory, String sourceName)
     {
+        this(exportDirectory, sourceName, ApplicationPreference.readTalkerAliasCsvExportEnabled());
+    }
+
+    /**
+     * Constructs an instance that exports newly observed and changed aliases to a CSV file when enabled.
+     *
+     * @param exportDirectory parent directory for the CSV file
+     * @param sourceName system or channel name used for the file name
+     * @param aliasExportEnabled true to initialize the CSV export file
+     */
+    TalkerAliasManager(Path exportDirectory, String sourceName, boolean aliasExportEnabled)
+    {
         mExportFile = exportDirectory.resolve(safeFileName(sourceName) + ".csv");
+
+        if(aliasExportEnabled)
+        {
+            initializeAliasExport();
+        }
     }
 
     /**
@@ -83,8 +102,7 @@ public class TalkerAliasManager
         {
             TalkerAliasIdentifier previous = mAliasMap.put(identifier.getValue(), alias);
 
-            if(identifier.getValue() > 0 && mExportFile != null && !Objects.equals(alias, previous) &&
-                ApplicationPreference.readTalkerAliasCsvExportEnabled())
+            if(identifier.getValue() > 0 && mAliasExportEnabled && !Objects.equals(alias, previous))
             {
                 int radio = identifier.getValue();
                 String aliasText = alias.toString().replaceFirst("^TA-", "");
@@ -95,26 +113,54 @@ public class TalkerAliasManager
 
     void appendCsv(int radio, String alias)
     {
+        if(!mAliasExportEnabled)
+        {
+            return;
+        }
+
+        synchronized(EXPORT_LOCKS.computeIfAbsent(mExportFile, ignored -> new Object()))
+        {
+            if(!mAliasExportEnabled)
+            {
+                return;
+            }
+
+            try
+            {
+                Files.writeString(mExportFile, radio + "," + csv(alias) + '\n', StandardCharsets.UTF_8,
+                    StandardOpenOption.APPEND);
+            }
+            catch(IOException ioe)
+            {
+                mAliasExportEnabled = false;
+                mLog.warn("Unable to export talker alias CSV [{}]", mExportFile, ioe);
+            }
+        }
+    }
+
+    /**
+     * Initializes the alias export file once so that later alias updates do not repeatedly attempt a failed file
+     * creation.
+     */
+    private void initializeAliasExport()
+    {
         synchronized(EXPORT_LOCKS.computeIfAbsent(mExportFile, ignored -> new Object()))
         {
             try
             {
                 Files.createDirectories(mExportFile.getParent());
-                boolean writeHeader = Files.notExists(mExportFile) || Files.size(mExportFile) == 0;
-                StringBuilder content = new StringBuilder();
 
-                if(writeHeader)
+                if(Files.notExists(mExportFile) || Files.size(mExportFile) == 0)
                 {
-                    content.append("radio,alias\n");
+                    Files.writeString(mExportFile, "radio,alias\n", StandardCharsets.UTF_8, StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND);
                 }
 
-                content.append(radio).append(',').append(csv(alias)).append('\n');
-                Files.writeString(mExportFile, content, StandardCharsets.UTF_8, StandardOpenOption.CREATE,
-                    StandardOpenOption.APPEND);
+                mAliasExportEnabled = true;
             }
             catch(IOException ioe)
             {
-                mLog.warn("Unable to export talker alias CSV [{}]", mExportFile, ioe);
+                mLog.warn("Unable to initialize talker alias CSV export [{}]", mExportFile, ioe);
             }
         }
     }

--- a/src/main/java/io/github/dsheirer/module/decode/dmr/DMRTrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/dmr/DMRTrafficChannelManager.java
@@ -32,6 +32,7 @@ import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.identifier.IdentifierCollection;
 import io.github.dsheirer.identifier.Role;
 import io.github.dsheirer.identifier.alias.TalkerAliasManager;
+import io.github.dsheirer.properties.SystemProperties;
 import io.github.dsheirer.message.IMessage;
 import io.github.dsheirer.message.MessageHistoryPreloadData;
 import io.github.dsheirer.message.MessageHistoryRequest;
@@ -104,7 +105,7 @@ public class DMRTrafficChannelManager extends TrafficChannelManager implements I
     private Listener<ChannelEvent> mChannelEventListener;
     private Listener<IDecodeEvent> mDecodeEventListener;
     private TrafficChannelTeardownMonitor mTrafficChannelTeardownMonitor = new TrafficChannelTeardownMonitor();
-    private TalkerAliasManager mTalkerAliasManager = new TalkerAliasManager();
+    private TalkerAliasManager mTalkerAliasManager;
     private Channel mParentChannel;
     private boolean mIgnoreDataCalls;
 
@@ -122,6 +123,8 @@ public class DMRTrafficChannelManager extends TrafficChannelManager implements I
     public DMRTrafficChannelManager(Channel parentChannel)
     {
         mParentChannel = parentChannel;
+        mTalkerAliasManager = new TalkerAliasManager(
+            SystemProperties.getInstance().getApplicationRootPath().resolve("Aliases"), parentChannel.getSystem());
 
         if(parentChannel.getDecodeConfiguration() instanceof DecodeConfigDMR)
         {

--- a/src/main/java/io/github/dsheirer/module/decode/nxdn/NXDNTrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nxdn/NXDNTrafficChannelManager.java
@@ -29,6 +29,7 @@ import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.identifier.IdentifierCollection;
 import io.github.dsheirer.identifier.MutableIdentifierCollection;
 import io.github.dsheirer.identifier.alias.TalkerAliasManager;
+import io.github.dsheirer.properties.SystemProperties;
 import io.github.dsheirer.identifier.encryption.EncryptionKeyIdentifier;
 import io.github.dsheirer.identifier.radio.RadioIdentifier;
 import io.github.dsheirer.module.decode.event.DecodeEvent;
@@ -83,7 +84,7 @@ public class NXDNTrafficChannelManager extends TrafficChannelManager implements 
     private final Map<Long, Channel> mAllocatedTrafficChannelMap = new HashMap<>();
     private final Map<Long, NXDNChannelEventTracker> mEventTrackerMap = new HashMap<>();
     private final Queue<Channel> mAvailableTrafficChannelQueue = new LinkedTransferQueue<>();
-    private final TalkerAliasManager mTalkerAliasManager = new TalkerAliasManager();
+    private final TalkerAliasManager mTalkerAliasManager;
     private final TrafficChannelTeardownMonitor mTrafficChannelTeardownMonitor = new TrafficChannelTeardownMonitor();
     private List<Channel> mManagedTrafficChannels;
     private Listener<IDecodeEvent> mDecodeEventListener;
@@ -100,6 +101,8 @@ public class NXDNTrafficChannelManager extends TrafficChannelManager implements 
     public NXDNTrafficChannelManager(Channel parentChannel)
     {
         mParentChannel = parentChannel;
+        mTalkerAliasManager = new TalkerAliasManager(
+            SystemProperties.getInstance().getApplicationRootPath().resolve("Aliases"), parentChannel.getSystem());
 
         if(parentChannel.getDecodeConfiguration() instanceof DecodeConfigNXDN configNXDN)
         {

--- a/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/P25TrafficChannelManager.java
@@ -30,6 +30,7 @@ import io.github.dsheirer.identifier.Identifier;
 import io.github.dsheirer.identifier.IdentifierCollection;
 import io.github.dsheirer.identifier.MutableIdentifierCollection;
 import io.github.dsheirer.identifier.alias.TalkerAliasManager;
+import io.github.dsheirer.properties.SystemProperties;
 import io.github.dsheirer.identifier.encryption.EncryptionKeyIdentifier;
 import io.github.dsheirer.identifier.patch.PatchGroupIdentifier;
 import io.github.dsheirer.identifier.patch.PatchGroupPreLoadDataContent;
@@ -125,7 +126,7 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
     private boolean mIgnoreDataCalls;
     //Used only for data calls
     private DecodeEventDuplicateDetector mDuplicateDetector = new DecodeEventDuplicateDetector();
-    private TalkerAliasManager mTalkerAliasManager = new TalkerAliasManager();
+    private TalkerAliasManager mTalkerAliasManager;
 
     /**
      * Constructs an instance.
@@ -134,6 +135,8 @@ public class P25TrafficChannelManager extends TrafficChannelManager implements I
     public P25TrafficChannelManager(Channel parentChannel)
     {
         mParentChannel = parentChannel;
+        mTalkerAliasManager = new TalkerAliasManager(
+            SystemProperties.getInstance().getApplicationRootPath().resolve("Aliases"), parentChannel.getSystem());
 
         if(parentChannel.getDecodeConfiguration() instanceof DecodeConfigP25Phase1 phase1)
         {

--- a/src/main/java/io/github/dsheirer/preference/application/ApplicationPreference.java
+++ b/src/main/java/io/github/dsheirer/preference/application/ApplicationPreference.java
@@ -33,11 +33,13 @@ public class ApplicationPreference extends Preference
 {
     private static final String PREFERENCE_KEY_CHANNEL_AUTO_DIAGNOSTIC_MONITORING = "automatic.diagnostic.monitoring";
     private static final String PREFERENCE_KEY_CHANNEL_AUTO_START_TIMEOUT = "channel.auto.start.timeout";
+    private static final String PREFERENCE_KEY_TALKER_ALIAS_CSV_EXPORT = "talker.alias.csv.export";
 
     private final static Logger mLog = LoggerFactory.getLogger(ApplicationPreference.class);
     private Preferences mPreferences = Preferences.userNodeForPackage(ApplicationPreference.class);
     private Integer mChannelAutoStartTimeout;
     private Boolean mAutomaticDiagnosticMonitoring;
+    private Boolean mTalkerAliasCsvExportEnabled;
 
     /**
      * Constructs an instance
@@ -102,6 +104,38 @@ public class ApplicationPreference extends Preference
     {
         mAutomaticDiagnosticMonitoring = enabled;
         mPreferences.putBoolean(PREFERENCE_KEY_CHANNEL_AUTO_DIAGNOSTIC_MONITORING, enabled);
+        notifyPreferenceUpdated();
+    }
+
+    /**
+     * Indicates if newly observed talker aliases should be exported to local CSV files.
+     */
+    public boolean isTalkerAliasCsvExportEnabled()
+    {
+        if(mTalkerAliasCsvExportEnabled == null)
+        {
+            mTalkerAliasCsvExportEnabled = readTalkerAliasCsvExportEnabled();
+        }
+
+        return mTalkerAliasCsvExportEnabled;
+    }
+
+    /**
+     * Reads the current talker alias CSV export preference without constructing a UserPreferences graph.
+     */
+    public static boolean readTalkerAliasCsvExportEnabled()
+    {
+        return Preferences.userNodeForPackage(ApplicationPreference.class)
+            .getBoolean(PREFERENCE_KEY_TALKER_ALIAS_CSV_EXPORT, false);
+    }
+
+    /**
+     * Enables or disables local talker alias CSV export.
+     */
+    public void setTalkerAliasCsvExportEnabled(boolean enabled)
+    {
+        mTalkerAliasCsvExportEnabled = enabled;
+        mPreferences.putBoolean(PREFERENCE_KEY_TALKER_ALIAS_CSV_EXPORT, enabled);
         notifyPreferenceUpdated();
     }
 }

--- a/src/test/java/io/github/dsheirer/identifier/alias/TalkerAliasManagerTest.java
+++ b/src/test/java/io/github/dsheirer/identifier/alias/TalkerAliasManagerTest.java
@@ -1,0 +1,43 @@
+/*
+ * ****************************************************************************
+ * Copyright (C) 2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * ****************************************************************************
+ */
+package io.github.dsheirer.identifier.alias;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TalkerAliasManagerTest
+{
+    @TempDir
+    Path mTemporaryDirectory;
+
+    @Test
+    void escapesCsvAndSanitizesFileName()
+    {
+        assertEquals("\"Unit \"\"12\"\", north\nline\"", TalkerAliasManager.csv("Unit \"12\", north\nline"));
+        assertEquals("County_System_1", TalkerAliasManager.safeFileName("T-County/System:1"));
+        assertEquals("Talker Aliases", TalkerAliasManager.safeFileName(""));
+    }
+
+    @Test
+    void appendsHeaderOnceAndEscapesAlias() throws Exception
+    {
+        TalkerAliasManager manager = new TalkerAliasManager(mTemporaryDirectory, "T-Test/System");
+        manager.appendCsv(1001, "Unit \"12\", north");
+        manager.appendCsv(1002, "Unit 14");
+
+        assertEquals("radio,alias\n1001,\"Unit \"\"12\"\", north\"\n1002,\"Unit 14\"\n",
+            Files.readString(mTemporaryDirectory.resolve("Test_System.csv")));
+    }
+}

--- a/src/test/java/io/github/dsheirer/identifier/alias/TalkerAliasManagerTest.java
+++ b/src/test/java/io/github/dsheirer/identifier/alias/TalkerAliasManagerTest.java
@@ -11,6 +11,7 @@
 package io.github.dsheirer.identifier.alias;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,13 +32,26 @@ class TalkerAliasManagerTest
     }
 
     @Test
-    void appendsHeaderOnceAndEscapesAlias() throws Exception
+    void createsHeaderAndAppendsEscapedAliases() throws Exception
     {
-        TalkerAliasManager manager = new TalkerAliasManager(mTemporaryDirectory, "T-Test/System");
+        TalkerAliasManager manager = new TalkerAliasManager(mTemporaryDirectory, "T-Test/System", true);
+        Path exportFile = mTemporaryDirectory.resolve("Test_System.csv");
+
+        assertEquals("radio,alias\n", Files.readString(exportFile));
+
         manager.appendCsv(1001, "Unit \"12\", north");
         manager.appendCsv(1002, "Unit 14");
 
         assertEquals("radio,alias\n1001,\"Unit \"\"12\"\", north\"\n1002,\"Unit 14\"\n",
-            Files.readString(mTemporaryDirectory.resolve("Test_System.csv")));
+            Files.readString(exportFile));
+    }
+
+    @Test
+    void doesNotCreateExportFileWhenDisabled()
+    {
+        TalkerAliasManager manager = new TalkerAliasManager(mTemporaryDirectory, "Test", false);
+        manager.appendCsv(1001, "Unit 12");
+
+        assertFalse(Files.exists(mTemporaryDirectory.resolve("Test.csv")));
     }
 }


### PR DESCRIPTION
Provides a safer alternative implementation for the CSV-export portion of #2437 while remaining compatible with the alias-list column in #2436.

- Disabled by default and controlled in Application preferences.
- Writes per-system files under the application `Aliases` directory.
- Escapes CSV fields and sanitizes file names.
- Moves file I/O off decoder threads and serializes writers sharing a file.
- Logs directory and write failures instead of silently ignoring them.
- Preserves existing DMR, NXDN, and P25 alias processing paths.