### PR TITLE
P25 Phase 2: consult I-ISCH 2 when I-ISCH 1 fails to decode

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/message/SuperFrameFragment.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/message/SuperFrameFragment.java
@@ -322,7 +322,7 @@ public class SuperFrameFragment implements IMessage
             return getIISCH1().getIschSequence().getTimeslotOffset();
         }
 
-        if(getIISCH1().isValid())
+        if(getIISCH2().isValid())
         {
             return getIISCH2().getIschSequence().getTimeslotOffset();
         }


### PR DESCRIPTION


`SuperFrameFragment.getTimeslotOffset()` tests `getIISCH1().isValid()` twice, so the second test never reaches I-ISCH 2 and a fragment whose first I-ISCH does not decode is descrambled at timeslot offset 0. `isFinalFragment()` next to it has the intended shape (I-ISCH 1, then I-ISCH 2), and both timeslots' I-ISCH carry the same ISCH-location field, so the second is a legitimate fallback.

On a weak signal this matters more than it looks: with the fragment's I-ISCH validity gate at fewer than 3 corrected bits, I-ISCH 1 fails on almost half of the fragments, and two of every three of those are then descrambled with the wrong phase and lose every MAC PDU. Measured with calibrated noise on eight Phase 2 traffic-channel recordings, this alone takes distinct MAC PDUs recovered at 0 dB from 176 to 192 of 240, measured on top of the two companion changes from the same branch (erasure decoding of the punctured SACCH/FACCH parity, and a matched filter), which are submitted separately.

No behaviour change when I-ISCH 1 decodes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

