### PR TITLE
P25 Phase 2: decode the punctured SACCH/FACCH parity as erasures

### DIFF
--- a/src/main/java/io/github/dsheirer/edac/ReedSolomon_63_ErasureDecoder.java
+++ b/src/main/java/io/github/dsheirer/edac/ReedSolomon_63_ErasureDecoder.java
@@ -1,0 +1,354 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.edac;
+
+/**
+ * Errors-and-erasures decoder for the P25 Reed-Solomon codes over GF(2^6) with primitive polynomial x^6 + x + 1
+ * (RS(63,35,29) and its shortened forms).
+ *
+ * The P25 Phase 2 SACCH and FACCH carry a shortened AND punctured RS(63,35) codeword: the leading information
+ * symbols are shortened away (known to be zero) and the trailing parity symbols are simply not transmitted.  An
+ * errors-only decoder that is handed zeros in the punctured positions sees them as symbol errors and spends its
+ * correction budget on them - 9 of 14 correctable symbols for FACCH, 6 of 14 for SACCH.  Marking the punctured
+ * positions as erasures costs one unit of budget each instead of two (2 * errors + erasures <= 28), leaving 9 and
+ * 11 correctable symbol errors respectively.
+ *
+ * Errors-and-erasures decoding via Forney-modified syndromes, Berlekamp-Massey, Chien search and the Forney
+ * algorithm.  Adapted from the Apache-2.0 licensed GopherTrunk project (internal/radio/framing/rs_gf64.go).
+ *
+ * Symbol ordering follows the existing BerlekempMassey convention used by the P25 message parsers: input[i] is the
+ * coefficient of x^i, so the parity symbols occupy the low indices and the (shortened) information symbols the
+ * high indices.
+ */
+public class ReedSolomon_63_ErasureDecoder
+{
+    private static final int N = 63;
+    private static final int[] EXP = new int[126];
+    private static final int[] LOG = new int[64];
+    private final int mParityCount;
+
+    static
+    {
+        int x = 1;
+
+        for(int i = 0; i < 63; i++)
+        {
+            EXP[i] = x;
+            LOG[x] = i;
+            int previous = x;
+            x = (x << 1) & 0x3F;
+
+            if((previous & 0x20) != 0)
+            {
+                x ^= 0x03; //x^6 = x + 1
+            }
+        }
+
+        for(int i = 63; i < 126; i++)
+        {
+            EXP[i] = EXP[i - 63];
+        }
+    }
+
+    /**
+     * Constructs a decoder for RS(63, k)
+     * @param k information symbol count (35 for the P25 Phase 2 SACCH/FACCH code)
+     */
+    public ReedSolomon_63_ErasureDecoder(int k)
+    {
+        mParityCount = N - k;
+    }
+
+    private static int mul(int a, int b)
+    {
+        return (a == 0 || b == 0) ? 0 : EXP[LOG[a] + LOG[b]];
+    }
+
+    private static int pow(int n)
+    {
+        n %= 63;
+
+        if(n < 0)
+        {
+            n += 63;
+        }
+
+        return EXP[n];
+    }
+
+    private static int inv(int a)
+    {
+        return EXP[63 - LOG[a]];
+    }
+
+    /**
+     * Syndromes of the codeword, cw[0] holding the highest-degree coefficient.
+     */
+    private int[] syndromes(int[] cw)
+    {
+        int[] s = new int[mParityCount];
+
+        for(int j = 1; j <= mParityCount; j++)
+        {
+            int alphaJ = pow(j);
+            int acc = 0;
+
+            for(int i = 0; i < N; i++)
+            {
+                acc = mul(acc, alphaJ) ^ cw[i];
+            }
+
+            s[j - 1] = acc;
+        }
+
+        return s;
+    }
+
+    private static int[] polyAddShiftScaled(int[] a, int[] b, int shift, int coefficient)
+    {
+        int[] out = new int[Math.max(a.length, b.length + shift)];
+        System.arraycopy(a, 0, out, 0, a.length);
+
+        for(int i = 0; i < b.length; i++)
+        {
+            out[i + shift] ^= mul(coefficient, b[i]);
+        }
+
+        return out;
+    }
+
+    private static int polyEval(int[] poly, int x)
+    {
+        int acc = 0;
+        int xp = 1;
+
+        for(int c : poly)
+        {
+            acc ^= mul(c, xp);
+            xp = mul(xp, x);
+        }
+
+        return acc;
+    }
+
+    private static int[] polyMulMod(int[] a, int[] b, int degree)
+    {
+        int[] out = new int[degree];
+
+        for(int i = 0; i < a.length && i < degree; i++)
+        {
+            if(a[i] == 0)
+            {
+                continue;
+            }
+
+            for(int j = 0; j < b.length && i + j < degree; j++)
+            {
+                out[i + j] ^= mul(a[i], b[j]);
+            }
+        }
+
+        return out;
+    }
+
+    private static int[] formalDerivative(int[] poly)
+    {
+        if(poly.length <= 1)
+        {
+            return new int[]{0};
+        }
+
+        int[] out = new int[poly.length - 1];
+
+        for(int i = 1; i < poly.length; i += 2)
+        {
+            out[i - 1] = poly[i];
+        }
+
+        return out;
+    }
+
+    /**
+     * Berlekamp-Massey.  Returns the error locator polynomial; its degree is returned via degree[0].
+     */
+    private static int[] berlekampMassey(int[] syndromes, int[] degree)
+    {
+        int[] lambda = {1};
+        int[] bPoly = {1};
+        int l = 0;
+        int m = 1;
+        int b = 1;
+
+        for(int i = 0; i < syndromes.length; i++)
+        {
+            int delta = syndromes[i];
+
+            for(int j = 1; j <= l && j < lambda.length; j++)
+            {
+                delta ^= mul(lambda[j], syndromes[i - j]);
+            }
+
+            if(delta == 0)
+            {
+                m++;
+            }
+            else if(2 * l <= i)
+            {
+                int[] previous = lambda.clone();
+                lambda = polyAddShiftScaled(lambda, bPoly, m, mul(delta, inv(b)));
+                l = i + 1 - l;
+                bPoly = previous;
+                b = delta;
+                m = 1;
+            }
+            else
+            {
+                lambda = polyAddShiftScaled(lambda, bPoly, m, mul(delta, inv(b)));
+                m++;
+            }
+        }
+
+        degree[0] = l;
+        return lambda;
+    }
+
+    /**
+     * Decodes the codeword.
+     *
+     * @param input codeword, input[i] being the coefficient of x^i (BerlekempMassey convention). Erased and
+     * shortened positions may hold any value.
+     * @param output receives the corrected codeword in the same convention, or a copy of the input when the
+     * codeword is not correctable.
+     * @param erasurePositions indices into input of the symbols that were not received (punctured parity).
+     * @return true when the codeword could NOT be corrected (matches BerlekempMassey.decode()'s return convention).
+     */
+    public boolean decode(int[] input, int[] output, int[] erasurePositions)
+    {
+        int erasureCount = erasurePositions.length;
+
+        if(erasureCount > mParityCount)
+        {
+            System.arraycopy(input, 0, output, 0, N);
+            return true;
+        }
+
+        //Reverse into highest-degree-first order and blank the erasures
+        int[] cw = new int[N];
+
+        for(int i = 0; i < N; i++)
+        {
+            cw[i] = input[N - 1 - i] & 0x3F;
+        }
+
+        for(int e : erasurePositions)
+        {
+            cw[N - 1 - e] = 0;
+        }
+
+        int[] synd = syndromes(cw);
+
+        //Erasure locator: product of (1 + Y x) over the erasure locators Y = alpha^(N-1-index)
+        int[] gamma = {1};
+
+        for(int e : erasurePositions)
+        {
+            int y = pow(N - 1 - (N - 1 - e));
+            int[] next = new int[gamma.length + 1];
+
+            for(int i = 0; i < gamma.length; i++)
+            {
+                next[i] ^= gamma[i];
+                next[i + 1] ^= mul(gamma[i], y);
+            }
+
+            gamma = next;
+        }
+
+        //Forney syndromes: the first erasureCount coefficients of S(x) * Gamma(x) are fixed by the erasures
+        int[] product = polyMulMod(synd, gamma, mParityCount);
+        int[] forney = new int[mParityCount - erasureCount];
+        System.arraycopy(product, erasureCount, forney, 0, forney.length);
+
+        int[] degree = new int[1];
+        int[] lambda = berlekampMassey(forney, degree);
+        int errorCount = degree[0];
+
+        if(2 * errorCount > mParityCount - erasureCount)
+        {
+            System.arraycopy(input, 0, output, 0, N);
+            return true;
+        }
+
+        //Errata locator: roots are the erasures and the errors together
+        int[] sigma = polyMulMod(lambda, gamma, lambda.length + gamma.length);
+        int[] positions = new int[N];
+        int[] locators = new int[N];
+        int found = 0;
+
+        for(int p = 0; p < N; p++)
+        {
+            if(polyEval(sigma, pow(-p)) == 0)
+            {
+                positions[found] = N - 1 - p;
+                locators[found] = pow(p);
+                found++;
+            }
+        }
+
+        if(found != errorCount + erasureCount)
+        {
+            System.arraycopy(input, 0, output, 0, N);
+            return true;
+        }
+
+        int[] omega = polyMulMod(synd, sigma, mParityCount);
+        int[] sigmaPrime = formalDerivative(sigma);
+
+        for(int i = 0; i < found; i++)
+        {
+            int xInverse = inv(locators[i]);
+            int denominator = polyEval(sigmaPrime, xInverse);
+
+            if(denominator == 0)
+            {
+                System.arraycopy(input, 0, output, 0, N);
+                return true;
+            }
+
+            cw[positions[i]] ^= mul(polyEval(omega, xInverse), inv(denominator));
+        }
+
+        for(int s : syndromes(cw))
+        {
+            if(s != 0)
+            {
+                System.arraycopy(input, 0, output, 0, N);
+                return true;
+            }
+        }
+
+        for(int i = 0; i < N; i++)
+        {
+            output[N - 1 - i] = cw[i];
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/timeslot/FacchTimeslot.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/timeslot/FacchTimeslot.java
@@ -23,7 +23,7 @@ import io.github.dsheirer.bits.BinaryMessage;
 import io.github.dsheirer.bits.CorrectedBinaryMessage;
 import io.github.dsheirer.bits.FragmentedIntField;
 import io.github.dsheirer.bits.IntField;
-import io.github.dsheirer.edac.ReedSolomon_63_35_29_P25;
+import io.github.dsheirer.edac.ReedSolomon_63_ErasureDecoder;
 import io.github.dsheirer.module.decode.p25.phase2.enumeration.DataUnitID;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacMessage;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacMessageFactory;
@@ -40,6 +40,8 @@ public class FacchTimeslot extends AbstractSignalingTimeslot
 {
     private final static Logger mLog = LoggerFactory.getLogger(FacchTimeslot.class);
     private static final int MAX_OCTET_INDEX = 144; //156-12 = message length minus CRC-12 checksum.
+    private static final ReedSolomon_63_ErasureDecoder REED_SOLOMON = new ReedSolomon_63_ErasureDecoder(35);
+    private static final int[] PUNCTURED_PARITY = {0, 1, 2, 3, 4, 5, 6, 7, 8};
 
     private static final IntField INFO_1 = IntField.range(2, 7);
     private static final IntField INFO_2 = IntField.range(8, 13);
@@ -88,6 +90,7 @@ public class FacchTimeslot extends AbstractSignalingTimeslot
     private static final IntField PARITY_19 = IntField.range(312, 317);
 
     private List<MacMessage> mMacMessages;
+    private boolean mReedSolomonValid;
 
     /**
      * Constructs a scrambled FACCH timeslot
@@ -204,13 +207,14 @@ public class FacchTimeslot extends AbstractSignalingTimeslot
 //            input[61] = 0; //Shortened
 //            input[62] = 0; //Shortened
 
-            ReedSolomon_63_35_29_P25 reedSolomon_63_35_29 = new ReedSolomon_63_35_29_P25();
 
             boolean irrecoverableErrors;
 
             try
             {
-                irrecoverableErrors = reedSolomon_63_35_29.decode(input, output);
+                //The FACCH parity is punctured: input[0..8] were never transmitted.  Decoding them as erasures rather
+                //than as zero-valued symbols roughly doubles the number of correctable symbol errors.
+                irrecoverableErrors = REED_SOLOMON.decode(input, output, PUNCTURED_PARITY);
             }
             catch(Exception e)
             {
@@ -218,6 +222,7 @@ public class FacchTimeslot extends AbstractSignalingTimeslot
                 irrecoverableErrors = true;
             }
 
+            mReedSolomonValid = !irrecoverableErrors;
             CorrectedBinaryMessage binaryMessage = new CorrectedBinaryMessage(156);
 
             int pointer = 0;
@@ -257,5 +262,15 @@ public class FacchTimeslot extends AbstractSignalingTimeslot
         }
 
         return mMacMessages;
+    }
+
+    /**
+     * Indicates if the outer Reed-Solomon code closed on this timeslot's MAC PDU (as opposed to the PDU only
+     * passing its CRC).  Evaluated by getMacMessages().
+     */
+    public boolean isReedSolomonValid()
+    {
+        getMacMessages();
+        return mReedSolomonValid;
     }
 }

--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/timeslot/SacchTimeslot.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/timeslot/SacchTimeslot.java
@@ -22,7 +22,7 @@ package io.github.dsheirer.module.decode.p25.phase2.timeslot;
 import io.github.dsheirer.bits.BinaryMessage;
 import io.github.dsheirer.bits.CorrectedBinaryMessage;
 import io.github.dsheirer.bits.IntField;
-import io.github.dsheirer.edac.ReedSolomon_63_35_29_P25;
+import io.github.dsheirer.edac.ReedSolomon_63_ErasureDecoder;
 import io.github.dsheirer.module.decode.p25.phase2.enumeration.DataUnitID;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacMessage;
 import io.github.dsheirer.module.decode.p25.phase2.message.mac.MacMessageFactory;
@@ -36,6 +36,8 @@ import java.util.List;
 public class SacchTimeslot extends AbstractSignalingTimeslot
 {
     private static final int MAX_OCTET_INDEX = 168; //180-12 = message length minus CRC-12 checksum.
+    private static final ReedSolomon_63_ErasureDecoder REED_SOLOMON = new ReedSolomon_63_ErasureDecoder(35);
+    private static final int[] PUNCTURED_PARITY = {0, 1, 2, 3, 4, 5};
 
     private static final IntField INFO_1 = IntField.range(2, 7);
     private static final IntField INFO_2 = IntField.range(8, 13);
@@ -91,6 +93,7 @@ public class SacchTimeslot extends AbstractSignalingTimeslot
     private static final IntField PARITY_22 = IntField.range(312, 317);
 
     private List<MacMessage> mMacMessages;
+    private boolean mReedSolomonValid;
 
     /**
      * Constructs a scrambled SACCH timeslot
@@ -214,13 +217,14 @@ public class SacchTimeslot extends AbstractSignalingTimeslot
 //            input[61] = 0; //Shortened
 //            input[62] = 0; //Shortened
 
-            ReedSolomon_63_35_29_P25 reedSolomon_63_35_29 = new ReedSolomon_63_35_29_P25();
 
             boolean irrecoverableErrors;
 
             try
             {
-                irrecoverableErrors = reedSolomon_63_35_29.decode(input, output);
+                //The SACCH parity is punctured: input[0..5] were never transmitted.  Decoding them as erasures rather
+                //than as zero-valued symbols roughly doubles the number of correctable symbol errors.
+                irrecoverableErrors = REED_SOLOMON.decode(input, output, PUNCTURED_PARITY);
             }
             catch(Exception e)
             {
@@ -228,6 +232,7 @@ public class SacchTimeslot extends AbstractSignalingTimeslot
                 irrecoverableErrors = true;
             }
 
+            mReedSolomonValid = !irrecoverableErrors;
             CorrectedBinaryMessage binaryMessage = new CorrectedBinaryMessage(180);
 
             int pointer = 0;
@@ -268,5 +273,15 @@ public class SacchTimeslot extends AbstractSignalingTimeslot
         }
 
         return mMacMessages;
+    }
+
+    /**
+     * Indicates if the outer Reed-Solomon code closed on this timeslot's MAC PDU (as opposed to the PDU only
+     * passing its CRC).  Evaluated by getMacMessages().
+     */
+    public boolean isReedSolomonValid()
+    {
+        getMacMessages();
+        return mReedSolomonValid;
     }
 }

--- a/src/test/java/io/github/dsheirer/edac/ReedSolomon63TestEncoder.java
+++ b/src/test/java/io/github/dsheirer/edac/ReedSolomon63TestEncoder.java
@@ -1,0 +1,122 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.edac;
+
+/**
+ * Systematic RS(63,35) encoder over GF(2^6), x^6 + x + 1, for tests: the code the P25 Phase 2 SACCH and FACCH
+ * carry (shortened and punctured on air).  Codewords are produced in the BerlekempMassey / ReedSolomon_63_ErasureDecoder
+ * convention: index i is the coefficient of x^i, so parity occupies indices 0..27 and information 28..62 (with the
+ * shortened information symbols at the top left zero).
+ */
+public final class ReedSolomon63TestEncoder
+{
+    private static final int N = 63, K = 35;
+    private static final int[] EXP = new int[126];
+    private static final int[] LOG = new int[64];
+    private static final int[] GENERATOR; //coefficient i of x^i, degree 28, monic
+
+    static
+    {
+        int x = 1;
+
+        for(int i = 0; i < 63; i++)
+        {
+            EXP[i] = x;
+            LOG[x] = i;
+            int previous = x;
+            x = (x << 1) & 0x3F;
+
+            if((previous & 0x20) != 0)
+            {
+                x ^= 0x03;
+            }
+        }
+
+        for(int i = 63; i < 126; i++)
+        {
+            EXP[i] = EXP[i - 63];
+        }
+
+        //g(x) = product of (x + alpha^j) for j = 1..28
+        int[] g = {1};
+
+        for(int j = 1; j <= N - K; j++)
+        {
+            int root = EXP[j];
+            int[] next = new int[g.length + 1];
+
+            for(int i = 0; i < g.length; i++)
+            {
+                next[i + 1] ^= g[i];
+                next[i] ^= mul(g[i], root);
+            }
+
+            g = next;
+        }
+
+        GENERATOR = g;
+    }
+
+    private ReedSolomon63TestEncoder()
+    {
+    }
+
+    private static int mul(int a, int b)
+    {
+        return (a == 0 || b == 0) ? 0 : EXP[LOG[a] + LOG[b]];
+    }
+
+    /**
+     * Encodes 35 information symbols (info[0] is the highest-degree symbol, x^62) into a 63-symbol codeword in the
+     * x^i-at-index-i convention.
+     */
+    public static int[] encode(int[] info)
+    {
+        if(info.length != K)
+        {
+            throw new IllegalArgumentException("35 information symbols required");
+        }
+
+        //Long division of info(x) * x^28 by g(x); remainder is the parity.
+        int[] remainder = new int[N - K];
+
+        for(int i = 0; i < K; i++)
+        {
+            int feedback = (info[i] & 0x3F) ^ remainder[N - K - 1];
+
+            for(int j = N - K - 1; j > 0; j--)
+            {
+                remainder[j] = remainder[j - 1] ^ mul(feedback, GENERATOR[j]);
+            }
+
+            remainder[0] = mul(feedback, GENERATOR[0]);
+        }
+
+        int[] codeword = new int[N];
+
+        for(int i = 0; i < K; i++)
+        {
+            codeword[N - 1 - i] = info[i] & 0x3F;
+        }
+
+        System.arraycopy(remainder, 0, codeword, 0, N - K);
+        return codeword;
+    }
+}

--- a/src/test/java/io/github/dsheirer/edac/ReedSolomon_63_ErasureDecoderTest.java
+++ b/src/test/java/io/github/dsheirer/edac/ReedSolomon_63_ErasureDecoderTest.java
@@ -1,0 +1,209 @@
+/*
+ * *****************************************************************************
+ * Copyright (C) 2014-2026 Dennis Sheirer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ * ****************************************************************************
+ */
+
+package io.github.dsheirer.edac;
+
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ReedSolomon_63_ErasureDecoderTest
+{
+    private static final int[] FACCH_PUNCTURED = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+    private static final int[] SACCH_PUNCTURED = {0, 1, 2, 3, 4, 5};
+    private static final int[] NONE = {};
+
+    /** A codeword with the top `shortened` information symbols zero, the rest pseudo-random. */
+    private static int[] codeword(long seed, int shortened)
+    {
+        Random random = new Random(seed);
+        int[] info = new int[35];
+
+        for(int i = shortened; i < 35; i++)
+        {
+            info[i] = random.nextInt(64);
+        }
+
+        return ReedSolomon63TestEncoder.encode(info);
+    }
+
+    /** Copies the codeword, zeroes the punctured positions and flips `errors` distinct other symbols. */
+    private static int[] damage(int[] codeword, int[] punctured, int errors, long seed)
+    {
+        int[] received = codeword.clone();
+
+        for(int p : punctured)
+        {
+            received[p] = 0;
+        }
+
+        Random random = new Random(seed);
+        boolean[] hit = new boolean[63];
+
+        for(int p : punctured)
+        {
+            hit[p] = true;
+        }
+
+        for(int e = 0; e < errors; e++)
+        {
+            int position;
+
+            do
+            {
+                position = random.nextInt(63);
+            }
+            while(hit[position]);
+
+            hit[position] = true;
+            received[position] ^= 1 + random.nextInt(63);
+        }
+
+        return received;
+    }
+
+    private static void assertCorrects(int[] codeword, int[] punctured, int errors, long seed)
+    {
+        ReedSolomon_63_ErasureDecoder decoder = new ReedSolomon_63_ErasureDecoder(35);
+        int[] received = damage(codeword, punctured, errors, seed);
+        int[] output = new int[63];
+        boolean irrecoverable = decoder.decode(received, output, punctured);
+        assertFalse(irrecoverable, "erasures=" + punctured.length + " errors=" + errors + " seed=" + seed);
+        assertArrayEquals(codeword, output, "erasures=" + punctured.length + " errors=" + errors + " seed=" + seed);
+    }
+
+    private static void assertRejects(int[] codeword, int[] punctured, int errors, long seed)
+    {
+        ReedSolomon_63_ErasureDecoder decoder = new ReedSolomon_63_ErasureDecoder(35);
+        int[] received = damage(codeword, punctured, errors, seed);
+        int[] output = new int[63];
+        assertTrue(decoder.decode(received, output, punctured),
+            "should be uncorrectable: erasures=" + punctured.length + " errors=" + errors + " seed=" + seed);
+    }
+
+    @Test
+    public void cleanCodewordDecodesAndReconstructsErasures()
+    {
+        for(long seed = 1; seed <= 20; seed++)
+        {
+            assertCorrects(codeword(seed, 9), FACCH_PUNCTURED, 0, seed);
+            assertCorrects(codeword(seed, 5), SACCH_PUNCTURED, 0, seed);
+        }
+    }
+
+    @Test
+    public void facchCorrectsNineErrorsWithNinePuncturedParity()
+    {
+        //2 * errors + erasures <= 28: 9 erasures leave 9 correctable errors, not 5.
+        for(long seed = 1; seed <= 50; seed++)
+        {
+            assertCorrects(codeword(seed, 9), FACCH_PUNCTURED, 9, seed);
+        }
+    }
+
+    @Test
+    public void facchRejectsTenErrors()
+    {
+        for(long seed = 1; seed <= 50; seed++)
+        {
+            assertRejects(codeword(seed, 9), FACCH_PUNCTURED, 10, seed);
+        }
+    }
+
+    @Test
+    public void sacchCorrectsElevenErrorsWithSixPuncturedParity()
+    {
+        for(long seed = 1; seed <= 50; seed++)
+        {
+            assertCorrects(codeword(seed, 5), SACCH_PUNCTURED, 11, seed);
+        }
+    }
+
+    @Test
+    public void sacchRejectsTwelveErrors()
+    {
+        for(long seed = 1; seed <= 50; seed++)
+        {
+            assertRejects(codeword(seed, 5), SACCH_PUNCTURED, 12, seed);
+        }
+    }
+
+    @Test
+    public void withoutErasuresMatchesErrorsOnlyDecoderUpToFourteenErrors()
+    {
+        //Same field and generator as the existing BerlekempMassey-based decoder: both must agree.
+        ReedSolomon_63_35_29_P25 reference = new ReedSolomon_63_35_29_P25();
+        ReedSolomon_63_ErasureDecoder decoder = new ReedSolomon_63_ErasureDecoder(35);
+
+        for(long seed = 1; seed <= 30; seed++)
+        {
+            int[] codeword = codeword(seed, 0);
+
+            for(int errors : new int[]{0, 1, 7, 14})
+            {
+                int[] received = damage(codeword, NONE, errors, seed);
+                int[] expected = new int[63];
+                int[] actual = new int[63];
+                boolean referenceFailed = reference.decode(received.clone(), expected);
+                boolean failed = decoder.decode(received, actual, NONE);
+                assertFalse(referenceFailed, "reference decoder failed at " + errors + " errors");
+                assertFalse(failed, "erasure decoder failed at " + errors + " errors");
+                assertArrayEquals(codeword, actual);
+                assertArrayEquals(expected, actual);
+            }
+        }
+    }
+
+    @Test
+    public void tooManyErasuresIsRejected()
+    {
+        ReedSolomon_63_ErasureDecoder decoder = new ReedSolomon_63_ErasureDecoder(35);
+        int[] erasures = new int[29];
+
+        for(int i = 0; i < erasures.length; i++)
+        {
+            erasures[i] = i;
+        }
+
+        int[] output = new int[63];
+        assertTrue(decoder.decode(codeword(1, 0), output, erasures));
+    }
+
+    @Test
+    public void erasedPositionsMayHoldAnyValue()
+    {
+        int[] codeword = codeword(7, 9);
+        int[] received = codeword.clone();
+
+        for(int p : FACCH_PUNCTURED)
+        {
+            received[p] = 0x3F; //not zero: the decoder must ignore whatever is there
+        }
+
+        int[] output = new int[63];
+        ReedSolomon_63_ErasureDecoder decoder = new ReedSolomon_63_ErasureDecoder(35);
+        assertFalse(decoder.decode(received, output, FACCH_PUNCTURED));
+        assertArrayEquals(codeword, output);
+        assertEquals(codeword[0], output[0]);
+    }
+}


### PR DESCRIPTION

Two commits: the decoder plus the timeslot wiring, then the tests.

## What the parsers already assume

`SacchTimeslot` and `FacchTimeslot` treat the ACCH as a shortened and punctured RS(63,35) codeword, and say so: the SACCH carries 30 information and 22 parity hexbits (`input[6..57]`), the FACCH 26 and 19 (`input[9..53]`), with the missing information symbols marked `//Shortened` and the missing parity symbols marked `//Punctured`. Shortening is free — those information symbols are zero at both ends. Puncturing is not: the transmitter computed those parity symbols and did not send them, so their value at the receiver is unknown.

Both timeslots currently fill the punctured positions with zero and hand the block to `BerlekempMassey`, an errors-only decoder. Unless the true parity symbol happened to be zero, each of those positions is a symbol error the decoder has to find and correct before it touches a real one.

## Why erasures are the right model

RS(63,35) has minimum distance 29, so its decoder has a budget of 28: an error, whose position is unknown, costs 2 of it; an erasure, whose position is known, costs 1 (Lin & Costello, *Error Control Coding*, errors-and-erasures decoding; Forney, "On decoding BCH codes", IEEE Trans. IT 1965, for the modified-syndrome method). A punctured symbol is exactly an erasure: the receiver knows precisely which positions are missing.

| burst | punctured parity | correctable errors today (zero-filled) | as erasures (2e + s ≤ 28) |
|---|---|---|---|
| FACCH | 9 | 14 − 9 = 5 | (28 − 9) / 2 = 9 |
| SACCH | 6 | 14 − 6 = 8 | (28 − 6) / 2 = 11 |

## The change

`ReedSolomon_63_ErasureDecoder` is an errors-and-erasures decoder for the P25 GF(2^6) codes: Forney-modified syndromes fold the known erasure locator in, Berlekamp–Massey (the same algorithm the existing decoder implements) finds the remaining error locator within what is left of the budget, Chien search and the Forney algorithm evaluate the combined errata locator, and the result is re-syndromed so a pattern beyond the radius fails cleanly instead of miscorrecting. It uses the existing `input[i]` = coefficient of x^i convention so the timeslot classes only change the decode call and pass their punctured positions. Both timeslots also now record whether the outer code closed (`isReedSolomonValid()`). Nothing in this pull request calls it: its consumer is a follow-up change that resolves the fragment's scrambling offset by decoding under each candidate and keeping the one whose MAC PDUs check out, which needs to tell the outer code closing apart from a bare CRC pass. That change is not open yet because it does not compile without this one. If you would rather not take an unused accessor, say so and I will drop it here and introduce it alongside the change that uses it. Adapted from the Apache-2.0 GopherTrunk project's implementation, with attribution in the header.

## Evidence it is correct

- The test builds RS(63,35) codewords with a systematic encoder over the same field and generator (roots α^1..α^28, as `BerlekempMassey.gen_poly()` builds them). With the FACCH erasure set the decoder corrects exactly 9 symbol errors and rejects 10; with the SACCH set, 11 and 12; erased positions may hold any value; with no erasures it agrees symbol-for-symbol with the existing `ReedSolomon_63_35_29_P25` decoder at 0, 1, 7 and 14 errors — which pins the field and generator conventions to the ones the parsers rely on.
- On eight clean Phase 2 traffic-channel recordings the decoder's output is identical to the current one: 234 distinct MAC PDUs, 1,149 PDU instances, before and after.

## Evidence it is useful

Same eight recordings with calibrated complex Gaussian noise added (SNR over the 50 kHz sample band). At 0 dB the fragment detector stays perfectly synchronized (122 of 122 fragments on the longest file, every sync within 4 bit errors) and the loss is entirely in MAC PDUs failing the outer code: 289 of 342 in that file. This change alone:

| | distinct MAC PDUs (of 240) | valid PDU instances |
|---|---|---|
| current | 92 | 289 |
| erasure decoding | 126 | 486 |

Together with the three companion changes from the same branch — the I-ISCH 2 fallback fix and a root-raised-cosine matched filter, both open as separate pull requests, and resolving the fragment's scrambling offset by decoding, which follows once this one merges — the same set reaches 231 distinct PDUs at 0 dB.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
