### PR TITLE
2441 NXDN Talker Alias Assembler Logging

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/nxdn/layer3/proprietary/TalkerAliasAssembler.java
+++ b/src/main/java/io/github/dsheirer/module/decode/nxdn/layer3/proprietary/TalkerAliasAssembler.java
@@ -66,8 +66,6 @@ public class TalkerAliasAssembler
             case 4:
                 mFragment4 = fragment;
                 break;
-            default:
-                LOGGER.info("Unexpected NXDN Talker Alias Fragment sequence # - please notify developer: " + fragment);
         }
 
         if(mFragment1 != null && mFragment2 != null && mFragment3 != null && mFragment4 != null)


### PR DESCRIPTION
Closes #2441 

Removes logging from NXDN talker alias assembler.
