### PR TITLE
P25 Phase 1: design the C4FM matched filter at 6400 baud, alpha 0.5

### DIFF
--- a/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderC4FM.java
+++ b/src/main/java/io/github/dsheirer/module/decode/p25/phase1/P25P1DecoderC4FM.java
@@ -133,10 +133,15 @@ public class P25P1DecoderC4FM extends FeedbackDecoder implements IByteBufferProv
         //Set the decimated sample rate to use for PLL error reporting.
         setDecimatedSampleRate(decimatedSampleRate);
 
+        //Note: getRootRaisedCosine() halves its samples-per-symbol argument, so the previous call with the actual value
+        //(4.0) designed a 9600 baud, alpha 0.2 filter.  Measured against an independent oracle on weak-signal
+        //control-channel and voice recordings, a 6400 baud, alpha 0.5 design (1.5x the actual value) recovers ~9%
+        //more corroborated TSBKs on the weakest channel with voice recall and false-decode rate unchanged, while a
+        //true 4800 baud, alpha 0.2 design is too narrow for C4FM and loses ~4% of marginal voice frames.
         int symbolLength = 16;
-        float rrcAlpha = 0.2f;
+        float rrcAlpha = 0.5f;
 
-        float[] taps = FilterFactory.getRootRaisedCosine(decimatedSampleRate / SYMBOL_RATE,
+        float[] taps = FilterFactory.getRootRaisedCosine(1.5 * decimatedSampleRate / SYMBOL_RATE,
                 symbolLength, rrcAlpha);
         mPulseShapingFilterI = new RealFIRFilter(taps);
         mPulseShapingFilterQ = new RealFIRFilter(taps);


### PR DESCRIPTION

Independent of the Phase 2 changes from the same branch; the only Phase 1 change.

`FilterFactory.getRootRaisedCosine()` halves its samples-per-symbol argument before designing (the Phase 2 matched-filter change from the same branch works around the same thing), so `P25P1DecoderC4FM`'s call with the actual 4.0 produces a 9600-baud, α 0.2 root-raised-cosine rather than the 4800-baud one the call reads as. That prompted a sweep of design rate and roll-off, adjudicated two ways: voice frames against an independent IQ oracle that finds frame syncs and decodes NIDs by exhaustive BCH search, and control-channel TSBKs by content corroboration (a block counts when another decoder or a later repeat carries the same opcode and payload; a block seen exactly once is a singleton, the shape a false accept takes).

| design | corroborated TSBKs, two weak control channels | marginal voice recall | clean voice | refuted claims |
|---|---|---|---|---|
| current (9600 baud, α 0.2) | 43,992 | 95.9% | 99.5% | 21 |
| 4800 baud, α 0.2 | 44,730 | 91.7% | 99.5% | 28 |
| **6400 baud, α 0.5** | **47,852** | 95.9% | 99.4% | 21 |
| 6400 baud, α 0.7 | 47,828 | 96.3% | 99.5% | 21 |
| 5486 baud, α 0.5 | 48,111 | 95.8% | 99.5% | 22 |

A true 4800-baud α 0.2 filter is too narrow for C4FM — its spectrum is wider than a linear 4800-baud RRC's — and costs four points of marginal voice recall. The 6400-baud, α 0.5–0.7 plateau gains 8.7–9.4% corroborated blocks, all of it on the weakest of the two channels (19,372 → 23,189), with the stronger one flat, voice recall flat, singletons ≤ 1 and refuted claims unchanged. The change passes 1.5× the actual samples-per-symbol and α 0.5, and the comment explains both.

The LSM and DMR decoders call the generator the same way and were not measured; they may deserve the same sweep.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
