### PR TITLE
P25 Phase 2: add a root-raised-cosine matched filter

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSK.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase2/P25P2DecoderHDQPSK.java
@@ -26,6 +26,7 @@ import io.github.dsheirer.dsp.filter.FilterFactory;
 import io.github.dsheirer.dsp.filter.design.FilterDesignException;
 import io.github.dsheirer.dsp.filter.fir.FIRFilterSpecification;
 import io.github.dsheirer.dsp.filter.fir.real.IRealFilter;
+import io.github.dsheirer.dsp.filter.fir.real.RealFIRFilter;
 import io.github.dsheirer.dsp.gain.complex.ComplexGainFactory;
 import io.github.dsheirer.dsp.gain.complex.IComplexGainControl;
 import io.github.dsheirer.dsp.psk.DQPSKGardnerDemodulator;
@@ -72,6 +73,8 @@ public class P25P2DecoderHDQPSK extends P25P2Decoder implements IdentifierUpdate
     private Map<Double,float[]> mBasebandFilters = new HashMap<>();
     protected IRealFilter mIBasebandFilter;
     protected IRealFilter mQBasebandFilter;
+    protected IRealFilter mIMatchedFilter;
+    protected IRealFilter mQMatchedFilter;
     private DecodeConfigP25Phase2 mDecodeConfigP25Phase2;
     private FrequencyCorrectionSyncMonitor mFrequencyCorrectionSyncMonitor;
 
@@ -109,6 +112,12 @@ public class P25P2DecoderHDQPSK extends P25P2Decoder implements IdentifierUpdate
 
         mIBasebandFilter = FilterFactory.getRealFilter(getBasebandFilter());
         mQBasebandFilter = FilterFactory.getRealFilter(getBasebandFilter());
+
+        //Root-raised-cosine matched filter, alpha 0.2, 8 symbols each side.  Note: getRootRaisedCosine() halves its
+        //samples-per-symbol argument, so pass twice the actual value to design the filter at the 6000 baud symbol rate.
+        float[] matchedFilterTaps = FilterFactory.getRootRaisedCosine(2.0 * getSampleRate() / getSymbolRate(), 16, 0.2f);
+        mIMatchedFilter = new RealFIRFilter(matchedFilterTaps);
+        mQMatchedFilter = new RealFIRFilter(matchedFilterTaps);
         mCostasLoop = new CostasLoop(getSampleRate(), getSymbolRate());
         mCostasLoop.setPLLBandwidth(PLLBandwidth.BW_300);
 
@@ -145,8 +154,8 @@ public class P25P2DecoderHDQPSK extends P25P2Decoder implements IdentifierUpdate
     @Override
     public void receive(ComplexSamples samples)
     {
-        float[] i = mIBasebandFilter.filter(samples.i());
-        float[] q = mQBasebandFilter.filter(samples.q());
+        float[] i = mIMatchedFilter.filter(mIBasebandFilter.filter(samples.i()));
+        float[] q = mQMatchedFilter.filter(mQBasebandFilter.filter(samples.q()));
 
         ComplexSamples amplified = mAGC.process(i, q, samples.timestamp());
         mQPSKDemodulator.receive(amplified);


### PR DESCRIPTION

`P25P2DecoderHDQPSK` feeds the demodulator straight from a 6.5 kHz low-pass filter and has no pulse-matched filter. H-DQPSK is a linearly modulated waveform with root-raised-cosine pulse shaping, so the receive filter that maximizes the signal-to-noise ratio at each symbol decision is the matching root-raised-cosine, whose noise-equivalent bandwidth is the symbol rate — 6 kHz two-sided at 6000 baud — against the roughly 13 kHz the low-pass alone admits. That is about a 3 dB noise penalty before any decoding starts.

The change adds an RRC (α 0.2, 16-symbol span, the roll-off the Phase 1 C4FM path already uses) after the low-pass, keeping the low-pass for adjacent-channel rejection.

One detail worth reviewing: `FilterFactory.getRootRaisedCosine()` halves its samples-per-symbol argument before designing, so a call with the actual value produces a filter for twice the symbol rate. Measured on the generated taps at 50 kHz / 6000 baud: −3 dB at 6.0 kHz with the actual value, 3.0 kHz when passing twice it. The new call passes twice the value and says why in a comment; the generator itself is left alone because the Phase 1, LSM and DMR decoders call it with the actual value and have been tuned against that behaviour (a separate Phase 1 change from the same branch measures what a corrected design does there).

Measured on eight Phase 2 traffic-channel recordings with calibrated noise, on top of the companion erasure-decoding change (submitted separately): distinct MAC PDUs at 0 dB 126 → 176 of 240, valid PDU instances 486 → 707; clean-signal output unchanged. Designing the filter at the wrong rate recovers only 119 / 448, and dropping the low-pass in favour of the RRC alone measured slightly worse (168 / 640), so both stay.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
